### PR TITLE
Update the finding max mode logic to account for vertical resolution as well

### DIFF
--- a/PcBdsPkg/Library/GraphicsConsoleHelperLib/GraphicsConsoleHelper.c
+++ b/PcBdsPkg/Library/GraphicsConsoleHelperLib/GraphicsConsoleHelper.c
@@ -50,6 +50,7 @@ InitializeModeTable (
   EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *Info  = NULL;
   UINT32                                Indx;
   UINT32                                MaxHRes = 800;
+  UINT32                                MaxVRes = 600;
   UINTN                                 Size    = 0;
 
   if (Gop == NULL) {
@@ -71,10 +72,12 @@ InitializeModeTable (
       for (Indx = 0; Indx < Gop->Mode->MaxMode; Indx++) {
         Status = Gop->QueryMode (Gop, Indx, &Size, &Info);
         if (!EFI_ERROR (Status)) {
-          if (MaxHRes < Info->HorizontalResolution) {
+          if (MaxHRes <= Info->HorizontalResolution &&
+              MaxVRes <= Info->VerticalResolution) {
             mNativeHorizontalResolution = Info->HorizontalResolution;
             mNativeVerticalResolution   = Info->VerticalResolution;
             MaxHRes                     = Info->HorizontalResolution;
+            MaxVRes                     = Info->VerticalResolution;
           }
 
           DEBUG ((DEBUG_INFO, "Mode Info for Mode %d\n", Indx));


### PR DESCRIPTION
## Description

The exiting logic would only look for the maximal horizontal resolution. The issue is that if the supported modes have other modes that supports more vertical pixels, this logic will truncate the display to a shorter screen with the same number of horizontal pixels.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?

## How This Was Tested

This change is verified on QEMU virtual platforms.

## Integration Instructions

N/A