### PR TITLE
Add support for splitting memory pages when a memory range is not a full page

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
@@ -1,3 +1,5 @@
+import copy
+
 # Memory range is either a page table entry, memory map entry,
 # or a description of the memory contents.
 #
@@ -72,6 +74,7 @@ class MemoryRange(object):
         self.NumberOfEntries = 1
         self.Found = False
         self.Attribute = 0
+        self.PageSplit = False
 
         # Check to see whether we're a type that we recognize.
         if self.RecordType not in ("TSEG", "MemoryMap", "LoadedImage", "SmmLoadedImage", "PDE", "GDT", "IDT", "PTEntry", "MAT", "GuardPage"):
@@ -226,11 +229,12 @@ class MemoryRange(object):
             "Privilege" : "User" if (self.UserPrivilege == 1) else "Supervisor",
             "Start" : "0x{0:010X}".format(self.PhysicalStart),
             "End" : "0x{0:010X}".format(self.PhysicalEnd),
-            "Number of Entries" : self.NumberOfEntries,
+            "Number of Entries" : self.NumberOfEntries if (not self.PageSplit) else str(self.NumberOfEntries) + " (p)" ,
             "Memory Type" : self.GetMemoryTypeDescription(),
             "Section Type" : section_type,
             "System Memory": self.GetSystemMemoryType(),
-            "Memory Contents" : self.ImageName}
+            "Memory Contents" : self.ImageName,
+            "Partial Page": self.PageSplit}
 
     def overlap(self, compare):
         if(self.PhysicalStart >= compare.PhysicalStart) and (self.PhysicalStart <= compare.PhysicalEnd):
@@ -246,6 +250,33 @@ class MemoryRange(object):
             return True
 
         return False
+
+    def split(self, end_of_current):
+        ''' split the memory range object into two and copy
+        all attributes to the new object.
+        end_of_current = physical end of the first object.
+
+        modify self
+        return 
+        '''
+        if end_of_current is None:
+            raise Exception("Failed Split - Invalid parameter.  end_of_current can not be none")
+
+        if end_of_current <= self.PhysicalStart:
+            raise Exception("Failed Split - Invalid parameter.  end_of_current can not be <= start. " + 
+                            f"self.PhysicalStart = {self.PhysicalStart} " + 
+                            f"end_of_current = {end_of_current}" )
+
+        if end_of_current >= self.PhysicalEnd:
+            raise Exception("Failed Split - Invalid parameter.  end_of_current can not be >= end" + 
+                            f"self.PhysicalEnd = {self.PhysicalEnd} " + 
+                            f"end_of_current = {end_of_current}" ) 
+
+        self.PageSplit = True
+        next = copy.deepcopy(self)
+        self.PhysicalEnd = end_of_current
+        next.PhysicalStart = end_of_current +1
+        return next
 
     def sameAttributes(self, compare):
         if compare is None:
@@ -279,6 +310,9 @@ class MemoryRange(object):
             return False
 
         if (self.Attribute != compare.Attribute):
+            return False
+        
+        if (self.PageSplit or compare.PageSplit):
             return False
 
         return True

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
@@ -21,7 +21,7 @@ from MemoryRangeObjects import *
 from BinaryParsing import *
 
 
-VERSION = "0.80"
+VERSION = "0.90"
 
 
 class ParsingTool(object):
@@ -95,18 +95,32 @@ class ParsingTool(object):
             self.ErrorMsg.append("No Memory Range info found in Info files")
 
         # Matching memory ranges up to page table entries
-        for pte in self.PageDirectoryInfo:
+        # use index based iteration so that page splitting
+        # is supported.
+        index = 0
+        while index < len(self.PageDirectoryInfo) - 1:
+            pte = self.PageDirectoryInfo[index]
             for mr in self.MemoryRangeInfo:
                 if pte.overlap(mr):
                     if mr.MemoryType is not None:
-                        if (pte.PhysicalEnd > mr.PhysicalEnd) or (pte.PhysicalStart < mr.PhysicalStart):
-                            logging.error("Memory range attribute does not cover entire page " + pte.pteDebugStr() +" " + mr.MemoryRangeToString())
-                            self.ErrorMsg.append("Memory range attribute does not cover entire page.  Base: 0x%X. "% (pte.PhysicalStart))
+                        if (pte.PhysicalStart < mr.PhysicalStart):
+                            next = pte.split(mr.PhysicalStart-1)
+                            self.PageDirectoryInfo.insert(index+1, next)
+                            #decrement the index so that we process this partial PTE again
+                            # since we are breaking from the MemoryRange Loop
+                            index -= 1
+                            break
+
+                        if (pte.PhysicalEnd > mr.PhysicalEnd):
+                            next = pte.split(mr.PhysicalEnd)
+                            self.PageDirectoryInfo.insert(index +1, next)
+          
                         if pte.MemoryType is None:
                             pte.MemoryType = mr.MemoryType
                         else:
                             logging.error("Multiple memory types found for one region " + pte.pteDebugStr() +" " + mr.MemoryRangeToString())
                             self.ErrorMsg.append("Multiple memory types found for one region.  Base: 0x%X.  EFI Memory Type: %d and %d"% (pte.PhysicalStart, pte.MemoryType,mr.MemoryType))
+                    
                     if mr.ImageName is not None:
                         if pte.ImageName is None:
                             pte.ImageName = mr.ImageName
@@ -114,8 +128,8 @@ class ParsingTool(object):
                             self.ErrorMsg.append("Multiple memory contents found for one region.  Base: 0x%X.  Memory Contents: %s and %s" % (pte.PhysicalStart, pte.ImageName, mr.ImageName ))
                             logging.error("Multiple memory contents found for one region " +pte.pteDebugStr() + " " +  mr.LoadedImageEntryToString())
 
-                    if(mr.SystemMemoryType is not None):
-                        if(pte.SystemMemoryType is None):
+                    if mr.SystemMemoryType is not None:
+                        if pte.SystemMemoryType is None:
                             pte.SystemMemoryType = mr.SystemMemoryType
                         else:
                             self.ErrorMsg.append("Multiple System Memory types found for one region.  Base: 0x%X.  EFI Memory Type: %s and %s."% (pte.PhysicalStart,pte.SystemMemoryType, mr.SystemMemoryType))
@@ -124,6 +138,7 @@ class ParsingTool(object):
             for MatEntry in self.MemoryAttributesTable:
                 if pte.overlap(MatEntry):
                     pte.Attribute = MatEntry.Attribute
+            index += 1
 
         # Combining adjacent PTEs that have the same attributes.
         index = 0


### PR DESCRIPTION
There are a few cases where a page might have different memory types if UEFI treats these ranges with the same attributes.