### PR TITLE
Add DebugPrintValist to DebugLib

### DIFF
--- a/MsCorePkg/Library/DebugPortPei/DebugPortPei.inf
+++ b/MsCorePkg/Library/DebugPortPei/DebugPortPei.inf
@@ -1,13 +1,13 @@
 ## @file
-# This library has no API or Library function callers. In the entry point it will publish 
-# the DebugPortPpi using the containing module's DebugLib instance functions. This allows all 
+# This library has no API or Library function callers. In the entry point it will publish
+# the DebugPortPpi using the containing module's DebugLib instance functions. This allows all
 # other modules within PEI to use a thin shim DebugLib that leverages the functions in the PPI.
 # This can provide a significant flash size savings for PEIMs which often have limited space.
 #
 # Copyright (c) 2016, Microsoft Corporation
 #
 # All rights reserved.
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 # 1. Redistributions of source code must retain the above copyright notice,
 # this list of conditions and the following disclaimer.
@@ -20,10 +20,10 @@
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
 # IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
 # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##
 

--- a/MsCorePkg/Library/PeiDebugLib/DebugLib.c
+++ b/MsCorePkg/Library/PeiDebugLib/DebugLib.c
@@ -5,13 +5,13 @@
   Copyright (c) 2018, Microsoft Corporation
 
   Copyright (c) 2006 - 2011, Intel Corporation. All rights reserved.<BR>
-  This program and the accompanying materials                          
-  are licensed and made available under the terms and conditions of the BSD License         
-  which accompanies this distribution.  The full text of the license may be found at        
-  http://opensource.org/licenses/bsd-license.php.                                            
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
 
-  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,                     
-  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.             
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 
 **/
 
@@ -32,15 +32,15 @@
 /**
   Prints a debug message to the debug output device if the specified error level is enabled.
 
-  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function 
-  GetDebugPrintErrorLevel (), then print the message specified by Format and the 
+  If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+  GetDebugPrintErrorLevel (), then print the message specified by Format and the
   associated variable argument list to the debug output device.
 
   If Format is NULL, then ASSERT().
 
   @param  ErrorLevel  The error level of the debug message.
   @param  Format      Format string for the debug message to print.
-  @param  ...         Variable argument list whose contents are accessed 
+  @param  ...         Variable argument list whose contents are accessed
                       based on the format string specified by Format.
 
 **/
