### PR TITLE
MsGraphicsPkg: FIX: Compilation warning with GCC regarding missing braces and some build erros.

### DIFF
--- a/MsGraphicsPkg/Include/Library/MsPlatformEarlyGraphicsLib.h
+++ b/MsGraphicsPkg/Include/Library/MsPlatformEarlyGraphicsLib.h
@@ -56,5 +56,5 @@ EFI_STATUS
 EFIAPI
 MsEarlyGraphicsGetFrameBufferInfo(EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE **GraphicsMode);
 
-#endif __MS_EARLY_GRAPHICS_LIB_H__
+#endif //__MS_EARLY_GRAPHICS_LIB_H__
 

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_10pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_10pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_10pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_10pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_10pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_12pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_12pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_12pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_12pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_12pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_13pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_13pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_13pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_13pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_13pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_14pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_14pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_14pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_14pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_14pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_18pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_18pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_18pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_18pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_18pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_22pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_22pt.h
@@ -68,9 +68,9 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_22pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_22pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+       {L'S'},                                               // Font Family name.
     },
-    L"urfaceSelawik_Regular_22pt"                                        // Font Family name continued.
+    L"urfaceSelawik_Regular_22pt",                                        // Font Family name continued.
 };
 
 

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_24pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_24pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_24pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_24pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_24pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_28pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_28pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_28pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_28pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_28pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_36pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_36pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_36pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_36pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_36pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_48pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_48pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_48pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_48pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_48pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_5pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_5pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_5pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_5pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_5pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_7pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_7pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_7pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_7pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_7pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_9pt.h
+++ b/MsGraphicsPkg/Include/Resources/FontPackage_Selawik_Regular_9pt.h
@@ -68,7 +68,7 @@ MS_UI_FONT_PACKAGE_HEADER mMsUiFontPackageHdr_Selawik_Regular_9pt =
             MS_UI_CUSTOM_FONT_Selawik_Regular_9pt_MAX_ADVANCE,       // Number of pixels to advance horizontally when moving from origin to next glyph.
         },
         EFI_HII_FONT_STYLE_NORMAL,                          // Font style (i.e., normal, bold, italic, etc.)
-        L'S',                                               // Font Family name.
+        {L'S'},                                               // Font Family name.
     },
     L"urfaceSelawik_Regular_9pt"                                        // Font Family name continued.
 };

--- a/MsGraphicsPkg/Include/Uefi/MsUefiInternalFormRepresentationEx.h
+++ b/MsGraphicsPkg/Include/Uefi/MsUefiInternalFormRepresentationEx.h
@@ -43,4 +43,3 @@
 #define ORDERED_LIST_BOOT_VALUE_32         ((UINT32)0x80000000)   // Currently, only value type UINT32 is supported
 
 #endif
-

--- a/MsGraphicsPkg/Library/MsUiThemeLib/Pei/MsUiThemeLib.c
+++ b/MsGraphicsPkg/Library/MsUiThemeLib/Pei/MsUiThemeLib.c
@@ -43,7 +43,7 @@ Environment:
 #include <Library/MsUiThemeLib.h>
 
 
