### PR TITLE
MfciPkg/MfciDxe: Fix GCC compilation issue in a test

### DIFF
--- a/MfciPkg/MfciDxe/Test/MfciMultipleCertsHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciMultipleCertsHostTest.c
@@ -193,6 +193,8 @@ MfciMultipleCertificatesShouldParseSingleCert (
   EFI_STATUS  Status;
   UINT8       Dummy;
 
+  Dummy = 0;
+
   expect_value (ValidateBlob, SignedPolicy, &Dummy);
   expect_value (ValidateBlob, SignedPolicySize, sizeof (Dummy));
   expect_value (ValidateBlob, TrustAnchorCertSize, sizeof (mCert_Trusted_CA));
@@ -314,6 +316,8 @@ MfciMultipleCertificatesShouldCheckInputs (
   EFI_STATUS  Status;
   UINT8       Dummy;
 
+  Dummy = 0;
+
   Status = ValidateBlobWithXdrCertificates (&Dummy, sizeof (Dummy), NULL, sizeof (mCert_Trusted_CA_Root_xdr));
   UT_ASSERT_STATUS_EQUAL (Status, EFI_ABORTED);
 
@@ -355,6 +359,9 @@ MfciMultipleCertificatesShouldCheckGeneralCertificates (
   UINT8       Dummy;
   UINT8       FakeCertificate;
 
+  Dummy           = 0;
+  FakeCertificate = 0;
+
   Status = ValidateBlobWithXdrCertificates (&Dummy, sizeof (Dummy), &FakeCertificate, sizeof (FakeCertificate));
   UT_ASSERT_STATUS_EQUAL (Status, EFI_ABORTED);
 
@@ -385,6 +392,9 @@ MfciMultipleCertificatesShouldCheckIndividualCertificate (
 {
   EFI_STATUS  Status;
   UINT8       Dummy;
+
+  Dummy = 0;
+
   // Not enough for individual size field
   UINT8  FakeCertificate1[] = { 0x00, 0x01, 0x02, 0x03, 0x04 };
   // No content individual certificate


### PR DESCRIPTION
## Description

Fixes #106 

GCC states `Dummy` and `FakeCertificate` may be used uninitialized since it is not assigned an initial value before being passed to functions in some tests.

`Dummy` Example:

```
INFO - /s/MfciPkg/MfciDxe/Test/MfciMultipleCertsHostTest.c:317:12: error: ‘Dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
INFO -   317 |   Status = ValidateBlobWithXdrCertificates (&Dummy, sizeof (Dummy), NULL, sizeof (mCert_Trusted_CA_Root_xdr));
INFO -       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO - /s/MfciPkg/MfciDxe/Test/MfciMultipleCertsHostTest.c:144:1: note: by argument 1 of type ‘const UINT8 *’ {aka ‘const unsigned char *’} to ‘ValidateBlobWithXdrCertificates’ declared here
```

`FakeCertificate` Example:

```
INFO - /s/MfciPkg/MfciDxe/Test/MfciMultipleCertsHostTest.c:358:12: error: ‘FakeCertificate’ may be used uninitialized [-Werror=maybe-uninitialized]
INFO -   358 |   Status = ValidateBlobWithXdrCertificates (&Dummy, sizeof (Dummy), &FakeCertificate, sizeof (FakeCertificate));
INFO -       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This change initializes the values as necessary to prevent the error.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Simple GCC compilation fix

## How This Was Tested

Verified compilation before (fails as shown above) and after (does not fail) with fix in this change.

## Integration Instructions

None - This will resolve a GCC build error that may have been encountered in the MFCI tests.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>