### PR TITLE
Add Host Based Unit Tests for HidMouseAbsolutePointerDxe

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -30,8 +30,10 @@ jobs:
     tool_chain_tag: 'GCC5'
     vm_image: 'ubuntu-latest'
     arch_list: "IA32,X64,ARM,AARCH64"
+    build_args: "CODE_COVERAGE=TRUE CC_HTML=TRUE" # MU_CHANGE
     # MU_CHANGE
     extra_steps:
-    - script: sudo apt-get install mingw-w64
-      displayName: Install Windows Resource Compiler for Linux
-
+    - script: |
+              sudo apt-get install -y mingw-w64 lcov
+              pip install lcov_cobertura pycobertura
+      displayName: Install Windows Resource Compiler for Linux & Code Coverage Tools

--- a/.azurepipelines/templates/ReadMe.md
+++ b/.azurepipelines/templates/ReadMe.md
@@ -16,7 +16,7 @@ use `apt` to update the system packages and add those necessary for Edk2 builds.
 
 ### pr-gate-build-job.yml
 
-This templates contains the jobs and most importantly the matrix of which packages and
+This template contains the jobs and most importantly the matrix of which packages and
 targets to run for Core CI.
 
 ### pr-gate-steps.yml
@@ -28,6 +28,12 @@ build type is "pull request"
 ### spell-check-prereq-steps.yml
 
 This template installs the node based tools used by the spell checker plugin. The steps
+in this template are conditional and will only run if variable `pkg_count` is greater than 0.
+
+
+### markdownlint-check-prereq-steps.yml
+
+This template installs the markdown lint tools used by the markdown linter plugin. The steps
 in this template are conditional and will only run if variable `pkg_count` is greater than 0.
 
 ## Platform CI templates

--- a/.azurepipelines/templates/markdownlint-check-prereq-steps.yml
+++ b/.azurepipelines/templates/markdownlint-check-prereq-steps.yml
@@ -13,6 +13,7 @@ parameters:
 
 steps:
 
-- script: npm install -g markdownlint-cli@0.31.0
+- script: npm install -g markdownlint-cli@0.31.1
   displayName: "Install markdown linter"
   condition: and(gt(variables.pkg_count, 0), succeeded())
+  timeoutInMinutes: 2

--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -13,6 +13,7 @@ parameters:
   vm_image: ''
   arch_list: ''
   extra_steps: []   # MU_CHANGE
+  build_args: ''    # MU_CHANGE - Allow environment level build args.
 
 # Build step
 jobs:
@@ -41,10 +42,12 @@ jobs:
     vmImage: ${{ parameters.vm_image }}
 
   steps:
-  - ${{ parameters.extra_steps }}   # MU_CHANGE
   - template: pr-gate-steps.yml
     parameters:
       tool_chain_tag: ${{ parameters.tool_chain_tag }}
       build_pkgs: $(Build.Pkgs)
       build_targets: $(Build.Targets)
       build_archs: ${{ parameters.arch_list }}
+      extra_steps: ${{ parameters.extra_steps }}   # MU_CHANGE
+      build_args: ${{ parameters.build_args }}     # MU_CHANGE
+      has_ci_dependencies: true

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -12,6 +12,9 @@ parameters:
   build_pkgs: ''
   build_targets: ''
   build_archs: ''
+  has_ci_dependencies: false    # MU_CHANGE - Enable toggle for stuart_ci_build
+  extra_steps: []               # MU_CHANGE - needed for clang
+  build_args: '' # MU_CHANGE - add build arguments to support code coverage
 
 steps:
 - checkout: self
@@ -54,18 +57,27 @@ steps:
 # install spell check prereqs
 - template: spell-check-prereq-steps.yml
 
+# MU_CHANGE - Add MarkdownLint
 # install markdownlint check prereqs
 - template: markdownlint-check-prereq-steps.yml
+
+
+# MU_CHANGE - [start] need support for extra steps for clang
+# Extra steps if needed
+- ${{ parameters.extra_steps }}
+# MU_CHANGE [end]
+
 
 # Build repo
 # MU_CHANGE - We use CI dependencies as well as submodules.
 - task: CmdLine@1
-  displayName: Setup ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+  displayName: Dependency Setup ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
   inputs:
     filename: stuart_ci_setup
     arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) --force-git -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
