### PR TITLE
Update Stack Cookie Exception Handler to Register Based on Fixed PCD

### DIFF
--- a/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.c
+++ b/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.c
@@ -23,9 +23,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/ResetSystemLib.h>
 #include <Library/MsWheaEarlyStorageLib.h>
 #include <Library/PeCoffGetEntryPointLib.h>
+#include <Library/PcdLib.h>
 
-#define IA32_PF_EC_ID        BIT4
-#define EXCEPT_STACK_COOKIE  0x40
+#define IA32_PF_EC_ID  BIT4
 
 STATIC EFI_HANDLE  mImageHandle = NULL;
 
@@ -202,7 +202,7 @@ CpuArchRegisterMemoryProtectionExceptionHandler (
 
   Status = mCpu->RegisterInterruptHandler (
                    mCpu,
-                   EXCEPT_STACK_COOKIE,
+                   PcdGet8 (PcdStackCookieExceptionVector),
                    MemoryProtectionStackCookieFailureHandler
                    );
 

--- a/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.inf
+++ b/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.inf
@@ -49,5 +49,8 @@
 [Guids]
   gMemoryProtectionExceptionHandlerGuid
 
+[FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
+
 [DEPEX]
   TRUE

--- a/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.inf
+++ b/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.inf
@@ -39,6 +39,7 @@
   HwResetSystemLib
   MsWheaEarlyStorageLib
   PeCoffGetEntryPointLib
+  PcdLib
 
 [Guids]
   gMemoryProtectionExceptionHandlerGuid               ## PRODUCES


### PR DESCRIPTION
## Description

To enable more easily setting the stack cookie failure vector, update the check to reference a fixed at build PCD in MdePkg.

## Breaking change?

No

## How This Was Tested

Triggering the interrupt on Q35

## Integration Instructions

N/A
