### PR TITLE
Update Mfci documentation with additional instructions. 

### DIFF
--- a/MfciPkg/Docs/Mfci_Integration_Guide.md
+++ b/MfciPkg/Docs/Mfci_Integration_Guide.md
@@ -88,7 +88,7 @@ string into the PCD.
 ```
 
 When using `!include MfciPkg/MfciPkg.dsc.inc`, please ensure the platform pcds for
- `PcdMfciPkcs7RequiredLeafEKU` and `PcdMfciPkcs7RequiredLeafEKU` are included after the `MfciPkg.dsc.inc`.git
+ `PcdMfciPkcs7RequiredLeafEKU` and `PcdMfciPkcs7RequiredLeafEKU` are included after the `MfciPkg.dsc.inc`
 
 ### MfciPkg Dependencies
 

--- a/MfciPkg/Docs/Mfci_Integration_Guide.md
+++ b/MfciPkg/Docs/Mfci_Integration_Guide.md
@@ -87,6 +87,9 @@ string into the PCD.
 
 ```
 
+When using `!include MfciPkg/MfciPkg.dsc.inc`, please ensure the platform pcds for
+ `PcdMfciPkcs7RequiredLeafEKU` and `PcdMfciPkcs7RequiredLeafEKU` are included after the `MfciPkg.dsc.inc`.
+
 ### MfciPkg Dependencies
 
 * Variable Policy

--- a/MfciPkg/Docs/Mfci_Integration_Guide.md
+++ b/MfciPkg/Docs/Mfci_Integration_Guide.md
@@ -66,7 +66,7 @@ To help convert the Mfci Pkcs certificate into a PCD, the BinToPcd.py in MU_BASE
 BinToPcd.py will ensure that the public key is properly formatted into RFC 4506 External Data
 Representation Standard.
 
-```
+```INI
 MU_BASECORE/BaseTools/Scripts/BinToPcd.py -i <PublicKey.cer> -o <Output.inc> -p gMfciPkgTokenSpaceGuid.PcdMfciPkcs7CertBufferXdr -x
 ```
 
@@ -88,7 +88,7 @@ string into the PCD.
 ```
 
 When using `!include MfciPkg/MfciPkg.dsc.inc`, please ensure the platform pcds for
- `PcdMfciPkcs7RequiredLeafEKU` and `PcdMfciPkcs7RequiredLeafEKU` are included after the `MfciPkg.dsc.inc`.
+ `PcdMfciPkcs7RequiredLeafEKU` and `PcdMfciPkcs7RequiredLeafEKU` are included after the `MfciPkg.dsc.inc`.git
 
 ### MfciPkg Dependencies
 

--- a/MfciPkg/Docs/Mfci_Integration_Guide.md
+++ b/MfciPkg/Docs/Mfci_Integration_Guide.md
@@ -62,9 +62,18 @@ must be overridden. Two other instances are available in the MfciPkg, or a custo
 The public portion of the Public/Private key needs to be included into for the MfciPkg to be able to verify
 policy blobs. This is done through the PCDs PcdMfciPkcs7CertBufferXdr.
 
-To help convert the Mfci Pkcs certificate into a PCD, the BinToPcd.py in MU_BASECORE can be used.
+To help convert the Mfci Pkcs certificate into a PCD, the BinToPcd.py in MU_BASECORE can be used. Using
+BinToPcd.py will ensure that the public key is properly formatted into RFC 4506 External Data
+Representation Standard.
+
+```
+MU_BASECORE/BaseTools/Scripts/BinToPcd.py -i <PublicKey.cer> -o <Output.inc> -p gMfciPkgTokenSpaceGuid.PcdMfciPkcs7CertBufferXdr -x
+```
 
 Additionally, PcdMfciPkcs7RequiredLeafEKU needs to be filled out with the Extended Key Usage information.