-  condition: and(gt(variables.pkg_count, 0), succeeded())
+  condition: and(gt(variables.pkg_count, 0), succeeded(), eq('${{ parameters.has_ci_dependencies }}', 'true'))
 
+# Build repo
 - task: CmdLine@1
   displayName: Setup ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
   inputs:
@@ -80,19 +92,21 @@ steps:
     arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
-# MU_CHANGE - We use binary BaseTools
+# MU_CHANGE [BEGIN] - We use binary BaseTools
 # build basetools
 #   do this after setup and update so that code base dependencies
 #   are all resolved.
 # - template: basetools-build-steps.yml
 #   parameters:
 #     tool_chain_tag: ${{ parameters.tool_chain_tag }}
+# MU_CHANGE [END]
 
 - task: CmdLine@1
   displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
   inputs:
     filename: stuart_ci_build
-    arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    # MU_CHANGE - Add build arguments parameter
+    arguments: -c .pytool/CISettings.py -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.build_args}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
 # Publish Test Results to Azure Pipelines/TFS
@@ -143,6 +157,8 @@ steps:
       TestSuites.xml
       **/BUILD_TOOLS_REPORT.html
       **/OVERRIDELOG.TXT
+      coverage.xml
+      coverage.html
     flattenFolders: true
   condition: succeededOrFailed()
 
@@ -154,3 +170,11 @@ steps:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'Build Logs $(System.JobName)'
   condition: succeededOrFailed()
+
+# MU_CHANGE - Publish the LCOV coverage files.
+- task: PublishCodeCoverageResults@1
+  condition: and(succeededOrFailed(), and(gt(variables.pkg_count, 0), contains('${{ parameters.build_args }}', 'CODE_COVERAGE=TRUE')))
+  inputs:
+    codeCoverageTool: 'Cobertura'
+    summaryFileLocation: 'Build/coverage.xml'
+    pathToSources: '$(Build.SourcesDirectory)'

--- a/.azurepipelines/templates/spell-check-prereq-steps.yml
+++ b/.azurepipelines/templates/spell-check-prereq-steps.yml
@@ -16,7 +16,9 @@ steps:
     versionSpec: '17.x' # MU_CHANGE
     #checkLatest: false # Optional
   condition: and(gt(variables.pkg_count, 0), succeeded())
+  timeoutInMinutes: 2
 
 - script: npm install -g cspell@5.20.0
   displayName: 'Install cspell npm'
   condition: and(gt(variables.pkg_count, 0), succeeded())
+  timeoutInMinutes: 2

--- a/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
+++ b/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
@@ -562,7 +562,18 @@ OnMouseReport (
         return;
       }
 
-      SingleTouchInput                 = (SINGLETOUCH_HID_INPUT_BUFFER *)HidInputReportBuffer;
+      SingleTouchInput = (SINGLETOUCH_HID_INPUT_BUFFER *)HidInputReportBuffer;
+
+      // Check values against known good range before copy.
+      if ((SingleTouchInput->CurrentX < HidMouseDev->Mode.AbsoluteMinX) ||
+          (SingleTouchInput->CurrentX > HidMouseDev->Mode.AbsoluteMaxX) ||
+          (SingleTouchInput->CurrentY < HidMouseDev->Mode.AbsoluteMinY) ||
+          (SingleTouchInput->CurrentY > HidMouseDev->Mode.AbsoluteMaxY))
+      {
+        DEBUG ((DEBUG_ERROR, "[%a] - invalid SingleTouch Coordinates [%d, %d]\n", __FUNCTION__, SingleTouchInput->CurrentX, SingleTouchInput->CurrentY));
+        return;
+      }
+
       HidMouseDev->State.ActiveButtons = SingleTouchInput->Touch;
       HidMouseDev->State.CurrentX      = SingleTouchInput->CurrentX;
       HidMouseDev->State.CurrentY      = SingleTouchInput->CurrentY;

