### PR TITLE
Add missing braces to gPciRootBridge #define for GCC

### DIFF
--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
@@ -55,7 +55,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
       } \
     }, \
     EISA_PNP_ID (0x0A03), 0 \
-  } 
+  }
 
 #define gEndEntire \
   { \

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
@@ -47,9 +47,15 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define gPciRootBridge \
   { \
-    ACPI_DEVICE_PATH, ACPI_DP, (UINT8) (sizeof (ACPI_HID_DEVICE_PATH)), (UINT8) \
-      ((sizeof (ACPI_HID_DEVICE_PATH)) >> 8), EISA_PNP_ID (0x0A03), 0 \
-  }
+    { \
+      ACPI_DEVICE_PATH, ACPI_DP, \
+      { \
+        (UINT8) (sizeof (ACPI_HID_DEVICE_PATH)), (UINT8) \
+        ((sizeof (ACPI_HID_DEVICE_PATH)) >> 8) \
+      } \
+    }, \
+    EISA_PNP_ID (0x0A03), 0 \
+  } 
 
 #define gEndEntire \
   { \


### PR DESCRIPTION
## Description
GCC compiler warns about missing braces with existing defintion of gPciRootBridge. This change fixes that.

- [ ] Breaking change?
No

## How This Was Tested
Local build on workstation.
Ran GCC build on internal Microsoft code base.

## Integration Instructions
N/A
