### PR TITLE
Avoid extra string manipulation for gEfiStatusCodeDataTypeStringGuid

### DIFF
--- a/MsCorePkg/Universal/StatusCodeHandler/Serial/Common/SerialStatusCodeHandler.c
+++ b/MsCorePkg/Universal/StatusCodeHandler/Serial/Common/SerialStatusCodeHandler.c
@@ -157,7 +157,7 @@ SerialStatusCode(
   //
   // Call SerialPort Lib function to do print.
   //
-  WriteStatusCode(BufferPtr, CharCount);
+  WriteStatusCode((UINT8 *)BufferPtr, CharCount);
 
 Cleanup:
   return EFI_SUCCESS;


### PR DESCRIPTION
This PR changes the implementation of SerialStatusCodeHandler so that pre-formatted strings (such as ones passed from FSP) don't use AsciiSprint() and are instead passed straight to the writer routine.