--- a/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
+++ b/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
@@ -524,9 +524,23 @@ OnMouseReport (
 
   HidMouseDev = (HID_MOUSE_ABSOLUTE_POINTER_DEV *)Context;
 
-  if ((HidMouseDev == NULL) || (HidInputReportBuffer == NULL)) {
-    DEBUG ((DEBUG_ERROR, "[%a] - Invalid input pointer.\n", __FUNCTION__));
-    ASSERT ((HidMouseDev != NULL) && (HidInputReportBuffer != NULL));
+  if (HidMouseDev == NULL) {
+    DEBUG ((DEBUG_ERROR, "[%a] - Invalid Context pointer: Null.\n", __FUNCTION__));
+    ASSERT (HidMouseDev != NULL);
+    return;
+  }
+
+  // Since this is called by external module the function should do basic
+  // check on Context parameter.
+  if (HidMouseDev->Signature != HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE) {
+    DEBUG ((DEBUG_ERROR, "[%a] - Invalid context pointer: Signature match failure.\n", __FUNCTION__));
+    ASSERT (HidMouseDev->Signature == HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE);
+    return;
+  }
+
+  if (HidInputReportBuffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "[%a] - Invalid input HidInputReportBuffer pointer.\n", __FUNCTION__));
+    ASSERT (HidInputReportBuffer != NULL);
     return;
   }
 

--- a/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
+++ b/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
@@ -620,7 +620,7 @@ OnMouseReport (
           (INT64)HidMouseDev->Mode.AbsoluteMaxY
           );
       // only use Z if optional byte is included (as indicated by the report size)
