### PR TITLE
UpdateFacsHardwareSignatureLib: Initialize NULL variables before use

### DIFF
--- a/PcBdsPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.c
+++ b/PcBdsPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.c
@@ -96,13 +96,13 @@ UpdateFacsHardwareSignature (
   UINTN                                                Handle;
   EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE            *FadtPtr = NULL;
   static EFI_ACPI_2_0_FIRMWARE_ACPI_CONTROL_STRUCTURE  *FacsPtr = NULL;
-  UINT32                                               *Buffer;
+  UINT32                                               *Buffer = NULL;
   UINTN                                                BufferCount;     // Count of UINT32 items in Buffer
 
   // Variables for Part 1 PCI data
   EFI_PCI_IO_PROTOCOL  *PciIo;
   UINTN                PciHandleCount;
-  EFI_HANDLE           *PciHandleBuffer;
+  EFI_HANDLE           *PciHandleBuffer = NULL;
   UINT32               PciId;
 
   // Variables for Part 2 Firmware Version data

--- a/PcBdsPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.c
+++ b/PcBdsPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.c
@@ -96,7 +96,7 @@ UpdateFacsHardwareSignature (
   UINTN                                                Handle;
   EFI_ACPI_3_0_FIXED_ACPI_DESCRIPTION_TABLE            *FadtPtr = NULL;
   static EFI_ACPI_2_0_FIRMWARE_ACPI_CONTROL_STRUCTURE  *FacsPtr = NULL;
-  UINT32                                               *Buffer = NULL;
+  UINT32                                               *Buffer  = NULL;
   UINTN                                                BufferCount;     // Count of UINT32 items in Buffer
 
   // Variables for Part 1 PCI data


### PR DESCRIPTION
Initialize Buffer and PciHandleBuffer to NULL before use. No functional changes. This fixes CLANG build errors.

File: UpdateFacsHardwareSignatureLib.c
337: CleanUp:
338:   //
339:   // Step 12. Free buffers
340:   //
341:   if (PciHandleBuffer != NULL) {
342:     FreePool (PciHandleBuffer);
343:   }
344: 
345:   if (Buffer != NULL) {
346:     FreePool (Buffer);
347:   }
