### PR TITLE
Update reset notification list to be notified before NVMe

### DIFF
--- a/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
@@ -126,7 +126,7 @@ OnResetNotificationProtocolInstalled (
   // Get a pointer to the report status code protocol.
   //
   Status = gBS->LocateProtocol (
-                  &gEfiResetNotificationProtocolGuid,
+                  &gEdkiiPlatformSpecificResetFilterProtocolGuid,
                   NULL,
                   (VOID **)&ResetNotificationProtocol
                   );
@@ -408,7 +408,7 @@ ProcessResetEventRegistration (
   // handler and we'll register when the protocol is installed.
   //
   Status = gBS->LocateProtocol (
-                  &gEfiResetNotificationProtocolGuid,
+                  &gEdkiiPlatformSpecificResetFilterProtocolGuid,
                   NULL,
                   (VOID **)&ResetNotificationProtocol
                   );
@@ -436,7 +436,7 @@ ProcessResetEventRegistration (
       DEBUG ((DEBUG_ERROR, "%a: failed to create Reset Protocol protocol callback event (%r)\n", __FUNCTION__, Status));
     } else {
       Status = gBS->RegisterProtocolNotify (
-                      &gEfiResetNotificationProtocolGuid,
+                      &gEdkiiPlatformSpecificResetFilterProtocolGuid,
                       ResetNotificationEvent,
                       &ResetNotificationRegistration
                       );

--- a/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
+++ b/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
@@ -53,7 +53,7 @@
   gMuEventPreExitBootServicesGuid
 
 [Protocols]
-  gEfiResetNotificationProtocolGuid                             ## CONSUMES
+  gEdkiiPlatformSpecificResetFilterProtocolGuid                 ## CONSUMES
   gEfiSimpleFileSystemProtocolGuid                              ## CONSUMES
 
 [Pcd]


### PR DESCRIPTION
## Description

Reset notification was handled by the NVMe driver before the AdvLogger could write the log to disk.

- [No] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?

## How This Was Tested

Tested on multiple systems.

## Integration Instructions

N/A
