### PR TITLE
Merged PR 917: Change PCD Skip Counter to a dynamic PCD

### DIFF
--- a/MsGraphicsPkg/Library/BootGraphicsLib/BootGraphicsLib.inf
+++ b/MsGraphicsPkg/Library/BootGraphicsLib/BootGraphicsLib.inf
@@ -1,10 +1,10 @@
 ## @file
-#  This library is for showing the main system boot graphics.  
+#  This library is for showing the main system boot graphics.
 #
 # Copyright (c) 2017 - 2018, Microsoft Corporation.
 #
 # All rights reserved.
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 # 1. Redistributions of source code must retain the above copyright notice,
 # this list of conditions and the following disclaimer.
@@ -17,10 +17,10 @@
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
 # IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
 # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##
 
@@ -31,7 +31,6 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BootGraphicsLib|DXE_DRIVER UEFI_APPLICATION
-  CONSTRUCTOR                    = BootGraphicsLibConstructor
 
 #
 # The following information is for reference only and not required by the build tools.

--- a/MsGraphicsPkg/MsGraphicsPkg.dec
+++ b/MsGraphicsPkg/MsGraphicsPkg.dec
@@ -114,13 +114,6 @@
   #  no theme guid hob is inserted into the HOB list.  This is for system that do not use PPI
   gMsGraphicsPkgTokenSpaceGuid.PcdUiThemeInDxe|FALSE|BOOLEAN|0x40000015
 
-  ##
-  # POST background coloring skip counter's initial/default value.
-  # Background is colored in DXE only when this counter reaches 0
-  # Default is 1, meaning background will not be colored on first invocation of Logo rendering library in DXE
-  #
-  gMsGraphicsPkgTokenSpaceGuid.PcdPostBackgroundColoringSkipCount|0x01|UINT8|0x40000187
-
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Power Off Delay and Hold time.  Delay is how long to wait before prompting the user, and
   #  hold is how long to display the power down dialog before shutting down
@@ -129,6 +122,13 @@
 
 [PcdsDynamic, PcdsDynamicEx]
   gMsGraphicsPkgTokenSpaceGuid.PcdCurrentPointerState|0x00000000|UINT64|0x40000009
- 
+
+  ##
+  # POST background coloring skip counter's initial/default value.
+  # Background is colored in DXE only when this counter reaches 0
+  # Default is 1, meaning background will not be colored on first invocation of Logo rendering library in DXE
+  #
+  gMsGraphicsPkgTokenSpaceGuid.PcdPostBackgroundColoringSkipCount|0x01|UINT8|0x40000187
+
 [UserExtensions.TianoCore."ExtraFiles"]
   MsGraphicsPkgExtra.uni


### PR DESCRIPTION
If the library is included by more than one module, the clear screen skip may occur too many times leading to display overlay.