-      if (HidInputReportBufferSize == sizeof (MOUSE_HID_INPUT_BUFFER)) {
+      if (HidInputReportBufferSize >= sizeof (MOUSE_HID_INPUT_BUFFER)) {
         HidMouseDev->State.CurrentZ =
           MIN (
             MAX (

--- a/HidPkg/HidMouseAbsolutePointerDxe/UnitTest/HidMouse.c
+++ b/HidPkg/HidMouseAbsolutePointerDxe/UnitTest/HidMouse.c
@@ -1,0 +1,968 @@
+/** @file
+  This module tests HID Mouse Driver logic for conversion between
+  HID report and absolute pointer protocol format for mouse movement
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/UnitTestLib.h>
+#include "../HidMouseAbsolutePointer.h"
+
+#define UNIT_TEST_NAME     "HID Mouse Host Test"
+#define UNIT_TEST_VERSION  "0.1"
+
+#define HID_MOUSE_ABSOLUTE_POINTER_DEV_BAD_SIGNATURE  SIGNATURE_32 ('B', 'A', 'D', 'S')
+
+/**
+ * @brief Really simple test to
+ * confirm device can be initialized in the test framework.
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestInitializeDevFunc (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status;
+
+  Status = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test a valid SingleTouch HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForSingleTouchValid (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  SINGLETOUCH_HID_INPUT_BUFFER    SingleTouchInput;
+  EFI_STATUS                      Status;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+  SingleTouchInput.CurrentX = 12;    // user selected safe values
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is valid.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMaxY);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMinY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, 12);
+  UT_ASSERT_EQUAL (device.State.CurrentY, 15);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 1);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test an invalid SingleTouch HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * X coordinate is larger than max
+ * Expect that report was ignored and state is not changed.
+ *
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForSingleTouchToLarge (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      CachedState;
+  SINGLETOUCH_HID_INPUT_BUFFER    SingleTouchInput;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state so future comparison can be done.
+  CopyMem (&CachedState, &device.State, sizeof (CachedState));
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+
+  /////
+  // TEST X coordinate
+  //////
+  SingleTouchInput.CurrentX = 1025;    // set this larger than MaxX thru inspection.
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMaxY);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMinY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  /////
+  // TEST Y coordinate
+  //////
+  SingleTouchInput.CurrentX = 10;
+  SingleTouchInput.CurrentY = 1025;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMaxY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test an invalid SingleTouch HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * X coordinate is smaller than minX
+ * Expect that report was ignored and state is not changed.
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForSingleTouchToSmall (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      CachedState;
+  SINGLETOUCH_HID_INPUT_BUFFER    SingleTouchInput;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state so future comparison can be done.
+  CopyMem (&CachedState, &device.State, sizeof (CachedState));
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+
+  /////////
+  // Test the X coordinate
+  //
+  device.Mode.AbsoluteMinX  = 1;   // change MinX
+  SingleTouchInput.CurrentX = 0;   // set this smaller than the MinX.  Previously forced MinX to 1 so 0 should be safe.
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMaxY);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMinY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  //////////
+  // Test the Y coordinate
+  ///////////
+  device.Mode.AbsoluteMinY  = 1;   // change MinY
+  SingleTouchInput.CurrentX = 10;
+  SingleTouchInput.CurrentY = 0;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMinY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test an invalid SingleTouch HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * The hid report is the incorrect length
+ * Expect that report was ignored and state is not changed.
+ *
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForIncorrectSingleTouchReportLength (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      CachedState;
+  SINGLETOUCH_HID_INPUT_BUFFER    SingleTouchInput;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state so future comparison can be done.
+  CopyMem (&CachedState, &device.State, sizeof (CachedState));
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+
+  // configure valid report for test
+  SingleTouchInput.CurrentX = 12;
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMaxY);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMinY);
+
+  // Test 1 - Report length too small
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput) -1, &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  // Test 2 - Report length too large
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput) +1, &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test invalid parameter of HidInputReportBuffer to OnMouseReport
+ *
+ * Expect that report was ignored and state is not changed.
+ *
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForInvalidParameterHidInputReportBuffer (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status = EFI_SUCCESS;
+  EFI_ABSOLUTE_POINTER_STATE      CachedState;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state so future comparison can be done.
+  CopyMem (&CachedState, &device.State, sizeof (CachedState));
+
+  OnMouseReport (SingleTouch, NULL, sizeof (SINGLETOUCH_HID_INPUT_BUFFER), &device);
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test an invalid parameter of context to onMouseReport
+ *
+ * Since OnMouseReport is called by external driver, the Context parameter should
+ * be confirmed to be:
+ *   Not NULL
+ *   A valid HID_MOUSE_ABSOLUTE_POINTER_DEV which will be checked by checking "signature" field.
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForInvalidParameterContext (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      CachedState;
+  SINGLETOUCH_HID_INPUT_BUFFER    SingleTouchInput;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_BAD_SIGNATURE;           // Use the bad signature here as it should be checked.
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state so future comparison can be done.
+  CopyMem (&CachedState, &device.State, sizeof (CachedState));
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+
+  SingleTouchInput.CurrentX = 12;
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  // Make sure the hardcoded test data is as expected.
+  // If any of these fail then the test needs to be adjusted
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX < device.Mode.AbsoluteMaxX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentX > device.Mode.AbsoluteMinX);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY < device.Mode.AbsoluteMaxY);
+  UT_ASSERT_TRUE (SingleTouchInput.CurrentY > device.Mode.AbsoluteMinY);
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), NULL);  // Null context
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);  // device has invalid signature
+
+  // See that state didn't change.
+  UT_ASSERT_MEM_EQUAL (&CachedState, &device.State, sizeof (CachedState));
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test the absolute pointer functionality for GetState and Reset
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestAbsolutePointerGetStateFunctionality (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  EFI_STATUS                      Status = EFI_SUCCESS;
+
+  // Initialize the device
+  ZeroMem (&device, sizeof (device));
+
+  device.Signature        = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  device.HidMouseProtocol = NULL;    // hopefully no usage otherwise need mocking
+
+  device.AbsolutePointerProtocol.GetState = GetMouseAbsolutePointerState;
+  device.AbsolutePointerProtocol.Reset    = HidMouseAbsolutePointerReset;
+  device.AbsolutePointerProtocol.Mode     = &device.Mode;
+
+  Status = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // Add a good HID report so the absolute pointer will have new state
+
+  SINGLETOUCH_HID_INPUT_BUFFER  SingleTouchInput;
+
+  ZeroMem (&SingleTouchInput, sizeof (SingleTouchInput));
+  SingleTouchInput.CurrentX = 12;
+  SingleTouchInput.CurrentY = 15;
+  SingleTouchInput.Touch    = 1;
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+
+  // Should be able to get the state and it should be non-zero
+
+  EFI_ABSOLUTE_POINTER_STATE  State;
+
+  ZeroMem (&State, sizeof (State));
+  Status = device.AbsolutePointerProtocol.GetState (&device.AbsolutePointerProtocol, &State);
+
+  /////
+  // Test that GetState worked and has expected data
+  //////
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  UT_ASSERT_EQUAL (State.CurrentX, 12);
+  UT_ASSERT_EQUAL (State.CurrentY, 15);
+  UT_ASSERT_EQUAL (State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (State.ActiveButtons, 1);
+
+  ////////////
+  // (ABSPTR) TEST that if no additional single touch events occur and another get state is called
+  //      it returns not ready and does not copy any state data
+  ///////////
+
+  // Clear state and expect that state will not have old data copied
+  // and EFI_not_ready will be returned
+
+  ZeroMem (&State, sizeof (State));
+  Status = device.AbsolutePointerProtocol.GetState (&device.AbsolutePointerProtocol, &State);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_NOT_READY);
+
+  UT_ASSERT_EQUAL (State.CurrentX, 0);
+  UT_ASSERT_EQUAL (State.CurrentY, 0);
+  UT_ASSERT_EQUAL (State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (State.ActiveButtons, 0);
+
+  ///////
+  // (ABSPTR) TEST that if valid data is set and then a reset is called before reading it the
+  //     data is cleared and no valid data is available for get state
+  ////////
+
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+  Status = device.AbsolutePointerProtocol.Reset (&device.AbsolutePointerProtocol, FALSE);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  Status = device.AbsolutePointerProtocol.GetState (&device.AbsolutePointerProtocol, &State);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_NOT_READY);
+
+  UT_ASSERT_EQUAL (State.CurrentX, 0);
+  UT_ASSERT_EQUAL (State.CurrentY, 0);
+  UT_ASSERT_EQUAL (State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (State.ActiveButtons, 0);
+
+  ///////
+  /// Pass in Null for State and confirm invalid parameter returned
+  ///////
+  OnMouseReport (SingleTouch, (UINT8 *)&SingleTouchInput, sizeof (SingleTouchInput), &device);
+  Status = device.AbsolutePointerProtocol.GetState (&device.AbsolutePointerProtocol, NULL);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_INVALID_PARAMETER);
+
+  return UNIT_TEST_PASSED;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// BOOT MOUSE TESTS
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Test a valid BootMouse HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * Report has No Z value
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForBootMouseValidNoZ (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  MOUSE_HID_INPUT_BUFFER          Input;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      Before;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 13;
+  Input.YDisplacement = 30;
+  Input.Button1       = 1; // button pressed
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input)-1, &device);  // subtract 1 since we want to have report with no Z displacement
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 1);
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = -20;
+  Input.YDisplacement = -52;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input)-1, &device);  // subtract 1 since we want to have report with no Z displacement
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 0);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test a valid BootMouse HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * Report has a valid Z value
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForBootMouseValidWithZ (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  MOUSE_HID_INPUT_BUFFER          Input;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      Before;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // set the mode Z max to 1024 to allow Z
+  // TODO - Look to make this based on HidProtocol Info
+  device.Mode.AbsoluteMaxZ = 1024;
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 13;
+  Input.YDisplacement = 30;
+  Input.ZDisplacement = 4;
+  Input.Button1       = 1; // button pressed
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ + Input.ZDisplacement);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 1);
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = -20;
+  Input.YDisplacement = -52;
+  Input.ZDisplacement = -2;
+  Input.Button2       = 1;
+  Input.Button3       = 1;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ + Input.ZDisplacement);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 6); // bit 1 | bit 2
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test a valid BootMouse HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * Report has a valid Z value plus carries extra device
+ * specific data as allowed by BootMouse report format
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForBootMouseValidWithZAndExtra (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  MOUSE_HID_INPUT_BUFFER          Input;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      Before;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // set the mode Z max to 1024 to allow Z
+  // TODO - Look to make this based on HidProtocol Info
+  device.Mode.AbsoluteMaxZ = 1024;
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 75;
+  Input.YDisplacement = 212;
+  Input.ZDisplacement = 17;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input) + 3, &device); // just add extra bytes to reported length since it should never be looked at
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ + Input.ZDisplacement);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 0);
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = -20;
+  Input.YDisplacement = -52;
+  Input.ZDisplacement = -2;
+  Input.Button3       = 1;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input) + 5, &device);  // just add extra bytes to reported length since it should never be looked at
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX + Input.XDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY + Input.YDisplacement);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ + Input.ZDisplacement);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 4);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test an invalid BootMouse HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * report length is shorter than allowed. State should not change.
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForBootMouseInvalidLength (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  MOUSE_HID_INPUT_BUFFER          Input;
+  EFI_STATUS                      Status;
+  EFI_ABSOLUTE_POINTER_STATE      Before;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // copy the state since boot mouse is displacement based the
+  // state is always changing based on current.
+  CopyMem (&Before, &device.State, sizeof (Before));
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 13;
+  Input.YDisplacement = 30;
+  Input.ZDisplacement = 4;
+  Input.Button1       = 1; // button pressed
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, 2, &device);  // length 2 is invalid.
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, Before.ActiveButtons);
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, 1, &device);  // length 1 is invalid.
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, Before.ActiveButtons);
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, 0, &device);    // length 0 is invalid.
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, Before.CurrentX);
+  UT_ASSERT_EQUAL (device.State.CurrentY, Before.CurrentY);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, Before.CurrentZ);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, Before.ActiveButtons);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+ * @brief Test a valid BootMouse HID report and its
+ * translation into the absolute pointer state to be correct.
+ *
+ * Reports with displacements that would exceed the bounds.
+ * Make sure state stays within the bounds
+ *
+ * @param Context
+ * @return UNIT_TEST_STATUS
+ */
+UNIT_TEST_STATUS
+EFIAPI
+TestOnMouseReportFuncForBootMouseValidBoundsCheck (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  HID_MOUSE_ABSOLUTE_POINTER_DEV  device;
+  MOUSE_HID_INPUT_BUFFER          Input;
+  EFI_STATUS                      Status;
+
+  ZeroMem (&device, sizeof (device));
+  device.Signature = HID_MOUSE_ABSOLUTE_POINTER_DEV_SIGNATURE;
+  Status           = InitializeMouseDevice (&device);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  // set the mode Z max to 1024 to allow Z
+  // TODO - Look to make this based on HidProtocol Info
+  device.Mode.AbsoluteMaxZ = 1024;
+
+  // Assume all modes have 0 to 1024 range.
+
+  // Set Current to within 127 of edge
+  device.State.CurrentX = 1024-127;
+  device.State.CurrentY = 1020;  // allow to go past
+  device.State.CurrentZ = 1000;
+
+  // Test 1 - Go to max X using max displacement; Go beyond max Y; Go to max Z
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 127;
+  Input.YDisplacement = 120;
+  Input.ZDisplacement = 24;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, 1024);
+  UT_ASSERT_EQUAL (device.State.CurrentY, 1024);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 1024);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 0);
+
+  // Test 2 - now that at max make sure more positive displacement doesn't cause increase
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = 20;
+  Input.YDisplacement = 1;
+  Input.ZDisplacement = 127;
+  Input.Button2       = 1;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, 1024);
+  UT_ASSERT_EQUAL (device.State.CurrentY, 1024);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 1024);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 2); // bit 1
+
+  // Test 3 - try to go to or below zero
+  device.State.CurrentX = 2;
+  device.State.CurrentY = 5;
+  device.State.CurrentZ = 127;
+
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = -127;
+  Input.YDisplacement = -6;
+  Input.ZDisplacement = -127;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, 0);
+  UT_ASSERT_EQUAL (device.State.CurrentY, 0);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 0);
+
+  // Test 4 - now that at min try more negative displacement
+  ZeroMem (&Input, sizeof (Input));
+  Input.XDisplacement = -5;
+  Input.YDisplacement = -127;
+  Input.ZDisplacement = -1;
+
+  OnMouseReport (BootMouse, (UINT8 *)&Input, sizeof (Input), &device);
+
+  // Get result of single touch event and compare
+  UT_ASSERT_EQUAL (device.State.CurrentX, 0);
+  UT_ASSERT_EQUAL (device.State.CurrentY, 0);
+  UT_ASSERT_EQUAL (device.State.CurrentZ, 0);
+  UT_ASSERT_EQUAL (device.State.ActiveButtons, 0);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize the unit test framework, suite, and unit tests for the
+  unit tests and run the unit tests.
+
+  @retval  EFI_SUCCESS           All test cases were dispatched.
+  @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                 initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      HidMouseMiscSuiteHandle; // basic functional tests
+  UNIT_TEST_SUITE_HANDLE      AbsPtrSuiteHandle;       // tests related to absolute pointer interface
+  UNIT_TEST_SUITE_HANDLE      SimpleTouchSuiteHandle;  // tests using SimpleTouch hid report
+  UNIT_TEST_SUITE_HANDLE      BootMouseSuiteHandle;    // tests using BootMouse hid report
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Create a suite
+  //
+  Status = CreateUnitTestSuite (&HidMouseMiscSuiteHandle, Framework, "HidMouseAbsolutePointerDxe basic tests", "HidMouseAbsolutePointerDxe.Misc", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for HidMouseMiscSuiteHandle\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // Register Tests
+  //
+  AddTestCase (HidMouseMiscSuiteHandle, "Initialize the Mouse Dev", "InitMouseDev", TestInitializeDevFunc, NULL, NULL, NULL);
+  AddTestCase (HidMouseMiscSuiteHandle, "OnMouseReport Func Invalid Parameter Context", "OnMouseReport.InvalidParameter.Context", TestOnMouseReportFuncForInvalidParameterContext, NULL, NULL, NULL);
+  AddTestCase (HidMouseMiscSuiteHandle, "OnMouseReport Func Invalid Parameter HidInputReportBuffer", "OnMouseReport.InvalidParameter.HidInputReportBuffer", TestOnMouseReportFuncForInvalidParameterHidInputReportBuffer, NULL, NULL, NULL);
+
+  //
+  // Create a suite
+  //
+  Status = CreateUnitTestSuite (&AbsPtrSuiteHandle, Framework, "HidMouseAbsolutePointerDxe absolute pointer protocol tests", "HidMouseAbsolutePointerDxe.AbsPtrProtocol", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for AbsPtrSuiteHandle\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // Register Tests
+  //
+  AddTestCase (AbsPtrSuiteHandle, "Test Absolute Pointer GetState function", "HidMouse.AbsolutePointer.GetState", TestAbsolutePointerGetStateFunctionality, NULL, NULL, NULL);
+
+  //
+  // Create a suite
+  //
+  Status = CreateUnitTestSuite (&SimpleTouchSuiteHandle, Framework, "HidMouseAbsolutePointerDxe SimpleTouch HID Report", "HidMouseAbsolutePointerDxe.HID.SimpleTouch", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SimpleTouchSuiteHandle\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // Register Tests
+  //
+  AddTestCase (SimpleTouchSuiteHandle, "Process a valid SingleTouch HID Report", "ValidReport", TestOnMouseReportFuncForSingleTouchValid, NULL, NULL, NULL);
+  AddTestCase (SimpleTouchSuiteHandle, "Process a SingleTouch HID Report with coordinates larger than max", "CoordinateLargerThanMax", TestOnMouseReportFuncForSingleTouchToLarge, NULL, NULL, NULL);
+  AddTestCase (SimpleTouchSuiteHandle, "Process a SingleTouch HID Report with coordinates smaller than min", "CoordinateSmallerThanMin", TestOnMouseReportFuncForSingleTouchToSmall, NULL, NULL, NULL);
+  AddTestCase (SimpleTouchSuiteHandle, "Process a SingleTouch HID Report incorrect length", "HidInputReportBufferSizeIncorrect", TestOnMouseReportFuncForIncorrectSingleTouchReportLength, NULL, NULL, NULL);
+
+  //
+  // Create a suite
+  //
+  Status = CreateUnitTestSuite (&BootMouseSuiteHandle, Framework, "HidMouseAbsolutePointerDxe Boot Mouse HID Report", "HidMouseAbsolutePointerDxe.HID.BootMouse", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for BootMouseSuiteHandle\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // Register Tests
+  //
+  AddTestCase (BootMouseSuiteHandle, "Process a valid BootMouse HID Report with no z field", "ValidReport.NoZ", TestOnMouseReportFuncForBootMouseValidNoZ, NULL, NULL, NULL);
+  AddTestCase (BootMouseSuiteHandle, "Process a valid BootMouse HID Report with z field", "ValidReport.WithZ", TestOnMouseReportFuncForBootMouseValidWithZ, NULL, NULL, NULL);
+  AddTestCase (BootMouseSuiteHandle, "Process a valid BootMouse HID Report with additional report data", "ValidReport.WithAdditionalData", TestOnMouseReportFuncForBootMouseValidWithZAndExtra, NULL, NULL, NULL);
+  AddTestCase (BootMouseSuiteHandle, "Process a BootMouse HID Report with incorrect length", "HidInputReportBufferSizeIncorrect", TestOnMouseReportFuncForBootMouseInvalidLength, NULL, NULL, NULL);
+  AddTestCase (BootMouseSuiteHandle, "Process a set of BootMouse HID Reports that try to exceed min and max", "MinMaxCoordinate", TestOnMouseReportFuncForBootMouseValidBoundsCheck, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/HidPkg/HidMouseAbsolutePointerDxe/UnitTest/HidMouseAbsolutePointerHostTest.inf
+++ b/HidPkg/HidMouseAbsolutePointerDxe/UnitTest/HidMouseAbsolutePointerHostTest.inf
@@ -1,0 +1,47 @@
+## @file
+# This module tests the HID Report to Absolute Pointer
+# logic of HidMouseAbsolutePointerDxe
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = HidMouseAbsolutePointerHostTest
+  FILE_GUID                      = 5b6e23e9-1d27-4cae-a224-0332ad498527
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  HidMouse.c
+  ../HidMouseAbsolutePointer.c  # contains code to unit test
+  ../HidMouseAbsolutePointer.h
+  ../ComponentName.c  # Only to resolve a few m Variables
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  HidPkg/HidPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  BaseLib
+  UnitTestLib
+  UefiLib
+  UefiBootServicesTableLib
+
+[Protocols]
+  gEfiAbsolutePointerProtocolGuid
+  gHidPointerProtocolGuid
+  
+
+[Pcd]
+
+
+[Guids]
+

--- a/HidPkg/HidPkg.ci.yaml
+++ b/HidPkg/HidPkg.ci.yaml
@@ -22,6 +22,9 @@
             "MdeModulePkg/MdeModulePkg.dec",
             "HidPkg/HidPkg.dec"
         ],
+        "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         "IgnoreInf": []
     },
 
@@ -29,6 +32,16 @@
     "DscCompleteCheck": {
         "IgnoreInf": [],
         "DscPath": "HidPkg.dsc"
+    },
+    ## options defined .pytool/Plugin/HostUnitTestCompilerPlugin
+    "HostUnitTestCompilerPlugin": {
+        "DscPath": "UnitTests/HidPkgHostTest.dsc"
+    },
+
+    ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
+    "HostUnitTestDscCompleteCheck": {
+        "IgnoreInf": [],
+        "DscPath": "UnitTests/HidPkgHostTest.dsc"
     },
 
     ## options defined ci/Plugin/GuidCheck

--- a/HidPkg/UnitTests/HidPkgHostTest.dsc
+++ b/HidPkg/UnitTests/HidPkgHostTest.dsc
@@ -1,0 +1,41 @@
+## @file
+# Host Unit Test DSC for the HID Package
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+################################################################################
+[Defines]
+  PLATFORM_NAME                  = HidPkg
+  PLATFORM_GUID                  = ed24dec6-ab1b-4788-8014-f81f7087e019
+  PLATFORM_VERSION               = 0.1
+  DSC_SPECIFICATION              = 0x00010005
+  OUTPUT_DIRECTORY               = Build/HidPkg
+  SUPPORTED_ARCHITECTURES        = IA32|X64
+  SKUID_IDENTIFIER               = DEFAULT
+  BUILD_TARGETS                  = NOOPT
+
+  
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc 
+
+################################################################################
+#
+# Components section - list of all Components needed by this Platform.
+#
+################################################################################
+[Components]
+  HidPkg/HidMouseAbsolutePointerDxe/UnitTest/HidMouseAbsolutePointerHostTest.inf {
+    <LibraryClasses>
+      UefiLib|MdePkg/Test/Library/StubUefiLib/StubUefiLib.inf
+      UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+    <PcdsFixedAtBuild>
+      #Turn off Halt on Assert and Print Assert so that libraries can
+      #be tested in more of a release mode environment
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
+  }
+
+
+
+[BuildOptions]
+  *_*_*_CC_FLAGS            = -D DISABLE_NEW_DEPRECATED_INTERFACES


### PR DESCRIPTION
Add Host-based unit tests for the HidMouseAbsolutePointerDxe to make sure HID report format parsing is correct and robust.