+The leaf EKU is used as an additional check during policy blob validation. Failure to include the correct
+EKU leaf will result in the policy blob being rejected.
+
 The below examples are from the Unit Test portion of this package. The Unit Test implementation can be
 followed to see how to convert a certificate into a binary pcd, and how to add the Extended Key Usage
 string into the PCD.

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -66,7 +66,7 @@ and can be used to sign the policy blob.
 After the policy blob is created, sign tool can be called, as in the below example. The signed policy blob
 has a .p7 extension, and this is the file that should be place into the MfciNext variable.
 
-```
+```INI
     c:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17763.0\\x64\\signtool.exe
     sign 
     /fd SHA256 
@@ -81,7 +81,9 @@ has a .p7 extension, and this is the file that should be place into the MfciNext
 
 ## Signed Packet Example
 
-Output of running [certutil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil) on a signed MFCI Policy packet (signed) is as follows:
+Output of running
+[certutil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
+ on a signed MFCI Policy packet (signed) is as follows:
 
 ```ASN
 Prompt >> certutil.exe -asn

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -55,8 +55,8 @@ used to generate test signing keys are included in this repo for reference. Plea
 needs to include OID `1.3.6.1.5.5.7.3.3` as well as the user designed leaf EKU that is used as an
 additional test.  This second EKU must be set in pcd `PcdMfciPkcs7RequiredLeafEKU`.
 
-*[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
-*[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
+* [Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
+* [Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
 
 ### Example signing
 

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -55,8 +55,8 @@ used to generate test signing keys are included in this repo for reference. Plea
 needs to include OID `1.3.6.1.5.5.7.3.3` as well as the user designed leaf EKU that is used as an
 additional test.  This second EKU must be set in pcd `PcdMfciPkcs7RequiredLeafEKU`.
 
-(../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
-(../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
+[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
+[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
 
 ### Example signing
 
@@ -71,7 +71,7 @@ has a .p7 extension, and this is the file that should be place into the MfciNext
     sign 
     /fd SHA256 
     /p7 .
-    /p7co 1.2.840.113549.1.7.1 
+    /p7co 1.2.840.113549.1.7.1
     /p7ce Embedded
     /f <pfx file of leaf key>.pfx
     /v /debug 
@@ -81,7 +81,7 @@ has a .p7 extension, and this is the file that should be place into the MfciNext
 
 ## Signed Packet Example
 
-`certutil.exe -asn`  output for an example MFCI Policy packet (signed) is as follows:
+Output of running `[certutil.exe -asn]`(<https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>) on a signed MFCI Policy packet
 
 ```ASN
 0000: 30 82 0e 6c                               ; SEQUENCE (e6c Bytes)

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -81,9 +81,11 @@ has a .p7 extension, and this is the file that should be place into the MfciNext
 
 ## Signed Packet Example
 
-Output of running `[certutil.exe -asn]`(<https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>) on a signed MFCI Policy packet
+Output of running [certutil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil) on a signed MFCI Policy packet (signed) is as follows:
 
 ```ASN
+Prompt >> certutil.exe -asn
+
 0000: 30 82 0e 6c                               ; SEQUENCE (e6c Bytes)
 0004:    06 09                                  ; OBJECT_ID (9 Bytes)
 0006:    |  2a 86 48 86 f7 0d 01 07  02

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -85,9 +85,11 @@ Output of running
 [certutil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
  on a signed MFCI Policy packet (signed) is as follows:
 
-```ASN
-Prompt >> certutil.exe -asn
+```BASH
+certutil.exe -asn
+```
 
+```ASN
 0000: 30 82 0e 6c                               ; SEQUENCE (e6c Bytes)
 0004:    06 09                                  ; OBJECT_ID (9 Bytes)
 0006:    |  2a 86 48 86 f7 0d 01 07  02

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -45,8 +45,39 @@ remaining fields are unescaped, WIDE NULL-terminated UTF-16LE strings.
 
 The PKCS7 digital signature format familiar to the UEFI ecosystem is used with 2 key differences.
 First, a full PKCS7 is used, not the SignedData subset used by authenticated variables.  Second,
-the P7 is embedded, not detatched.  The policy targeting and flavor information are embedded in a
+the P7 is embedded, not detached.  The policy targeting and flavor information are embedded in a
 PKCS 7 Data inside the full PKCS 7 Signed object.
+
+### Signing Key
+
+To digitally sign a policy blob, a public/private key combination is required.  The scripts
+used to generate test signing keys are included in this repo for reference. Please note that the EKU
+needs to include OID `1.3.6.1.5.5.7.3.3` as well as the user designed leaf EKU that is used as an
+additional test.  This second EKU must be set in pcd `PcdMfciPkcs7RequiredLeafEKU`.
+
+(../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
+(../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
+
+### Example signing
+
+[Signtool](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool) is available in Windows Kits
+and can be used to sign the policy blob.
+
+After the policy blob is created, sign tool can be called, as in the below example. The signed policy blob
+has a .p7 extension, and this is the file that should be place into the MfciNext variable.
+
+```
+    c:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17763.0\\x64\\signtool.exe
+    sign 
+    /fd SHA256 
+    /p7 .
+    /p7co 1.2.840.113549.1.7.1 
+    /p7ce Embedded
+    /f <pfx file of leaf key>.pfx
+    /v /debug 
+    /p <password used to secure the leaf key pfx file>
+    <input policy>.bin
+```
 
 ## Signed Packet Example
 

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -30,7 +30,7 @@ At runtime, a UEFI implementor may consider the policy blobs to be opaque, as Mf
 the task of authenticating, verifying targeting, and parsing the blobs down to the 64-bit policies.
 
 For the purpose of testing, a python library and commandline wrappers are provided to facilitate
-creation of signed MFCI policies.
+creation of unsigned MFCI policies. After the policies are created, they will still need to be signed.
 
 * <https://github.com/tianocore/edk2-pytool-library/blob/master/docs/features/windows_firmware_policy.md>
 * <https://github.com/tianocore/edk2-pytool-extensions/blob/master/docs/usability/using_firmware_policy_tool.md>

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -83,11 +83,7 @@ has a .p7 extension, and this is the file that should be place into the MfciNext
 
 Output of running
 [certutil.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
- on a signed MFCI Policy packet (signed) is as follows:
-
-```BASH
-certutil.exe -asn
-```
+ on a signed MFCI Policy packet (signed). `certutil.exe -asn`
 
 ```ASN
 0000: 30 82 0e 6c                               ; SEQUENCE (e6c Bytes)

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -55,8 +55,8 @@ used to generate test signing keys are included in this repo for reference. Plea
 needs to include OID `1.3.6.1.5.5.7.3.3` as well as the user designed leaf EKU that is used as an
 additional test.  This second EKU must be set in pcd `PcdMfciPkcs7RequiredLeafEKU`.
 
-<[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)>
-<[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)>
+*[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
+*[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
 
 ### Example signing
 

--- a/MfciPkg/Docs/Mfci_Structures.md
+++ b/MfciPkg/Docs/Mfci_Structures.md
@@ -55,8 +55,8 @@ used to generate test signing keys are included in this repo for reference. Plea
 needs to include OID `1.3.6.1.5.5.7.3.3` as well as the user designed leaf EKU that is used as an
 additional test.  This second EKU must be set in pcd `PcdMfciPkcs7RequiredLeafEKU`.
 
-[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)
-[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)
+<[Windows Power Shell Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1)>
+<[Windows Batch Script](../UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat)>
 
 ### Example signing
 

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
@@ -77,8 +77,22 @@ Export-PfxCertificate -Cert $LeafTestBadEku -FilePath $currentdir\Leaf-NoEku.pfx
 Export-Certificate -Cert $LeafTestBadEku -FilePath $currentdir\Leaf-NoEku.cer -Type cer
 
 
-#Remove-Item $RootCert
-#Remove-Item $CA
-#Remove-Item $LeafTest
-#Remove-Item $CaNotTrusted
-#Remove-Item $LeafTestBadEku
+# New-SelfSignedCertificate adds the certificates to the local machine (CertMgr.msc).
+# These commands will remove the generated certificates from the local machine
+# The certificates will still exist in the pfx (personal exchange files)
+$path = "Cert:\LocalMachine\My\"
+
+$certtoremove = $path+$LeafTestBadEku.thumbprint
+Remove-Item $certtoremove
+
+$certtoremove = $path+$CaNotTrusted.thumbprint
+Remove-Item $certtoremove
+
+$certtoremove = $path+$LeafTest.thumbprint
+Remove-Item $certtoremove
+
+$certtoremove = $path+$CA.thumbprint
+Remove-Item $certtoremove
+
+$certtoremove = $path+$RootCert.thumbprint
+Remove-Item $certtoremove

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+$mypwd = ConvertTo-SecureString -String "12345" -Force -AsPlainText
+$currentdir = Get-Location
+
+
+# Create a Self Signed root public/private key, $RootCert
+# certificate is good for 300 months from creation date
+# certificate is exportable, uses sha256 hash function and is stored locally 
+# certificate is expected to be used to sign code
+# 
+$RootCert = New-SelfSignedCertificate -Subject "A Test Root CA"  -KeyLength  4096 -NotAfter (Get-Date).AddMonths(300) -HashAlgorithm sha256 -KeyExportPolicy Exportable  -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign
+
+# Export the self signed keys to a Pfx (Personal Information Exchange)
+Export-PfxCertificate -Cert $RootCert -FilePath $currentdir\Root.pfx -Password $mypwd
+
+# Export the Public key portion of the certificate
+Export-Certificate -Cert $RootCert -FilePath $currentdir\Root.cer -Type cer
+
+
+#
+# Create a CA public/private key that is signed by the $RootCert
+# certificate is good for 150 months from creation date
+# certificate is exportable, uses sha256 hash function and is stored locally 
+# certificate is expected to be used to sign code
+# 
+$CA = New-SelfSignedCertificate -Subject "A UEFI Test CA"  -KeyLength  4096 -NotAfter (Get-Date).AddMonths(150) -HashAlgorithm sha256 -Signer $RootCert -KeyExportPolicy Exportable -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -KeyUsage DigitalSignature,KeyEncipherment,CertSign
+
+# Export the CA keys to a Pfx (Personal Information Exchange)
+Export-PfxCertificate -Cert $CA -FilePath $currentdir\CA.pfx -Password $mypwd
+
+# Export the Public key portion of the certificate
+Export-Certificate -Cert $CA -FilePath $currentdir\CA.cer -Type cer
+
+#
+# Create a leaf test key, which will be used for signing Mfci firmware updates
+# certificate is 3072 bytes (maximum available for singing mfci packets)
+# certificate is good for 30 months
+# certificat is exportable, uses sha256 hash function
+# cetificate is signed by CA
+# Text Extensions - EKU Any purpose (2.5.29.37)
+# include EKU  1.3.6.1.5.5.7.3.3, which signifies that certificate can be used for code signing 
+# include EKU 1.3.6.1.4.1.311.45.255.255 which is the EKU that is used by Mfci as an additional check when verifying certificate used to sign packet (this needs to match PcdMfciPkcs7RequiredLeafEKU) 
+$LeafTest = New-SelfSignedCertificate -Subject "FwPolicy test leaf" -KeyLength  3072 -NotAfter (Get-Date).AddMonths(30) -HashAlgorithm sha256 -Signer $CA -KeyExportPolicy Exportable -KeySpec Signature -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -TextExtension @("2.5.29.37={text}1.3.6.1.4.1.311.45.255.255,1.3.6.1.5.5.7.3.3") -KeyUsage DigitalSignature,KeyEncipherment
+
+# Export the CA keys to a Pfx (Personal Information Exchange)
+Export-PfxCertificate -Cert $LeafTest -ChainOption BuildChain -FilePath $currentdir\Leaf-test.pfx -Password $mypwd
+
+# Export the Public key portion of the certificate
+Export-Certificate -Cert $LeafTest -FilePath $currentdir\Leaf-test.cer -Type cer
+
+
+## Other Test Certificates outside of the main chain.
+
+#
+# Create a different CA, still signed by Root CA, but f
+#
+$CaNotTrusted = New-SelfSignedCertificate -Subject "Not Trusted UEFI Test CA"  -KeyLength  4096 -NotAfter (Get-Date).AddMonths(150) -HashAlgorithm sha256 -Signer $RootCert -KeyExportPolicy Exportable -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign
+
+# Export the CA keys to a Pfx (Personal Information Exchange)
+Export-PfxCertificate -Cert $CaNotTrusted -FilePath $currentdir\CA-NotTrusted.pfx -Password $mypwd
+
+# Export the Public key portion of the certificate
+Export-Certificate -Cert $CaNotTrusted -FilePath $currentdir\CA-NotTrusted.cer -Type cer
+
+
+#
+# Create a leaf test key, with an unmatched EKU
+# 
+$LeafTestBadEku = New-SelfSignedCertificate -Subject "Another test leaf With unmatched EKU" -KeyLength  3072 -NotAfter (Get-Date).AddMonths(30) -HashAlgorithm sha256 -Signer $CA -KeyExportPolicy Exportable -KeySpec KeyExchange -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -TextExtension @("2.5.29.37={text}1.3.6.1.4.1.311.255.0.0,1.3.6.1.5.5.7.3.3") 
+
+# Export the CA keys to a Pfx (Personal Information Exchange)
+Export-PfxCertificate -Cert $LeafTestBadEku -FilePath $currentdir\Leaf-NoEku.pfx -Password $mypwd
+
+# Export the Public key portion of the certificate
+Export-Certificate -Cert $LeafTestBadEku -FilePath $currentdir\Leaf-NoEku.cer -Type cer
+
+
+#Remove-Item $RootCert
+#Remove-Item $CA
+#Remove-Item $LeafTest
+#Remove-Item $CaNotTrusted
+#Remove-Item $LeafTestBadEku

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/CreateCertificates.ps1
@@ -27,7 +27,7 @@ Export-Certificate -Cert $RootCert -FilePath $currentdir\Root.cer -Type cer
 # 
 $CA = New-SelfSignedCertificate -Subject "A UEFI Test CA"  -KeyLength  4096 -NotAfter (Get-Date).AddMonths(150) -HashAlgorithm sha256 -Signer $RootCert -KeyExportPolicy Exportable -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -KeyUsage DigitalSignature,KeyEncipherment,CertSign
 
-# Export the CA keys to a Pfx (Personal Information Exchange)
+# Export the CA keys to a Pfx (Personal Information Exchange) (Contains boht private and public)
 Export-PfxCertificate -Cert $CA -FilePath $currentdir\CA.pfx -Password $mypwd
 
 # Export the Public key portion of the certificate
@@ -35,16 +35,16 @@ Export-Certificate -Cert $CA -FilePath $currentdir\CA.cer -Type cer
 
 #
 # Create a leaf test key, which will be used for signing Mfci firmware updates
-# certificate is 3072 bytes (maximum available for singing mfci packets)
+# certificate is 3072 bytes (maximum available for signing mfci packets)
 # certificate is good for 30 months
-# certificat is exportable, uses sha256 hash function
+# certificate is exportable, uses sha256 hash function
 # cetificate is signed by CA
 # Text Extensions - EKU Any purpose (2.5.29.37)
 # include EKU  1.3.6.1.5.5.7.3.3, which signifies that certificate can be used for code signing 
 # include EKU 1.3.6.1.4.1.311.45.255.255 which is the EKU that is used by Mfci as an additional check when verifying certificate used to sign packet (this needs to match PcdMfciPkcs7RequiredLeafEKU) 
 $LeafTest = New-SelfSignedCertificate -Subject "FwPolicy test leaf" -KeyLength  3072 -NotAfter (Get-Date).AddMonths(30) -HashAlgorithm sha256 -Signer $CA -KeyExportPolicy Exportable -KeySpec Signature -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -TextExtension @("2.5.29.37={text}1.3.6.1.4.1.311.45.255.255,1.3.6.1.5.5.7.3.3") -KeyUsage DigitalSignature,KeyEncipherment
 
-# Export the CA keys to a Pfx (Personal Information Exchange)
+# Export the leaf-test keys to a Pfx (Personal Information Exchange) (contains both private and public)
 Export-PfxCertificate -Cert $LeafTest -ChainOption BuildChain -FilePath $currentdir\Leaf-test.pfx -Password $mypwd
 
 # Export the Public key portion of the certificate
@@ -54,11 +54,11 @@ Export-Certificate -Cert $LeafTest -FilePath $currentdir\Leaf-test.cer -Type cer
 ## Other Test Certificates outside of the main chain.
 
 #
-# Create a different CA, still signed by Root CA, but f
+# Create a different CA, still signed by Root CA, but not used to sign the leaf certificate
 #
 $CaNotTrusted = New-SelfSignedCertificate -Subject "Not Trusted UEFI Test CA"  -KeyLength  4096 -NotAfter (Get-Date).AddMonths(150) -HashAlgorithm sha256 -Signer $RootCert -KeyExportPolicy Exportable -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign
 
-# Export the CA keys to a Pfx (Personal Information Exchange)
+# Export the CA keys to a Pfx (Personal Information Exchange) (contains both private and public)
 Export-PfxCertificate -Cert $CaNotTrusted -FilePath $currentdir\CA-NotTrusted.pfx -Password $mypwd
 
 # Export the Public key portion of the certificate
@@ -66,7 +66,7 @@ Export-Certificate -Cert $CaNotTrusted -FilePath $currentdir\CA-NotTrusted.cer -
 
 
 #
-# Create a leaf test key, with an unmatched EKU
+# Create a leaf test key, with an unmatched EKU, signed by the same CA has the leaf test with the valid EKU
 # 
 $LeafTestBadEku = New-SelfSignedCertificate -Subject "Another test leaf With unmatched EKU" -KeyLength  3072 -NotAfter (Get-Date).AddMonths(30) -HashAlgorithm sha256 -Signer $CA -KeyExportPolicy Exportable -KeySpec KeyExchange -CertStoreLocation "cert:\LocalMachine\My" -KeyUsageProperty Sign -TextExtension @("2.5.29.37={text}1.3.6.1.4.1.311.255.0.0,1.3.6.1.5.5.7.3.3") 
 

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat
@@ -1,7 +1,7 @@
 REM Copyright (c) Microsoft Corporation.
-REM Licensed under the MIT License.
+REM SPDX-License-Identifier: BSD-2-Clause-Patent
 
-REM MakeCert (inlcuded in Windows Kits) has been depreciated. The recomened replacement is  New-SelfSignedCertificate in windows power shell.
+REM MakeCert (inlcuded in Windows Kits) has been depreciated. The recommended replacement is  New-SelfSignedCertificate in windows power shell.
 REM Please see CreateCertificate.ps1 for example usage
 
 rem exit /B

--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/data/certs/MakeChainingCerts.bat
@@ -1,3 +1,9 @@
+REM Copyright (c) Microsoft Corporation.
+REM Licensed under the MIT License.
+
+REM MakeCert (inlcuded in Windows Kits) has been depreciated. The recomened replacement is  New-SelfSignedCertificate in windows power shell.
+REM Please see CreateCertificate.ps1 for example usage
+
 rem exit /B
 @echo off
 
@@ -8,6 +14,7 @@ REM Creating Certs requires the Win10 WDK.  If you don't have the MakeCert tool 
 
 set KIT=10
 set VER=bin\10.0.18362.0
+
 set EKU_TEST=1.3.6.1.4.1.311.45.255.255,1.3.6.1.5.5.7.3.3
 set EKU_INVALID=1.3.6.1.4.1.311.255.0.0,1.3.6.1.5.5.7.3.3
 


### PR DESCRIPTION
## Description

Updated Mfci documentation to include better signing information and information about key generation.
Added information about required OID for signing.
Made instructions clearer that policy blobs need signed after generated, and that additional steps are required.
Added example signing instruction.
Updated batch file copyright 
Added power shell script for key generation.

- [ ] Breaking change?
  - This is mainly documentation change.
 
## How This Was Tested
No code changes 

## Integration Instructions
N/A
