### PR TITLE
CodeQL Fixes - Second Pass

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
@@ -244,7 +244,7 @@ AdvancedLoggerAccessLibGetNextFormattedLine (
       LastChar = '\0';
       while ((LineEntry->ResidualLen > 0) &&
              (LastChar != '\n') &&
-             (TargetLen < (mMaxMessageSize - 2)))
+             (TargetLen < (UINT16)(mMaxMessageSize - 2)))
       {
         LastChar     = *LineEntry->ResidualChar++;
         *TargetPtr++ = LastChar;

--- a/HidPkg/HidKeyboardDxe/HidKeyboard.c
+++ b/HidPkg/HidKeyboardDxe/HidKeyboard.c
@@ -651,7 +651,9 @@ SetKeyboardLayoutEvent (
   //
   TableEntry    = GetKeyDescriptor (HidKeyboardDevice, 0x58);
   KeyDescriptor = GetKeyDescriptor (HidKeyboardDevice, 0x28);
-  CopyMem (TableEntry, KeyDescriptor, sizeof (EFI_KEY_DESCRIPTOR));
+  if ((TableEntry != NULL) && (KeyDescriptor != NULL)) {
+    CopyMem (TableEntry, KeyDescriptor, sizeof (EFI_KEY_DESCRIPTOR));
+  }
 
   FreePool (KeyboardLayout);
 }

--- a/HidPkg/HidKeyboardDxe/HidKeyboard.c
+++ b/HidPkg/HidKeyboardDxe/HidKeyboard.c
@@ -985,7 +985,7 @@ ProcessKeyStroke (
   // Bytes 3 to n are for normal keycodes
   //
   KeyRelease = FALSE;
-  for (LastKeyCode = 0; LastKeyCode < LastReportKeyCount; LastKeyCode++) {
+  for (LastKeyCode = 0; (UINTN)LastKeyCode < LastReportKeyCount; LastKeyCode++) {
     if (!HIDKBD_VALID_KEYCODE (LastReport->KeyCode[LastKeyCode])) {
       continue;
     }
@@ -995,7 +995,7 @@ ProcessKeyStroke (
     // then it is released. Otherwise, it is not released.
     //
     KeyRelease = TRUE;
-    for (KeyCode = 0; KeyCode < CurrentReportKeyCount; KeyCode++) {
+    for (KeyCode = 0; (UINTN)KeyCode < CurrentReportKeyCount; KeyCode++) {
       if (!HIDKBD_VALID_KEYCODE (CurrentReport->KeyCode[KeyCode])) {
         continue;
       }
@@ -1035,7 +1035,7 @@ ProcessKeyStroke (
   // Handle normal key's pressing situation
   //
   KeyPress = FALSE;
-  for (KeyCode = 0; KeyCode < CurrentReportKeyCount; KeyCode++) {
+  for (KeyCode = 0; (UINTN)KeyCode < CurrentReportKeyCount; KeyCode++) {
     if (!HIDKBD_VALID_KEYCODE (CurrentReport->KeyCode[KeyCode])) {
       continue;
     }
@@ -1045,7 +1045,7 @@ ProcessKeyStroke (
     // then it is pressed. Otherwise, it is not pressed.
     //
     KeyPress = TRUE;
-    for (LastKeyCode = 0; LastKeyCode < LastReportKeyCount; LastKeyCode++) {
+    for (LastKeyCode = 0; (UINTN)LastKeyCode < LastReportKeyCount; LastKeyCode++) {
       if (!HIDKBD_VALID_KEYCODE (LastReport->KeyCode[LastKeyCode])) {
         continue;
       }

--- a/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
+++ b/HidPkg/HidMouseAbsolutePointerDxe/HidMouseAbsolutePointer.c
@@ -139,6 +139,8 @@ HidMouseAbsolutePointerDriverBindingStart (
   HID_POINTER_PROTOCOL            *HidMouseProtocol;
   HID_MOUSE_ABSOLUTE_POINTER_DEV  *HidMouseDev;
 
+  HidMouseDev = NULL;
+
   DEBUG ((DEBUG_VERBOSE, "[%a]\n", __FUNCTION__));
 
   // Get our HID mouse abstraction

--- a/MsCorePkg/Core/GuidedSectionExtractPeim/GuidedSectionExtract.c
+++ b/MsCorePkg/Core/GuidedSectionExtractPeim/GuidedSectionExtract.c
@@ -74,13 +74,16 @@ PeimInitializeGuidedSectionExtract (
   //
   if ((ExtractHandlerNumber > 0) && (ExtractHandlerGuidTable != NULL)) {
     GuidPpi = (EFI_PEI_PPI_DESCRIPTOR *)AllocatePool (ExtractHandlerNumber * sizeof (EFI_PEI_PPI_DESCRIPTOR));
-    ASSERT (GuidPpi != NULL);
-    while (ExtractHandlerNumber-- > 0) {
-      GuidPpi->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
-      GuidPpi->Ppi   = (VOID *)&mCustomGuidedSectionExtractionPpi;
-      GuidPpi->Guid  = &ExtractHandlerGuidTable[ExtractHandlerNumber];
-      Status         = PeiServicesInstallPpi (GuidPpi++);
-      ASSERT_EFI_ERROR (Status);
+    if (GuidPpi == NULL) {
+      ASSERT (GuidPpi != NULL);
+    } else {
+      while (ExtractHandlerNumber-- > 0) {
+        GuidPpi->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
+        GuidPpi->Ppi   = (VOID *)&mCustomGuidedSectionExtractionPpi;
+        GuidPpi->Guid  = &ExtractHandlerGuidTable[ExtractHandlerNumber];
+        Status         = PeiServicesInstallPpi (GuidPpi++);
+        ASSERT_EFI_ERROR (Status);
+      }
     }
   }
 

--- a/MsGraphicsPkg/Library/BaseUiRectangleLib/UiRectangle.c
+++ b/MsGraphicsPkg/Library/BaseUiRectangleLib/UiRectangle.c
@@ -281,7 +281,7 @@ PRIVATE_Init (
       SetMem32 (priv->FillData, priv->FillDataSize, priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.Color1);  // set row to Color1
 
       // setup alternate color.  Color band is width stripe_width.
-      for (int i = priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth; i < FillDataSizeInPixels; i += (priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth * 2)) {
+      for (int i = priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth; (INTN)i < FillDataSizeInPixels; i += (priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth * 2)) {
         INTN  Len = FillDataSizeInPixels - i;
         if (Len > priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth) {
           Len = (INTN)priv->Public.StyleInfo.FillTypeInfo.CheckerboardFill.CheckboardWidth;
@@ -298,7 +298,7 @@ PRIVATE_Init (
 
       // setup dot row. as row two of the filldata
       for (int i = priv->Public.StyleInfo.FillTypeInfo.PolkaSquareFill.DistanceBetweenSquares / 2;
-           i < (FillDataSizeInPixels / 2);
+           (INTN)i < (FillDataSizeInPixels / 2);
            i += (priv->Public.StyleInfo.FillTypeInfo.PolkaSquareFill.SquareWidth + priv->Public.StyleInfo.FillTypeInfo.PolkaSquareFill.DistanceBetweenSquares)
            )
       {

--- a/MsGraphicsPkg/Library/SimpleUIToolKit/Utilities.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/Utilities.c
@@ -129,7 +129,7 @@ GetTextStringBitmapSize (
 
   // Calculate the bounding rectangle around the text as rendered (note this it may be in multiple rows).
   //
-  for (RowIndex = 0, Width = 0, Height = 0; RowIndex < RowInfoSize; RowIndex++) {
+  for (RowIndex = 0, Width = 0, Height = 0; (UINTN)RowIndex < RowInfoSize; RowIndex++) {
     Width   = (UINT16)(Width < (UINT32)StringRowInfo[RowIndex].LineWidth ? (UINT32)StringRowInfo[RowIndex].LineWidth : Width);
     Height += (UINT16)StringRowInfo[RowIndex].LineHeight;
   }

--- a/MsWheaPkg/MsWheaReport/MsWheaEarlyStorageMgr.c
+++ b/MsWheaPkg/MsWheaReport/MsWheaEarlyStorageMgr.c
@@ -667,7 +667,7 @@ MsWheaESProcess (
 
   // Go through normal entries
   while ((Header.ActiveRange >= sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON)) &&
-         (Index <= (Header.ActiveRange - sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON))))
+         (Index <= (UINT32)(Header.ActiveRange - sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON))))
   {
     Status = MsWheaESReadData (
                (VOID *)&mRevInfo,

--- a/MsWheaPkg/MsWheaReport/MsWheaReportHER.c
+++ b/MsWheaPkg/MsWheaReport/MsWheaReportHER.c
@@ -275,6 +275,9 @@ MsWheaAnFBuffer (
   UINT8                             *ExtraSectionData;
   MS_WHEA_ERROR_EXTRA_SECTION_DATA  *ExtraSectionPtr;
 
+  CperErrSecDscp   = NULL;
+  ExtraSectionData = NULL;
+
   DEBUG ((DEBUG_INFO, "%a: enter...\n", __FUNCTION__));
 
   if ((MsWheaEntryMD == NULL) || (PayloadSize == NULL)) {
@@ -326,7 +329,7 @@ MsWheaAnFBuffer (
 
   // Add all section data.
   CreateMuTelemetryData (MsWheaEntryMD, MuTelemetryData);
-  if (ExtraSectionPtr != NULL) {
+  if ((ExtraSectionData != NULL) && (ExtraSectionPtr != NULL)) {
     CopyMem (
       ExtraSectionData,
       &ExtraSectionPtr->Data,

--- a/MsWheaPkg/MsWheaReport/MsWheaReportHER.c
+++ b/MsWheaPkg/MsWheaReport/MsWheaReportHER.c
@@ -275,8 +275,9 @@ MsWheaAnFBuffer (
   UINT8                             *ExtraSectionData;
   MS_WHEA_ERROR_EXTRA_SECTION_DATA  *ExtraSectionPtr;
 
-  CperErrSecDscp   = NULL;
-  ExtraSectionData = NULL;
+  CperErrSecDscp      = NULL;
+  CperErrExtraSecDscp = NULL;
+  ExtraSectionData    = NULL;
 
   DEBUG ((DEBUG_INFO, "%a: enter...\n", __FUNCTION__));
 


### PR DESCRIPTION
## Description

Makes changes to comply with alerts raised by CodeQL.

A prior pass with a subset of queries used here was already done so this is mostly addressing
issues discovered by enabling a few new queries.

Most of the issues here fall into the following two categories:

1. Potential use of uninitialized pointer
2. Inconsistent integer width used in loop comparison

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Should just be refactoring to address alerts

## How This Was Tested

1. Verified CI build
2. Verified boot to EFI shell on QemuQ35Pkg

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>