### PR TITLE
MfciPkg: enforce spell check, fix spelling, add exceptions where needed

### DIFF
--- a/MfciPkg/Docs/Mfci_Feature.md
+++ b/MfciPkg/Docs/Mfci_Feature.md
@@ -6,7 +6,7 @@ The following is prerelease documentation for an upcoming feature.  Details are 
 
 ## Overview
 
-### In a Sentance
+### In a Sentence
 
 Manufacturer Firmware Configuration Interface (MFCI) is a UEFI BIOS feature that provides a secure
 mechanism for an authorized agent, such as an OEM or ODM, to modify firmware security properties

--- a/MfciPkg/Library/MfciRetrievePolicyLibNull/ReadMe.md
+++ b/MfciPkg/Library/MfciRetrievePolicyLibNull/ReadMe.md
@@ -1,4 +1,4 @@
-# MfciRetirevePolicyLib: NULL edition
+# MfciRetrievePolicyLib: NULL edition
 
 ## About
 

--- a/MfciPkg/Library/MfciRetrievePolicyLibViaHob/ReadMe.md
+++ b/MfciPkg/Library/MfciRetrievePolicyLibViaHob/ReadMe.md
@@ -1,4 +1,4 @@
-# MfciRetirevePolicyLib: HOB edition
+# MfciRetrievePolicyLib: HOB edition
 
 ## About
 

--- a/MfciPkg/Library/MfciRetrievePolicyLibViaVariable/ReadMe.md
+++ b/MfciPkg/Library/MfciRetrievePolicyLibViaVariable/ReadMe.md
@@ -1,4 +1,4 @@
-# MfciRetirevePolicyLib: UEFI variable edition
+# MfciRetrievePolicyLib: UEFI variable edition
 
 ## About
 

--- a/MfciPkg/MfciDxe/MfciPublicInterface.c
+++ b/MfciPkg/MfciDxe/MfciPublicInterface.c
@@ -86,7 +86,7 @@ GetPhaseIndicatorStatus (
 /**
   This callback is registered on EndOfDxe to clean up the notification context.
 
-  This is done for security so that after EndOfDxe an ellicit attempt may not be
+  This is done for security so that after EndOfDxe an illicit attempt may not be
   made to trick drivers in a MFCI Policy change.
 
   @param[in]  Event     Event whose notification function is being invoked
@@ -313,7 +313,7 @@ InternalRegisterMfciPolicyChangeNotifyCallback (
 /**
   This callback is registered on EndOfDxe to clean up the notification context.
 
-  This is done for security so that after EndOfDxe an ellicit attempt may not be
+  This is done for security so that after EndOfDxe an illicit attempt may not be
   made to trick drivers in a MFCI Policy change.
 
   @param[in]  Event     Event whose notification function is being invoked

--- a/MfciPkg/MfciPkg.ci.yaml
+++ b/MfciPkg/MfciPkg.ci.yaml
@@ -52,12 +52,19 @@
 
     ## options defined ci/Plugin/SpellCheck
     "SpellCheck": {
-        "AuditOnly": True,           # Fails test but run in AuditOnly mode to collect log
         "IgnoreStandardPaths": [     # Standard Plugin defined paths that should be ignore
         ],
         "IgnoreFiles": [             # use gitignore syntax to ignore errors in matching files
         ],
         "ExtendWords": [           # words to extend to the dictionary for this package
+            "basecore",
+            "certutil",
+            "commandline",
+            "detatched",
+            "mfci's",
+            "mfcipkg",
+            "pkg's",
+            "reprovisioned"
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
     }

--- a/MfciPkg/MfciPkg.dec
+++ b/MfciPkg/MfciPkg.dec
@@ -64,7 +64,7 @@
   # TRUE: MfciDxe will call MfciDeviceIdSupportLib to gather the targeting
   # strings, and it (MfciDxe) will set the device targeting variables. This invocation
   # of MfciDeviceIdSupportLib occurs during the gMsStartOfBdsNotify event, which is
-  # triggered immedietly prior to EndOfDxe
+  # triggered immediately prior to EndOfDxe
   ##
   gMfciPkgTokenSpaceGuid.PcdMfciPopulateTargetFromDeviceIdSupportLib|FALSE|BOOLEAN|0x40000044
 

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest.c
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest.c
@@ -298,10 +298,10 @@ EntryPoint (
 
   // The test case data contexts are large, to be nice to the stack we define them as static
   // Some of the data comes from PCDs (not constant), and it was necessary to pass that data
-  // via static pointers to the data.  Unfortinately to test a 0 or NULL, this required declaring
+  // via static pointers to the data.  Unfortunately to test a 0 or NULL, this required declaring
   // static pointers to 0 and NULL.
   //
-  // TODO: any suggestions on friendler code or comment for below code?
+  // TODO: any suggestions on friendlier code or comment for below code?
 
   static CONST VOID* CONST  mNullPtr = NULL;
   static CONST UINT8* mCertCA;


### PR DESCRIPTION
MfciPkg spelling update

- CI build will no longer "audit" spelling issues, they will cause CI to fail
- Spelling errors fixed
- Real terms added to dictionary