### PR TITLE
Merged PR 906: Fixed off by one error in 128 pixel tall unlock icon

### DIFF
--- a/MsGraphicsPkg/Library/ColorBarDisplayDeviceStateLib/Resources/UnlockBitmap128.h
+++ b/MsGraphicsPkg/Library/ColorBarDisplayDeviceStateLib/Resources/UnlockBitmap128.h
@@ -1,4 +1,4 @@
-// 82  x 128 x 32bpp
+// 83  x 128 x 32bpp
 CONST UINT32 mBltBuffer128[] = { 
   0x00FF0000, 0x00FF0000, 0x00FF0000, 0x00FF0000, 
   0x00FF0000, 0x00FF0000, 0x00FF0000, 0x00FF0000, 
@@ -2658,4 +2658,4 @@ CONST UINT32 mBltBuffer128[] = {
   0x00FF0000, 0x00FF0000, 0x00FF0000, 0x00FF0000
 };
 
-BITMAPDATA unlock128 = {128, 82, mBltBuffer128, sizeof(mBltBuffer128)};
+BITMAPDATA unlock128 = {128, 83, mBltBuffer128, sizeof(mBltBuffer128)};


### PR DESCRIPTION
Backporting a bugfix from release/201811.

(cherry picked from commit b0f3f401a423ea141c2ae375cc62761a9c93763f)