### PR TITLE
Remove gEfiEventPreReadyToBootGuid from Dfci

### DIFF
--- a/DfciPkg/Application/DfciMenu/DfciMenu.inf
+++ b/DfciPkg/Application/DfciMenu/DfciMenu.inf
@@ -94,7 +94,6 @@
   gEfiSimpleFileSystemProtocolGuid
   gEfiTlsConfigurationProtocolGuid
   gEfiUsbIoProtocolGuid
-  gMsOSKProtocolGuid
 
 [FeaturePcd]
 

--- a/DfciPkg/Application/DfciMenu/DfciMenu.inf
+++ b/DfciPkg/Application/DfciMenu/DfciMenu.inf
@@ -79,7 +79,6 @@
   gDfciSettingsGuid
   gDfciSettingsManagerVarNamespace
   gEfiBootManagerPolicyNetworkGuid
-  gEfiEventPreReadyToBootGuid
   gEfiTlsCaCertificateGuid
   gEfiCertX509Guid
 

--- a/DfciPkg/Application/DfciMenu/DfciSARecovery.inf
+++ b/DfciPkg/Application/DfciMenu/DfciSARecovery.inf
@@ -1,7 +1,7 @@
 ## @file
-# DfciMenu.inf
+# DfciSARecovery.inf
 #
-# DfciMenu is an application that presents & manages the Dfci settings page.
+# Stand alone application/example for DFCI recovery
 #
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -69,12 +69,9 @@
 
 [Guids]
   gDfciAuthProvisionVarNamespace
-  gDfciConfigCompleteEventGroupGuid
-  gDfciConfigStartEventGroupGuid
   gDfciMenuFormsetGuid
   gDfciRecoveryFormsetGuid
   gDfciPermissionManagerVarNamespace
-  gDfciSettingsGuid
   gDfciSettingsManagerVarNamespace
   gEfiBootManagerPolicyNetworkGuid
   gEfiTlsCaCertificateGuid
@@ -86,21 +83,8 @@
   gDfciSettingPermissionsProtocolGuid
   gEfiBlockIoProtocolGuid
   gEfiBootManagerPolicyProtocolGuid
-  gEfiHiiConfigAccessProtocolGuid
   gEfiHttpProtocolGuid
   gEfiHttpServiceBindingProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
   gEfiTlsConfigurationProtocolGuid
   gEfiUsbIoProtocolGuid
-  gMsOSKProtocolGuid
-
-[FeaturePcd]
-
-[Pcd]
-  gDfciPkgTokenSpaceGuid.PcdSetupUiReducedFunction
-
-[Depex]
-  gEfiVariableArchProtocolGuid  AND
-  gDfciSettingAccessProtocolGuid AND
-  gDfciAuthenticationProtocolGuid AND
-  gDfciSettingPermissionsProtocolGuid

--- a/DfciPkg/Application/DfciMenu/DfciSARecovery.inf
+++ b/DfciPkg/Application/DfciMenu/DfciSARecovery.inf
@@ -77,7 +77,6 @@
   gDfciSettingsGuid
   gDfciSettingsManagerVarNamespace
   gEfiBootManagerPolicyNetworkGuid
-  gEfiEventPreReadyToBootGuid
   gEfiTlsCaCertificateGuid
   gEfiCertX509Guid
 


### PR DESCRIPTION
This guid is not used by these modules and therefore should not be declared a dependency.  Extra dependencies like this are incorrect and make the code harder to integrate into other code bases.