### PR TITLE
AdvLoggerPkg/AdvLoggerMmAccessLib: Fix cast conversion compiler error

### DIFF
--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
@@ -97,7 +97,7 @@ AdvLoggerAccessInit (
   // Locate the Logger Information block.
   //
   if (FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    mLoggerInfo = (ADVANCED_LOGGER_INFO *)(VOID *)FixedPcdGet64 (PcdAdvancedLoggerBase);
+    mLoggerInfo = (ADVANCED_LOGGER_INFO *)(VOID *)(UINTN)FixedPcdGet64 (PcdAdvancedLoggerBase);
   } else {
     GuidHob = GetFirstGuidHob (&gAdvancedLoggerHobGuid);
     if (GuidHob == NULL) {


### PR DESCRIPTION
## Description

Commit fd357a1 introduced a conversion cast that produces the following
VS(2019) build error:

```
AdvLoggerPkg\Library\AdvLoggerMmAccessLib\AdvLoggerMmAccessLib.c(100):
  'type cast': conversion from 'unsigned int' to 'void *' of greater size
```

This change casts the integer to UINTN before casting to a pointer.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified change resolves build error.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>