-extern MS_UI_THEME_DESCRIPTION *gPlatformTheme = NULL;
+extern MS_UI_THEME_DESCRIPTION *gPlatformTheme;
 
 
 /**

--- a/MsGraphicsPkg/MsEarlyGraphics/Dxe/MsEarlyGraphics.h
+++ b/MsGraphicsPkg/MsEarlyGraphics/Dxe/MsEarlyGraphics.h
@@ -43,6 +43,6 @@
 #include <Library/MsPlatformEarlyGraphicsLib.h>
 #include <Library/MsUiThemeLib.h>
 
-#include "..\MsEarlyGraphicsCommon.h"
+#include "../MsEarlyGraphicsCommon.h"
 
 #endif

--- a/MsGraphicsPkg/MsEarlyGraphics/Dxe/MsEarlyGraphics.inf
+++ b/MsGraphicsPkg/MsEarlyGraphics/Dxe/MsEarlyGraphics.inf
@@ -43,8 +43,8 @@
 [Sources]
   MsEarlyGraphics.c
   MsEarlyGraphics.h
-  ..\MsEarlyGraphicsCommon.c
-  ..\MsEarlyGraphicsCommon.h
+  ../MsEarlyGraphicsCommon.c
+  ../MsEarlyGraphicsCommon.h
 
 
 [Packages]

--- a/MsGraphicsPkg/MsEarlyGraphics/Pei/MsEarlyGraphics.h
+++ b/MsGraphicsPkg/MsEarlyGraphics/Pei/MsEarlyGraphics.h
@@ -45,6 +45,6 @@
 #include <Library/MsPlatformEarlyGraphicsLib.h>
 #include <Library/MsUiThemeLib.h>
 
-#include "..\MsEarlyGraphicsCommon.h"
+#include "../MsEarlyGraphicsCommon.h"
 
 #endif  // _MS_EARLY_GRAPHICS_PEI_H_

--- a/MsGraphicsPkg/MsEarlyGraphics/Pei/MsEarlyGraphics.inf
+++ b/MsGraphicsPkg/MsEarlyGraphics/Pei/MsEarlyGraphics.inf
@@ -42,8 +42,8 @@
 [Sources]
   MsEarlyGraphics.c
   MsEarlyGraphics.h
-  ..\MsEarlyGraphicsCommon.c
-  ..\MsEarlyGraphicsCommon.h
+  ../MsEarlyGraphicsCommon.c
+  ../MsEarlyGraphicsCommon.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MsGraphicsPkg/OnScreenKeyboardDxe/DisplayTransform.c
+++ b/MsGraphicsPkg/OnScreenKeyboardDxe/DisplayTransform.c
@@ -83,7 +83,7 @@ POINT3D
 TransformPoint (IN POINT3D InPoint)
 {
     int j, k;
-    POINT3D pt = {0.0, 0.0, 0.0, 0.0};
+    POINT3D pt = { {0.0, 0.0, 0.0, 0.0} };
 
     // Apply scale, rotation, and translation transform (multiplication)
     //

--- a/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDriver.c
+++ b/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDriver.c
@@ -57,8 +57,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <Guid/ConsoleInDevice.h>
 #include <Guid/OSKDevicePath.h>
 
-#include "OnscreenKeyboard.h"
-#include "OnscreenKeyboardProtocol.h"
+#include "OnScreenKeyboard.h"
+#include "OnScreenKeyboardProtocol.h"
 #include "DisplayTransform.h"
 #include "KeyMapping.h"
 
@@ -74,19 +74,23 @@ static EFI_HANDLE mControllerHandle = NULL;
 //
 static OSK_DEVICE_PATH mPlatformOSKDevice = {
     {
+      {
         HARDWARE_DEVICE_PATH,
         HW_VENDOR_DP,
         {
             (UINT8)(sizeof(VENDOR_DEVICE_PATH)),
             (UINT8)((sizeof(VENDOR_DEVICE_PATH)) >> 8)
-        },
-        OSK_DEVICE_PATH_GUID
+        }
+      },
+      OSK_DEVICE_PATH_GUID
     },
     {
         END_DEVICE_PATH_TYPE,
         END_ENTIRE_DEVICE_PATH_SUBTYPE,
-        END_DEVICE_PATH_LENGTH,
-        0
+        {
+            END_DEVICE_PATH_LENGTH,
+            0
+        }
     }
 };
 
@@ -2867,6 +2871,7 @@ Exit:
 }
 
 EFI_STATUS
+EFIAPI
 OSKResetInputDevice (IN EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
 IN BOOLEAN                          ExtendedVerification)
 {
@@ -2881,6 +2886,7 @@ IN BOOLEAN                          ExtendedVerification)
 
 
 EFI_STATUS
+EFIAPI
 OSKReadKeyStroke (IN  EFI_SIMPLE_TEXT_INPUT_PROTOCOL     *This,
 OUT EFI_INPUT_KEY                      *pKey)
 {
@@ -2913,6 +2919,7 @@ OUT EFI_INPUT_KEY                      *pKey)
 
 
 EFI_STATUS
+EFIAPI
 OSKResetInputDeviceEx (IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
 IN BOOLEAN                             ExtendedVerification)
 {
@@ -2921,6 +2928,7 @@ IN BOOLEAN                             ExtendedVerification)
 
 
 EFI_STATUS
+EFIAPI
 OSKReadKeyStrokeEx (IN  EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL     *This,
 OUT EFI_KEY_DATA                          *pKey)
 {
@@ -2934,6 +2942,7 @@ OUT EFI_KEY_DATA                          *pKey)
 
 
 EFI_STATUS
+EFIAPI
 OSKSetState (IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
 IN EFI_KEY_TOGGLE_STATE               *KeyToggleState)
 {
@@ -2942,6 +2951,7 @@ IN EFI_KEY_TOGGLE_STATE               *KeyToggleState)
 
 
 EFI_STATUS
+EFIAPI
 OSKRegisterKeyNotify (IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
 IN EFI_KEY_DATA                       *KeyData,
 IN EFI_KEY_NOTIFY_FUNCTION            KeyNotificationFunction,
@@ -2952,6 +2962,7 @@ OUT EFI_HANDLE                        *NotifyHandle)
 
 
 EFI_STATUS
+EFIAPI
 OSKUnregisterKeyNotify (IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL  *This,
 IN EFI_HANDLE                         NotificationHandle)
 {
@@ -3340,7 +3351,7 @@ IN EFI_SYSTEM_TABLE  *SystemTable
         );
     ASSERT_EFI_ERROR(Status);
 
-    DEBUG((DEBUG_INFO, __FUNCTION__"OSK DEVICE Handle %x\n", mControllerHandle));
+    DEBUG((DEBUG_INFO, "%a OSK DEVICE Handle %x\n", __FUNCTION__, mControllerHandle));
     //
     // Install UEFI Driver Model protocol(s).
     //

--- a/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardProtocol.c
+++ b/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardProtocol.c
@@ -42,6 +42,7 @@
 
 
 EFI_STATUS
+EFIAPI
 OSKShowIcon (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
              IN BOOLEAN                         bShowIcon)
 {
@@ -54,6 +55,7 @@ OSKShowIcon (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKShowDockAndCloseButtons (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                             IN BOOLEAN                         bShowDockAndCloseButtons)
 {
@@ -68,6 +70,7 @@ OSKShowDockAndCloseButtons (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKSetIconPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                     IN SCREEN_POSITION                 Position)
 {
@@ -83,6 +86,7 @@ OSKSetIconPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                         IN SCREEN_POSITION                  Position,
                         IN OSK_DOCKED_STATE                 DockedState)
@@ -98,6 +102,7 @@ OSKSetKeyboardPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardRotationAngle (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                              IN SCREEN_ANGLE                     KeyboardAngle)
 {
@@ -112,6 +117,7 @@ OSKSetKeyboardRotationAngle (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKGetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINT32                           *ModeBitfield)
 {
@@ -127,6 +133,7 @@ OSKGetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINT32                           ModeBitfield)
 {
@@ -142,6 +149,7 @@ OSKSetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardSize (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINTN                             PercentOfScreenWidth)
 {
@@ -157,6 +165,7 @@ OSKSetKeyboardSize (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKShowKeyboard (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                  IN BOOLEAN                         bShowKeyboard)
 {
@@ -187,6 +196,7 @@ OSKShowKeyboard (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
 
 
 EFI_STATUS
+EFIAPI
 OSKGetKeyboardBounds (IN  MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                       OUT SWM_RECT                        *FrameRect)
 {

--- a/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardProtocol.h
+++ b/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardProtocol.h
@@ -33,43 +33,53 @@
 
 
 EFI_STATUS
+EFIAPI
 OSKShowIcon (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
              IN BOOLEAN                         bShowIcon);
 
 EFI_STATUS
+EFIAPI
 OSKShowDockAndCloseButtons (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                             IN BOOLEAN                         bShowDockAndCloseButtons);
 
 EFI_STATUS
+EFIAPI
 OSKSetIconPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                     IN SCREEN_POSITION                 Position);
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardPosition (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                         IN SCREEN_POSITION                  Position,
                         IN OSK_DOCKED_STATE                 DockedState);
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardRotationAngle (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                              IN SCREEN_ANGLE                     KeyboardAngle);
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardSize (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINTN                             PercentOfScreenWidth);
 
 EFI_STATUS
+EFIAPI
 OSKGetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINT32                           *ModeBitfield);
 
 EFI_STATUS
+EFIAPI
 OSKSetKeyboardMode (IN MS_ONSCREEN_KEYBOARD_PROTOCOL    *This,
                     IN UINT32                           ModeBitfield);
 
 EFI_STATUS
+EFIAPI
 OSKShowKeyboard (IN MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                  IN BOOLEAN                         bShowKeyboard);
 
 EFI_STATUS
+EFIAPI
 OSKGetKeyboardBounds (IN  MS_ONSCREEN_KEYBOARD_PROTOCOL   *This,
                       OUT SWM_RECT                        *FrameRect);
 

--- a/MsGraphicsPkg/PrintScreenLogger/PrintScreenLogger.c
+++ b/MsGraphicsPkg/PrintScreenLogger/PrintScreenLogger.c
@@ -41,8 +41,10 @@ typedef struct {
 // Register two notifications, one for a RightCtrl-PrtScn and one for a LeftCtrl-PrtScn
 //      
 STATIC PRINT_SCREEN_KEYS  gPrtScnKeys[] = {
-    {0,0,EFI_SHIFT_STATE_VALID | EFI_LEFT_CONTROL_PRESSED  | EFI_SYS_REQ_PRESSED, 0, NULL},
-    {0,0,EFI_SHIFT_STATE_VALID | EFI_RIGHT_CONTROL_PRESSED | EFI_SYS_REQ_PRESSED, 0, NULL}
+    {
+        {0,0,EFI_SHIFT_STATE_VALID | EFI_LEFT_CONTROL_PRESSED  | EFI_SYS_REQ_PRESSED, 0, NULL},
+        {0,0,EFI_SHIFT_STATE_VALID | EFI_RIGHT_CONTROL_PRESSED | EFI_SYS_REQ_PRESSED, 0, NULL}
+    },
 };
 
 #define NUMBER_KEY_NOTIFIES (sizeof(gPrtScnKeys)/sizeof(PRINT_SCREEN_KEYS)) 

--- a/MsGraphicsPkg/PrintScreenLogger/PrintScreenLogger.h
+++ b/MsGraphicsPkg/PrintScreenLogger/PrintScreenLogger.h
@@ -33,7 +33,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __PRINTSCREEN_LOGGER_H__
 
 #include <Uefi.h>
-#include <Uefi\UefiInternalFormRepresentation.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
 
 #include <IndustryStandard/Bmp.h>
 

--- a/MsGraphicsPkg/RenderingEngineDxe/RenderingEngine.c
+++ b/MsGraphicsPkg/RenderingEngineDxe/RenderingEngine.c
@@ -60,13 +60,12 @@ EFI_DRIVER_BINDING_PROTOCOL     mSREDriverBinding =
 };
 
 // Rendering Engine device path.
-static
 VENDOR_DEVICE_PATH  mRenderingEngineDevicePath =
 {
     {
         HARDWARE_DEVICE_PATH,
         HW_VENDOR_DP,
-        sizeof(VENDOR_DEVICE_PATH),
+        {sizeof(VENDOR_DEVICE_PATH), 0}
     },
     // {FC5A6D66-1DB0-4165-98DC-BC747941F0CE}
     { 0xfc5a6d66, 0x1db0, 0x4165, { 0x98, 0xdc, 0xbc, 0x74, 0x79, 0x41, 0xf0, 0xce } }
@@ -77,6 +76,7 @@ VENDOR_DEVICE_PATH  mRenderingEngineDevicePath =
 //
 static
 EFI_STATUS
+EFIAPI
 SREShowMousePointer (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                      IN  BOOLEAN                         ShowPointer);
 
@@ -232,6 +232,7 @@ RectsOverlap (IN SWM_RECT   A,
 
 static
 EFI_STATUS
+EFIAPI
 SREBlt (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL            *This,
         IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL           *BltBuffer,
         IN  EFI_GRAPHICS_OUTPUT_BLT_OPERATION       BltOperation,
@@ -405,6 +406,7 @@ SREBlt (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL            *This,
 
 static
 EFI_STATUS
+EFIAPI
 SREQueryMode (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL          *This,
               IN  UINT32                                ModeNumber,
               OUT UINTN                                 *SizeOfInfo,
@@ -421,6 +423,7 @@ SREQueryMode (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL          *This,
 
 static
 EFI_STATUS
+EFIAPI
 SRESetMode (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL *This,
             IN  UINT32                       ModeNumber)
 {
@@ -444,6 +447,7 @@ SRESetMode (IN  EFI_GRAPHICS_OUTPUT_PROTOCOL *This,
 
 static
 EFI_STATUS
+EFIAPI
 SRESetMousePointer (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                     IN  const UINT32                    *MouseBitmap,
                     IN  UINT32                          Width,
@@ -547,6 +551,7 @@ Exit:
 
 static
 EFI_STATUS
+EFIAPI
 SREShowMousePointer (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                      IN  BOOLEAN                         ShowPointer)
 {
@@ -576,6 +581,7 @@ SREShowMousePointer (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
 
 static
 EFI_STATUS
+EFIAPI
 SREMoveMousePointer (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                      IN  UINT32                          OrigX,
                      IN  UINT32                          OrigY)
@@ -717,6 +723,7 @@ SampleSurfaceFrameTimerCallback (IN EFI_EVENT  Event,
 
 static
 EFI_STATUS
+EFIAPI
 SRECreateSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                   IN  EFI_HANDLE                      ImageHandle,
                   IN  SWM_RECT                        FrameRect,
@@ -832,6 +839,7 @@ Exit:
 
 static
 EFI_STATUS
+EFIAPI
 SREResizeSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                   IN  EFI_HANDLE                      ImageHandle,
                   IN  SWM_RECT                        *FrameRect)
@@ -958,6 +966,7 @@ SREResizeSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
 
 static
 EFI_STATUS
+EFIAPI
 SREActivateSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                     IN  EFI_HANDLE                      ImageHandle,
                     IN  BOOLEAN                         MakeActive)
@@ -1087,6 +1096,7 @@ SREActivateSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
 
 static
 EFI_STATUS
+EFIAPI
 SREDeleteSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
                   IN  EFI_HANDLE                      ImageHandle)
 {
@@ -1165,6 +1175,7 @@ SREDeleteSurface (IN  MS_RENDERING_ENGINE_PROTOCOL    *This,
 
 static
 EFI_STATUS
+EFIAPI
 SRESetModeSurface (IN  MS_RENDERING_ENGINE_PROTOCOL     *This,
                    IN  EFI_HANDLE                       ImageHandle,
                    IN  MS_SRE_SURFACE_MODE              Mode)

--- a/MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerProtocol.c
+++ b/MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerProtocol.c
@@ -39,6 +39,7 @@
 
 **/
 EFI_STATUS
+EFIAPI
 SWMAbsolutePointerReset (IN EFI_ABSOLUTE_POINTER_PROTOCOL *this,
                          IN BOOLEAN                        ExtendedVerification)
 {
@@ -96,6 +97,7 @@ Exit:
 
 **/
 EFI_STATUS
+EFIAPI
 SWMAbsolutePointerGetState (IN EFI_ABSOLUTE_POINTER_PROTOCOL     *this,
                             IN OUT MS_SWM_ABSOLUTE_POINTER_STATE *State)
 {


### PR DESCRIPTION
This fixes a warning from GCC that complains about missing braces (caused by
multi-dimensional array is treated as a linear arrary and unicode marco). And fix
errors about initialized an 'extern' variable and build path errors in UNIX.

Test: With very little modifications in OvmfPkgX64.dsc, Drivers in MsGraphicsPkg can
be built successfully with OvmfPkg. In Qemu, SetupBrowserDxe could use MsGraphicsPkg/DisplayEngineDxe (with GopOverrideDxe, MsUiThemeProtocolDxe, SimpleWindowManger, OnScreenKeyboardDxe) to render the UI correctly.