### PR TITLE
Ignore .venv (default .venv folder name)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 tags/
 .vscode/
 *.bak
+.venv
 BuildConfig.conf
 
 # Repo-specific


### PR DESCRIPTION
## Description

Default .venv folder name is .venv. Should be ignored in gitignore.

- [ ] Breaking change? -> No

## How This Was Tested

n/a

## Integration Instructions

n/a