@@ -82,6 +82,57 @@ DebugPrint (
 }
 
 /**
+Prints a debug message to the debug output device if the specified error level is enabled.
+
+If any bit in ErrorLevel is also set in DebugPrintErrorLevelLib function
+GetDebugPrintErrorLevel (), then print the message specified by Format and the
+associated variable argument list to the debug output device.
+
+If Format is NULL, then ASSERT().
+
+If the length of the message string specificed by Format is larger than the maximum allowable
+record length, then directly return and not print it.
+
+@param  ErrorLevel    The error level of the debug message.
+@param  Format        Format string for the debug message to print.
+@param  VaListMarker  VA_LIST marker for the variable argument list.
+
+**/
+VOID
+EFIAPI
+DebugPrintValist(
+  IN  UINTN        ErrorLevel,
+  IN  CONST CHAR8  *Format,
+  VA_LIST          VaListMarker
+  )
+{
+  DEBUG_PORT_PPI *DebugPortPPI;
+  EFI_STATUS      Status;
+
+  //
+  // If Format is NULL, then ASSERT().
+  //
+  ASSERT (Format != NULL);
+
+  //
+  // Check driver Debug Level value and global debug level
+  //
+  if ((ErrorLevel & GetDebugPrintErrorLevel ()) == 0) {
+    return;
+  }
+
+  Status = PeiServicesLocatePpi (
+              &gDebugPortPpiGuid,
+              0,
+              NULL,
+              (VOID **) &DebugPortPPI
+              );
+  if (Status == EFI_SUCCESS) {
+    DebugPortPPI->DebugPortPrint (ErrorLevel, Format, VaListMarker);
+  }
+}
+
+/**
   Dumps memory formatted.
 
   Dumps the memory as hex bytes.  Other additional options
@@ -100,7 +151,7 @@ DebugDumpMemory (
   IN  CONST VOID   *Address,
   IN  UINTN         Length,
   IN  UINT32        Flags
-  ) 
+  )
 {
   DEBUG_PORT_PPI *DebugPortPPI;
   EFI_STATUS    Status;
@@ -129,14 +180,14 @@ DebugDumpMemory (
 }
 
 /**
-  Prints an assert message containing a filename, line number, and description.  
+  Prints an assert message containing a filename, line number, and description.
   This may be followed by a breakpoint or a dead loop.
 
   Print a message of the form "ASSERT <FileName>(<LineNumber>): <Description>\n"
-  to the debug output device.  If DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED bit of 
-  PcdDebugProperyMask is set then CpuBreakpoint() is called. Otherwise, if 
-  DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED bit of PcdDebugProperyMask is set then 
-  CpuDeadLoop() is called.  If neither of these bits are set, then this function 
+  to the debug output device.  If DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED bit of
+  PcdDebugProperyMask is set then CpuBreakpoint() is called. Otherwise, if
+  DEBUG_PROPERTY_ASSERT_DEADLOOP_ENABLED bit of PcdDebugProperyMask is set then
+  CpuDeadLoop() is called.  If neither of these bits are set, then this function
   returns immediately after the message is printed to the debug output device.
   DebugAssert() must actively prevent recursion.  If DebugAssert() is called while
   processing another DebugAssert(), then DebugAssert() must return immediately.
@@ -169,7 +220,7 @@ DebugAssert (
 
   if (!EFI_ERROR (Status)) {
     DebugPortPPI->DebugPortAssert (FileName, LineNumber, Description);
-  } 
+  }
   else {
     //
     // Generate a Breakpoint, DeadLoop, or NOP based on PCD settings
@@ -188,14 +239,14 @@ DebugAssert (
 /**
   Fills a target buffer with PcdDebugClearMemoryValue, and returns the target buffer.
 
-  This function fills Length bytes of Buffer with the value specified by 
+  This function fills Length bytes of Buffer with the value specified by
   PcdDebugClearMemoryValue, and returns Buffer.
 
   If Buffer is NULL, then ASSERT().
-  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT(). 
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
 
   @param   Buffer  The pointer to the target buffer to be filled with PcdDebugClearMemoryValue.
-  @param   Length  The number of bytes in Buffer to fill with zeros PcdDebugClearMemoryValue. 
+  @param   Length  The number of bytes in Buffer to fill with zeros PcdDebugClearMemoryValue.
 
   @return  Buffer  The pointer to the target buffer filled with PcdDebugClearMemoryValue.
 
@@ -222,7 +273,7 @@ DebugClearMemory (
 /**
   Returns TRUE if ASSERT() macros are enabled.
 
-  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of 
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of
   PcdDebugProperyMask is set.  Otherwise FALSE is returned.
 
   @retval  TRUE    The DEBUG_PROPERTY_DEBUG_ASSERT_ENABLED bit of PcdDebugProperyMask is set.
@@ -239,10 +290,10 @@ DebugAssertEnabled (
 }
 
 
-/**  
+/**
   Returns TRUE if DEBUG() macros are enabled.
 
-  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of 
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of
   PcdDebugProperyMask is set.  Otherwise FALSE is returned.
 
   @retval  TRUE    The DEBUG_PROPERTY_DEBUG_PRINT_ENABLED bit of PcdDebugProperyMask is set.
@@ -259,10 +310,10 @@ DebugPrintEnabled (
 }
 
 
-/**  
+/**
   Returns TRUE if DEBUG_CODE() macros are enabled.
 
-  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of 
+  This function returns TRUE if the DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of
   PcdDebugProperyMask is set.  Otherwise FALSE is returned.
 
   @retval  TRUE    The DEBUG_PROPERTY_DEBUG_CODE_ENABLED bit of PcdDebugProperyMask is set.
@@ -279,10 +330,10 @@ DebugCodeEnabled (
 }
 
 
-/**  
+/**
   Returns TRUE if DEBUG_CLEAR_MEMORY() macro is enabled.
 
-  This function returns TRUE if the DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of 
+  This function returns TRUE if the DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of
   PcdDebugProperyMask is set.  Otherwise FALSE is returned.
 
   @retval  TRUE    The DEBUG_PROPERTY_CLEAR_MEMORY_ENABLED bit of PcdDebugProperyMask is set.


### PR DESCRIPTION
Update DebugPortPei with function missing from API contract defined in BaseCore DebugLib.h