### PR TITLE
DfciPkg/UnitTests/pip-requirements.txt: Remove pytool-library; bump robot framework

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/pip-requirements.txt
+++ b/DfciPkg/UnitTests/DfciTests/pip-requirements.txt
@@ -1,2 +1,1 @@
-edk2-pytool-library>=0.10.13
-robotframework>=4.0.1
+robotframework>=6.0.1


### PR DESCRIPTION
## Description

- Removes edk2-pytool-library since it has a very old version and
   the module can be picked up from (1) the main repo
   pip-requirements.txt or (2) the edk2-pytool-extensions dependency.

- Updates robotframework pip module version since it also now very old.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Should not be breaking for the reasons mentioned in the description.

## How This Was Tested

Todo

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>