### PR TITLE
Add Arm64 Translation Table Data Collection via DxePagingAudit

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -1,0 +1,240 @@
+/** @file -- PagingAuditProcessor.c
+
+Platform specific memory audit functions.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/ArmLib.h>
+#include "../PagingAuditCommon.h"
+
+extern MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol;
+
+#define TT_ADDRESS_MASK  (0xFFFFFFFFFULL << 12)
+
+#define IS_TABLE(page, level)  ((level == 3) ? FALSE : (((page) & TT_TYPE_MASK) == TT_TYPE_TABLE_ENTRY))
+#define IS_BLOCK(page, level)  ((level == 3) ? (((page) & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3) : ((page & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY))
+#define ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
+
+/**
+  This helper function walks the page tables to retrieve:
+  - a count of each entry
+  - a count of each directory entry
+  - [optional] a flat list of each entry
+  - [optional] a flat list of each directory entry
+
+  @param[in, out]   Pte1GCount, Pte2MCount, Pte4KCount, PdeCount
+      On input, the number of entries that can fit in the corresponding buffer (if provided).
+      It is expected that this will be zero if the corresponding buffer is NULL.
+      On output, the number of entries that were encountered in the page table.
+  @param[out]       Pte1GEntries, Pte2MEntries, Pte4KEntries, PdeEntries
+      A buffer which will be filled with the entries that are encountered in the tables.
+
+  @retval     EFI_SUCCESS             All requested data has been returned.
+  @retval     EFI_INVALID_PARAMETER   One or more of the count parameter pointers is NULL.
+  @retval     EFI_INVALID_PARAMETER   Presence of buffer counts and pointers is incongruent.
+  @retval     EFI_BUFFER_TOO_SMALL    One or more of the buffers was insufficient to hold
+                                      all of the entries in the page tables. The counts
+                                      have been updated with the total number of entries
+                                      encountered.
+
+**/
+EFI_STATUS
+EFIAPI
+GetFlatPageTableData (
+  IN OUT UINTN  *Pte1GCount,
+  IN OUT UINTN  *Pte2MCount,
+  IN OUT UINTN  *Pte4KCount,
+  IN OUT UINTN  *PdeCount,
+  IN OUT UINTN  *GuardCount,
+  OUT UINT64    *Pte1GEntries,
+  OUT UINT64    *Pte2MEntries,
+  OUT UINT64    *Pte4KEntries,
+  OUT UINT64    *PdeEntries,
+  OUT UINT64    *GuardEntries
+  )
+{
+  EFI_STATUS  Status = EFI_SUCCESS;
+  UINT64      *Pml0;
+  UINT64      *Pte1G;
+  UINT64      *Pte2M;
+  UINT64      *Pte4K;
+  UINT64      Index3              = 0;
+  UINT64      Index2              = 0;
+  UINT64      Index1              = 0;
+  UINT64      Index0              = 0;
+  UINTN       MyGuardCount        = 0;
+  UINTN       MyPdeCount          = 0;
+  UINTN       My4KCount           = 0;
+  UINTN       My2MCount           = 0;
+  UINTN       My1GCount           = 0;
+  UINTN       NumPage4KNotPresent = 0;
+  UINTN       NumPage2MNotPresent = 0;
+  UINTN       NumPage1GNotPresent = 0;
+  UINT64      RootEntryCount      = 0;
+  UINT64      Address;
+  BOOLEAN     Valid;
+
+  //  Count parameters should be provided.
+  if ((Pte1GCount == NULL) || (Pte2MCount == NULL) || (Pte4KCount == NULL) || (PdeCount == NULL) || (GuardCount == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // If a count is greater than 0, the corresponding buffer pointer MUST be provided.
+  // It will be assumed that all buffers have space for any corresponding count.
+  if (((*Pte1GCount > 0) && (Pte1GEntries == NULL)) || ((*Pte2MCount > 0) && (Pte2MEntries == NULL)) ||
+      ((*Pte4KCount > 0) && (Pte4KEntries == NULL)) || ((*PdeCount > 0) && (PdeEntries == NULL)) ||
+      ((*GuardCount > 0) && (GuardEntries == NULL)))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Pml0           = (UINT64 *)ArmGetTTBR0BaseAddress ();
+  RootEntryCount = ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
+  MyPdeCount++;
+  if (MyPdeCount <= *PdeCount) {
+    PdeEntries[MyPdeCount-1] = (UINT64)Pml0;
+  }
+
+  for (Index0 = 0x0; Index0 < RootEntryCount; Index0++) {
+    Index1 = 0;
+    Index2 = 0;
+    Index3 = 0;
+    if (!IS_TABLE (Pml0[Index0], 0)) {
+      continue;
+    }
+
+    Pte1G = (UINT64 *)(Pml0[Index0] & TT_ADDRESS_MASK);
+
+    MyPdeCount++;
+    if (MyPdeCount <= *PdeCount) {
+      PdeEntries[MyPdeCount-1] = (UINT64)Pte1G;
+    }
+
+    for (Index1 = 0x0; Index1 < TT_ENTRY_COUNT; Index1++ ) {
+      Index2 = 0;
+      Index3 = 0;
+      Valid  = TRUE;
+      if ((Pte1G[Index1] & 0x1) == 0) {
+        NumPage1GNotPresent++;
+        Valid = FALSE;
+      }
+
+      if (!IS_BLOCK (Pte1G[Index1], 1) && Valid) {
+        Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
+
+        MyPdeCount++;
+        if (MyPdeCount <= *PdeCount) {
+          PdeEntries[MyPdeCount-1] = (UINT64)Pte2M;
+        }
+
+        for (Index2 = 0x0; Index2 < TT_ENTRY_COUNT; Index2++ ) {
+          Index3 = 0;
+          Valid  = TRUE;
+          if ((Pte2M[Index2] & 0x1) == 0) {
+            NumPage2MNotPresent++;
+            Valid = FALSE;
+          }
+
+          if (!IS_BLOCK (Pte2M[Index2], 2) && Valid) {
+            Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
+            MyPdeCount++;
+
+            if (MyPdeCount <= *PdeCount) {
+              PdeEntries[MyPdeCount-1] = (UINT64)Pte4K;
+            }
+
+            for (Index3 = 0x0; Index3 < TT_ENTRY_COUNT; Index3++ ) {
+              if (!IS_BLOCK (Pte4K[Index3], 3)) {
+                NumPage4KNotPresent++;
+                Address = IndexToAddress (Index0, Index1, Index2, Index3);
+                if ((mMemoryProtectionProtocol != NULL) && (mMemoryProtectionProtocol->IsGuardPage (Address))) {
+                  MyGuardCount++;
+                  if (MyGuardCount <= *GuardCount) {
+                    GuardEntries[MyGuardCount - 1] = Address;
+                  }
+
+                  continue;
+                }
+              }
+
+              My4KCount++;
+              if (My4KCount <= *Pte4KCount) {
+                Pte4KEntries[My4KCount-1] = Pte4K[Index3] | IndexToAddress (Index0, Index1, Index2, Index3);
+              }
+            }
+          } else {
+            My2MCount++;
+
+            if (My2MCount <= *Pte2MCount) {
+              Pte2MEntries[My2MCount-1] = Pte2M[Index2] | IndexToAddress (Index0, Index1, Index2, Index3);
+            }
+          }
+        }
+      } else {
+        My1GCount++;
+
+        if (My1GCount <= *Pte1GCount) {
+          Pte1GEntries[My1GCount-1] = Pte1G[Index1] | IndexToAddress (Index0, Index1, Index2, Index3);
+        }
+      }
+    }
+  }
+
+  DEBUG ((DEBUG_ERROR, "Pages used for Page Tables   = %d\n", MyPdeCount));
+  DEBUG ((DEBUG_ERROR, "Number of   4K Pages active  = %d - NotPresent = %d\n", My4KCount - NumPage4KNotPresent, NumPage4KNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   2M Pages active  = %d - NotPresent = %d\n", My2MCount - NumPage2MNotPresent, NumPage2MNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   1G Pages active  = %d - NotPresent = %d\n", My1GCount - NumPage1GNotPresent, NumPage1GNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   Guard Pages active  = %d\n", MyGuardCount));
+
+  //
+  // determine whether any of the buffers were too small.
+  // Only matters if a given buffer was provided.
+  //
+  if (((Pte1GEntries != NULL) && (*Pte1GCount < My1GCount)) || ((Pte2MEntries != NULL) && (*Pte2MCount < My2MCount)) ||
+      ((Pte4KEntries != NULL) && (*Pte4KCount < My4KCount)) || ((PdeEntries != NULL) && (*PdeCount < MyPdeCount)) ||
+      ((GuardEntries != NULL) && (*GuardCount < MyGuardCount)))
+  {
+    Status = EFI_BUFFER_TOO_SMALL;
+  }
+
+  //
+  // Update all the return pointers.
+  //
+  *Pte1GCount = My1GCount;
+  *Pte2MCount = My2MCount;
+  *Pte4KCount = My4KCount;
+  *PdeCount   = MyPdeCount;
+  *GuardCount = MyGuardCount;
+
+  return Status;
+}
+
+/**
+  Calculate the maximum physical address bits supported.
+
+  @return the maximum support physical address bits supported.
+**/
+UINT8
+EFIAPI
+CalculateMaximumSupportAddressBits (
+  VOID
+  )
+{
+  return 36;
+}
+
+/**
+   Dump platform specific handler. Created handler(s) need to be compliant with
+   Windows\PagingReportGenerator.py, i.e. TSEG.
+**/
+VOID
+EFIAPI
+DumpProcessorSpecificHandlers (
+  VOID
+  )
+{
+  return;
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
@@ -1,0 +1,28 @@
+/** @file -- DxePagingAuditTestsArm64.c
+    ARM64 implementations for DXE paging audit tests
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "../DxePagingAuditTestApp.h"
+
+/**
+  Check the page table for Read/Write/Execute regions.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+NoReadWriteExecute (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_LOG_WARNING ("Test not implemented!\n");
+  return UNIT_TEST_PASSED;
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -236,7 +236,7 @@ DxePagingAuditTestAppEntryPoint (
       goto EXIT;
     }
 
-    AddTestCase (Misc, "No pages can be read,write,execute", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, NULL, NULL, Context);
+    AddTestCase (Misc, "No pages can be read,write,execute", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, NULL, NULL, NULL);
 
     //
     // Execute the tests.

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -7,145 +7,150 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include "../../PagingAuditCommon.h"
-
-#include <Library/UnitTestLib.h>
-#include <Library/CpuPageTableLib.h>
-#include <Library/DxeMemoryProtectionHobLib.h>
-#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
 #include <Protocol/ShellParameters.h>
 #include <Protocol/Shell.h>
+#include <Protocol/SimpleFileSystem.h>
+#include <Library/FileHandleLib.h>
+
+#include "DxePagingAuditTestApp.h"
 
 #define UNIT_TEST_APP_NAME     "Paging Audit Test"
 #define UNIT_TEST_APP_VERSION  "1"
 #define MAX_CHARS_TO_READ      3
-
-// TRUE if A interval subsumes B interval
-#define CHECK_SUBSUMPTION(AStart, AEnd, BStart, BEnd) \
-  ((AStart <= BStart) && (AEnd >= BEnd))
-
-typedef struct _PAGING_AUDIT_TEST_CONTEXT {
-  IA32_MAP_ENTRY    *Entries;
-  UINTN             Count;
-} PAGING_AUDIT_TEST_CONTEXT;
 
 CHAR8  *mMemoryInfoDatabaseBuffer   = NULL;
 UINTN  mMemoryInfoDatabaseSize      = 0;
 UINTN  mMemoryInfoDatabaseAllocSize = 0;
 
 /**
-  Check the page table for Read/Write/Execute regions.
 
-  @param[in] Context            Unit test context
+ Locates and opens the SFS volume containing the application and, if successful, returns an
+ FS handle to the opened volume.
 
-  @retval UNIT_TEST_PASSED      The unit test passed
-  @retval other                 The unit test failed
+  @param    mFs_Handle       Handle to the opened volume.
+
+  @retval   EFI_SUCCESS     The FS volume was opened successfully.
+  @retval   Others          The operation failed.
 
 **/
-UNIT_TEST_STATUS
-EFIAPI
-NoReadWriteExecute (
-  IN UNIT_TEST_CONTEXT  Context
+STATIC
+EFI_STATUS
+OpenAppSFS (
+  OUT EFI_FILE  **Fs_Handle
   )
 {
-  IA32_MAP_ENTRY                             *Map                      = ((PAGING_AUDIT_TEST_CONTEXT *)Context)->Entries;
-  UINTN                                      MapCount                  = ((PAGING_AUDIT_TEST_CONTEXT *)Context)->Count;
-  UINTN                                      Index                     = 0;
-  BOOLEAN                                    FoundRWXAddress           = FALSE;
-  BOOLEAN                                    IgnoreRWXAddress          = FALSE;
-  MEMORY_PROTECTION_DEBUG_PROTOCOL           *MemoryProtectionProtocol = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION_PROTOCOL  *SpecialRegionProtocol    = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION           *SpecialRegions           = NULL;
-  UINTN                                      SpecialRegionCount        = 0;
-  UINTN                                      SpecialRegionIndex        = 0;
-  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImageList    = NULL;
-  LIST_ENTRY                                 *NonProtectedImageLink    = NULL;
-  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImage        = NULL;
+  EFI_DEVICE_PATH_PROTOCOL         *DevicePath;
+  BOOLEAN                          Found;
+  EFI_HANDLE                       Handle;
+  EFI_HANDLE                       *HandleBuffer;
+  UINTN                            Index;
+  UINTN                            NumHandles;
+  EFI_STRING                       PathNameStr;
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *SfProtocol;
+  EFI_STATUS                       Status;
+  EFI_FILE_PROTOCOL                *FileHandle;
+  EFI_FILE_PROTOCOL                *FileHandle2;
 
-  UT_ASSERT_NOT_EFI_ERROR (
-    gBS->LocateProtocol (
-           &gMemoryProtectionDebugProtocolGuid,
-           NULL,
-           (VOID **)&MemoryProtectionProtocol
-           )
-    );
+  Status       = EFI_SUCCESS;
+  SfProtocol   = NULL;
+  NumHandles   = 0;
+  HandleBuffer = NULL;
 
-  UT_ASSERT_NOT_EFI_ERROR (
-    MemoryProtectionProtocol->GetImageList (
-                                &NonProtectedImageList,
-                                NonProtected
-                                )
-    );
+  //
+  // Locate all handles that are using the SFS protocol.
+  //
+  Status = gBS->LocateHandleBuffer (
+                  ByProtocol,
+                  &gEfiSimpleFileSystemProtocolGuid,
+                  NULL,
+                  &NumHandles,
+                  &HandleBuffer
+                  );
 
-  UT_ASSERT_NOT_EFI_ERROR (
-    gBS->LocateProtocol (
-           &gMemoryProtectionSpecialRegionProtocolGuid,
-           NULL,
-           (VOID **)&SpecialRegionProtocol
-           )
-    );
+  if (EFI_ERROR (Status) != FALSE) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate all handles using the Simple FS protocol (%r)\n", __FUNCTION__, Status));
+    goto CleanUp;
+  }
 
-  UT_ASSERT_NOT_EFI_ERROR (
-    SpecialRegionProtocol->GetSpecialRegions (
-                             &SpecialRegions,
-                             &SpecialRegionCount
-                             )
-    );
+  //
+  // Search the handles to find one that is on a GPT partition on a hard drive.
+  //
+  Found = FALSE;
+  for (Index = 0; (Index < NumHandles) && (Found == FALSE); Index += 1) {
+    DevicePath = DevicePathFromHandle (HandleBuffer[Index]);
+    if (DevicePath == NULL) {
+      continue;
+    }
 
-  for ( ; Index < MapCount; Index++) {
-    if ((Map[Index].Attribute.Bits.ReadWrite != 0) && (Map[Index].Attribute.Bits.Nx == 0)) {
-      IgnoreRWXAddress = FALSE;
-      if (NonProtectedImageList != NULL) {
-        for (NonProtectedImageLink = NonProtectedImageList->Link.ForwardLink;
-             NonProtectedImageLink != &NonProtectedImageList->Link;
-             NonProtectedImageLink = NonProtectedImageLink->ForwardLink)
-        {
-          NonProtectedImage = CR (
-                                NonProtectedImageLink,
-                                IMAGE_RANGE_DESCRIPTOR,
-                                Link,
-                                IMAGE_RANGE_DESCRIPTOR_SIGNATURE
-                                );
-          if CHECK_SUBSUMPTION (
-               NonProtectedImage->Base,
-               NonProtectedImage->Base + NonProtectedImage->Length,
-               Map[Index].LinearAddress,
-               Map[Index].LinearAddress + Map[Index].Length
-               ) {
-            IgnoreRWXAddress = TRUE;
-            break;
-          }
-        }
+    //
+    // Convert the device path to a string to print it.
+    //
+    PathNameStr = ConvertDevicePathToText (DevicePath, TRUE, TRUE);
+    DEBUG ((DEBUG_ERROR, "%a: device path %d -> %s\n", __FUNCTION__, Index, PathNameStr));
+
+    //
+    // Check if this is a block IO device path. If it is not, keep searching.
+    // This changes our locate device path variable, so we'll have to restore
+    // it afterwards.
+    //
+    Status = gBS->LocateDevicePath (
+                    &gEfiBlockIoProtocolGuid,
+                    &DevicePath,
+                    &Handle
+                    );
+
+    if (EFI_ERROR (Status) != FALSE) {
+      DEBUG ((DEBUG_ERROR, "%a: not a block IO device path\n", __FUNCTION__));
+      continue;
+    }
+
+    Status = gBS->HandleProtocol (
+                    HandleBuffer[Index],
+                    &gEfiSimpleFileSystemProtocolGuid,
+                    (VOID **)&SfProtocol
+                    );
+
+    if (EFI_ERROR (Status) != FALSE) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate Simple FS protocol using the handle to fs0: %r \n", __FUNCTION__, Status));
+      goto CleanUp;
+    }
+
+    //
+    // Open the volume/partition.
+    //
+    Status = SfProtocol->OpenVolume (SfProtocol, &FileHandle);
+    if (EFI_ERROR (Status) != FALSE) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to open Simple FS volume fs0: %r \n", __FUNCTION__, Status));
+      goto CleanUp;
+    }
+
+    //
+    // Ensure the PktName file is present
+    //
+    Status = FileHandle->Open (FileHandle, &FileHandle2, L"DxePagingAuditTestApp.efi", EFI_FILE_MODE_READ, 0);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "%a: Unable to locate %s. Status: %r\n", __FUNCTION__, L"DxePagingAuditTestApp.efi", Status));
+      Status = FileHandleClose (FileHandle);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Error closing Vol Handle. Code = %r\n", __FUNCTION__, Status));
       }
 
-      if ((SpecialRegionCount > 0) && !IgnoreRWXAddress) {
-        for (SpecialRegionIndex = 0; SpecialRegionIndex < SpecialRegionCount; SpecialRegionIndex++) {
-          if (CHECK_SUBSUMPTION (
-                SpecialRegions[SpecialRegionIndex].Start,
-                SpecialRegions[SpecialRegionIndex].Start + SpecialRegions[SpecialRegionIndex].Length,
-                Map[Index].LinearAddress,
-                Map[Index].LinearAddress + Map[Index].Length
-                ) &&
-              (SpecialRegions[SpecialRegionIndex].EfiAttributes == 0))
-          {
-            IgnoreRWXAddress = TRUE;
-            break;
-          }
-        }
-      }
-
-      if (!IgnoreRWXAddress) {
-        UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Map[Index].LinearAddress, Map[Index].LinearAddress + Map[Index].Length);
-        FoundRWXAddress = TRUE;
-      } else {
-        UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Map[Index].LinearAddress, Map[Index].LinearAddress + Map[Index].Length);
-      }
+      Status = EFI_NOT_FOUND;
+      continue;
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a: Located app device path\n", __FUNCTION__));
+      Status     = FileHandleClose (FileHandle2);
+      *Fs_Handle = (EFI_FILE *)FileHandle;
+      break;
     }
   }
 
-  UT_ASSERT_FALSE (FoundRWXAddress);
+CleanUp:
+  if (HandleBuffer != NULL) {
+    FreePool (HandleBuffer);
+  }
 
-  return UNIT_TEST_PASSED;
+  return Status;
 }
 
 /**
@@ -166,16 +171,11 @@ DxePagingAuditTestAppEntryPoint (
   )
 {
   EFI_STATUS                     Status;
-  UNIT_TEST_FRAMEWORK_HANDLE     Fw   = NULL;
-  UNIT_TEST_SUITE_HANDLE         Misc = NULL;
-  PAGING_AUDIT_TEST_CONTEXT      *Context;
-  IA32_CR4                       Cr4;
-  PAGING_MODE                    PagingMode;
-  IA32_MAP_ENTRY                 *Map           = NULL;
-  UINTN                          MapCount       = 0;
-  UINTN                          PagesAllocated = 0;
-  BOOLEAN                        RunTests       = TRUE;
+  UNIT_TEST_FRAMEWORK_HANDLE     Fw       = NULL;
+  UNIT_TEST_SUITE_HANDLE         Misc     = NULL;
+  BOOLEAN                        RunTests = TRUE;
   EFI_SHELL_PARAMETERS_PROTOCOL  *ShellParams;
+  EFI_FILE                       *Fs_Handle;
 
   DEBUG ((DEBUG_ERROR, "%a()\n", __FUNCTION__));
 
@@ -197,7 +197,13 @@ DxePagingAuditTestAppEntryPoint (
     if (StrnCmp (ShellParams->Argv[1], L"-r", 4) == 0) {
       RunTests = TRUE;
     } else if (StrnCmp (ShellParams->Argv[1], L"-d", 4) == 0) {
-      DumpPagingInfo (NULL, NULL);
+      Status = OpenAppSFS (&Fs_Handle);
+
+      if (!EFI_ERROR ((Status))) {
+        DumpPagingInfo (Fs_Handle);
+      } else {
+        DumpPagingInfo (NULL);
+      }
     } else {
       if (StrnCmp (ShellParams->Argv[1], L"-h", 4) != 0) {
         DEBUG ((DEBUG_INFO, "Invalid argument!\n"));
@@ -211,13 +217,6 @@ DxePagingAuditTestAppEntryPoint (
   }
 
   if (RunTests) {
-    Context = (PAGING_AUDIT_TEST_CONTEXT *)AllocateZeroPool (sizeof (PAGING_AUDIT_TEST_CONTEXT));
-
-    if (Context == NULL) {
-      DEBUG ((DEBUG_ERROR, "Failed to allocate test context\n"));
-      goto EXIT;
-    }
-
     //
     // Start setting up the test framework for running the tests.
     //
@@ -226,37 +225,6 @@ DxePagingAuditTestAppEntryPoint (
       DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
       goto EXIT;
     }
-
-    // Poll CR4 to deterimine the page table depth
-    Cr4.UintN = AsmReadCr4 ();
-
-    if (Cr4.Bits.LA57 != 0) {
-      PagingMode = Paging5Level;
-    } else {
-      PagingMode = Paging4Level;
-    }
-
-    // CR3 is the page table pointer
-    Status = PageTableParse (AsmReadCr3 (), PagingMode, NULL, &MapCount);
-
-    while (Status == RETURN_BUFFER_TOO_SMALL) {
-      if ((Map != NULL) && (PagesAllocated > 0)) {
-        FreePages (Map, PagesAllocated);
-      }
-
-      PagesAllocated = EFI_SIZE_TO_PAGES (MapCount * sizeof (IA32_MAP_ENTRY));
-      Map            = AllocatePages (PagesAllocated);
-
-      if (Map == NULL) {
-        DEBUG ((DEBUG_ERROR, "Failed to allocate page table map\n"));
-        goto EXIT;
-      }
-
-      Status = PageTableParse (AsmReadCr3 (), PagingMode, Map, &MapCount);
-    }
-
-    Context->Entries = Map;
-    Context->Count   = MapCount;
 
     //
     // Create test suite
@@ -278,14 +246,6 @@ EXIT:
 
     if (Fw) {
       FreeUnitTestFramework (Fw);
-    }
-
-    if ((Map != NULL) && (PagesAllocated > 0)) {
-      FreePages (Map, PagesAllocated);
-    }
-
-    if (Context != NULL) {
-      FreePool (Context);
     }
   }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
@@ -1,0 +1,27 @@
+/** @file -- DxePagingAuditTestApp.h
+This Shell App tests the page table or writes page table and
+memory map information to SFS
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "../../PagingAuditCommon.h"
+
+#include <Library/UnitTestLib.h>
+
+/**
+  Check the page table for Read/Write/Execute regions.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+NoReadWriteExecute (
+  IN UNIT_TEST_CONTEXT  Context
+  );

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
@@ -1,0 +1,160 @@
+/** @file -- DxePagingAuditTestsx86.c
+    x86 implementations for DXE paging audit tests
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/CpuPageTableLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
+#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
+
+#include "../DxePagingAuditTestApp.h"
+
+// TRUE if A interval subsumes B interval
+#define CHECK_SUBSUMPTION(AStart, AEnd, BStart, BEnd) \
+  ((AStart <= BStart) && (AEnd >= BEnd))
+
+/**
+  Check the page table for Read/Write/Execute regions.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+NoReadWriteExecute (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  IA32_MAP_ENTRY                             *Map                      = NULL;
+  UINTN                                      MapCount                  = 0;
+  UINTN                                      Index                     = 0;
+  BOOLEAN                                    FoundRWXAddress           = FALSE;
+  BOOLEAN                                    IgnoreRWXAddress          = FALSE;
+  MEMORY_PROTECTION_DEBUG_PROTOCOL           *MemoryProtectionProtocol = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION_PROTOCOL  *SpecialRegionProtocol    = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION           *SpecialRegions           = NULL;
+  UINTN                                      SpecialRegionCount        = 0;
+  UINTN                                      SpecialRegionIndex        = 0;
+  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImageList    = NULL;
+  LIST_ENTRY                                 *NonProtectedImageLink    = NULL;
+  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImage        = NULL;
+  IA32_CR4                                   Cr4;
+  PAGING_MODE                                PagingMode;
+  UINTN                                      PagesAllocated = 0;
+  EFI_STATUS                                 Status;
+
+  // Poll CR4 to deterimine the page table depth
+  Cr4.UintN = AsmReadCr4 ();
+
+  if (Cr4.Bits.LA57 != 0) {
+    PagingMode = Paging5Level;
+  } else {
+    PagingMode = Paging4Level;
+  }
+
+  // CR3 is the page table pointer
+  Status = PageTableParse (AsmReadCr3 (), PagingMode, NULL, &MapCount);
+
+  while (Status == RETURN_BUFFER_TOO_SMALL) {
+    if ((Map != NULL) && (PagesAllocated > 0)) {
+      FreePages (Map, PagesAllocated);
+    }
+
+    PagesAllocated = EFI_SIZE_TO_PAGES (MapCount * sizeof (IA32_MAP_ENTRY));
+    Map            = AllocatePages (PagesAllocated);
+
+    UT_ASSERT_NOT_NULL (Map);
+    Status = PageTableParse (AsmReadCr3 (), PagingMode, Map, &MapCount);
+  }
+
+  UT_ASSERT_NOT_EFI_ERROR (
+    gBS->LocateProtocol (
+           &gMemoryProtectionDebugProtocolGuid,
+           NULL,
+           (VOID **)&MemoryProtectionProtocol
+           )
+    );
+
+  UT_ASSERT_NOT_EFI_ERROR (
+    MemoryProtectionProtocol->GetImageList (
+                                &NonProtectedImageList,
+                                NonProtected
+                                )
+    );
+
+  UT_ASSERT_NOT_EFI_ERROR (
+    gBS->LocateProtocol (
+           &gMemoryProtectionSpecialRegionProtocolGuid,
+           NULL,
+           (VOID **)&SpecialRegionProtocol
+           )
+    );
+
+  UT_ASSERT_NOT_EFI_ERROR (
+    SpecialRegionProtocol->GetSpecialRegions (
+                             &SpecialRegions,
+                             &SpecialRegionCount
+                             )
+    );
+
+  for ( ; Index < MapCount; Index++) {
+    if ((Map[Index].Attribute.Bits.ReadWrite != 0) && (Map[Index].Attribute.Bits.Nx == 0)) {
+      IgnoreRWXAddress = FALSE;
+      if (NonProtectedImageList != NULL) {
+        for (NonProtectedImageLink = NonProtectedImageList->Link.ForwardLink;
+             NonProtectedImageLink != &NonProtectedImageList->Link;
+             NonProtectedImageLink = NonProtectedImageLink->ForwardLink)
+        {
+          NonProtectedImage = CR (
+                                NonProtectedImageLink,
+                                IMAGE_RANGE_DESCRIPTOR,
+                                Link,
+                                IMAGE_RANGE_DESCRIPTOR_SIGNATURE
+                                );
+          if CHECK_SUBSUMPTION (
+               NonProtectedImage->Base,
+               NonProtectedImage->Base + NonProtectedImage->Length,
+               Map[Index].LinearAddress,
+               Map[Index].LinearAddress + Map[Index].Length
+               ) {
+            IgnoreRWXAddress = TRUE;
+            break;
+          }
+        }
+      }
+
+      if ((SpecialRegionCount > 0) && !IgnoreRWXAddress) {
+        for (SpecialRegionIndex = 0; SpecialRegionIndex < SpecialRegionCount; SpecialRegionIndex++) {
+          if (CHECK_SUBSUMPTION (
+                SpecialRegions[SpecialRegionIndex].Start,
+                SpecialRegions[SpecialRegionIndex].Start + SpecialRegions[SpecialRegionIndex].Length,
+                Map[Index].LinearAddress,
+                Map[Index].LinearAddress + Map[Index].Length
+                ) &&
+              (SpecialRegions[SpecialRegionIndex].EfiAttributes == 0))
+          {
+            IgnoreRWXAddress = TRUE;
+            break;
+          }
+        }
+      }
+
+      if (!IgnoreRWXAddress) {
+        UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Map[Index].LinearAddress, Map[Index].LinearAddress + Map[Index].Length);
+        FoundRWXAddress = TRUE;
+      } else {
+        UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Map[Index].LinearAddress, Map[Index].LinearAddress + Map[Index].Length);
+      }
+    }
+  }
+
+  UT_ASSERT_FALSE (FoundRWXAddress);
+
+  return UNIT_TEST_PASSED;
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/Driver/DxePagingAuditDriver.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/Driver/DxePagingAuditDriver.c
@@ -14,6 +14,23 @@ UINTN  mMemoryInfoDatabaseSize      = 0;
 UINTN  mMemoryInfoDatabaseAllocSize = 0;
 
 /**
+   Event notification handler. Will dump paging information to disk.
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+
+**/
+VOID
+EFIAPI
+DumpPagingInfoEvent (
+  IN      EFI_EVENT  Event,
+  IN      VOID       *Context
+  )
+{
+  DumpPagingInfo (NULL);
+}
+
+/**
   PagingAuditDriverEntryPoint
 
   @param[in] ImageHandle  The firmware allocated handle for the EFI image.
@@ -38,7 +55,7 @@ PagingAuditDriverEntryPoint (
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
                   TPL_CALLBACK,
-                  DumpPagingInfo,
+                  DumpPagingInfoEvent,
                   NULL,
                   &gMuEventPreExitBootServicesGuid,
                   &Event

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -26,12 +26,17 @@
 [Sources.X64]
   X64/PagingAuditProcessor.c
 
+[Sources.AARCH64]
+  AArch64/PagingAuditProcessor.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
   UefiTestingPkg/UefiTestingPkg.dec
+  
+[Packages.AARCH64]
+  ArmPkg/ArmPkg.dec
 
 [LibraryClasses]
   UefiDriverEntryPoint
@@ -40,9 +45,14 @@
   UefiBootServicesTableLib
   UefiLib
   PeCoffGetEntryPointLib
-  UefiCpuLib
   HobLib
   DxeServicesTableLib
+
+[LibraryClasses.AARCH64]
+  ArmLib
+
+[LibraryClasses.X64]
+  UefiCpuLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -18,13 +18,20 @@
 
 [Sources]
   Dxe/App/DxePagingAuditTestApp.c
+  Dxe/App/DxePagingAuditTestApp.h
   PagingAuditCommon.c
   PagingAuditCommon.h
 
-
 [Sources.X64]
   X64/PagingAuditProcessor.c
+  Dxe/App/X64/DxePagingAuditTests.c
 
+[Sources.AARCH64]
+  AArch64/PagingAuditProcessor.c
+  Dxe/App/AArch64/DxePagingAuditTests.c
+  
+[Packages.AARCH64]
+  ArmPkg/ArmPkg.dec
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -41,12 +48,18 @@
   PeCoffGetEntryPointLib
   UefiApplicationEntryPoint
   ShellLib
-  UefiCpuLib
   HobLib
   DxeServicesTableLib
   UnitTestLib
-  CpuPageTableLib
   DxeMemoryProtectionHobLib
+  FileHandleLib
+
+[LibraryClasses.AARCH64]
+  ArmLib
+
+[LibraryClasses.X64]
+  UefiCpuLib
+  CpuPageTableLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -38,112 +38,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define IndexToAddress(a, b, c, d)  ((UINT64) ((UINT64)a << 39) + ((UINT64)b << 30) + ((UINT64)c <<  21) + ((UINT64)d << 12))
 
-#define AMD_64_SMM_ADDR  0xC0010112
-#define AMD_64_SMM_MASK  0xC0010113
-
-#define VALID_SMRR_LOW_POS   BIT17
-#define VALID_SMRR_HIGH_POS  BIT51
-#define VALID_SMRR_BIT_MASK  (~(~(BIT51 - 1) | (BIT17 - 1)))
-
 #define TSEG_EFI_MEMORY_TYPE  (EfiMaxMemoryType + 1)
 #define NONE_GCD_MEMORY_TYPE  (EfiGcdMemoryTypeMaximum + 1)
 #define NONE_EFI_MEMORY_TYPE  (EfiMaxMemoryType + 2)
-
-#pragma pack(1)
-
-//
-// Page-Map Level-4 Offset (PML4) and
-// Page-Directory-Pointer Offset (PDPE) entries 4K & 2MB
-//
-typedef union {
-  struct {
-    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
-    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
-    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
-    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
-    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
-    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
-    UINT64    Reserved             : 1;  // Reserved
-    UINT64    MustBeZero           : 2;  // Must Be Zero
-    UINT64    Available            : 3;  // Available for use by system software
-    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
-    UINT64    AvailableHigh        : 11; // Available for use by system software
-    UINT64    Nx                   : 1;  // No Execute bit
-  } Bits;
-  UINT64    Uint64;
-} PAGE_MAP_AND_DIRECTORY_POINTER;
-
-//
-// Page Table Entry 4KB
-//
-typedef union {
-  struct {
-    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
-    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
-    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
-    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
-    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
-    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
-    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
-    UINT64    PAT                  : 1;  //
-    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
-    UINT64    Available            : 3;  // Available for use by system software
-    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
-    UINT64    AvailableHigh        : 11; // Available for use by system software
-    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
-  } Bits;
-  UINT64    Uint64;
-} PAGE_TABLE_4K_ENTRY;
-
-//
-// Page Table Entry 2MB
-//
-typedef union {
-  struct {
-    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
-    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
-    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
-    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
-    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
-    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
-    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
-    UINT64    MustBe1              : 1;  // Must be 1
-    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
-    UINT64    Available            : 3;  // Available for use by system software
-    UINT64    PAT                  : 1;  //
-    UINT64    MustBeZero           : 8;  // Must be zero;
-    UINT64    PageTableBaseAddress : 31; // Page Table Base Address
-    UINT64    AvailableHigh        : 11; // Available for use by system software
-    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
-  } Bits;
-  UINT64    Uint64;
-} PAGE_TABLE_ENTRY;
-
-//
-// Page Table Entry 1GB
-//
-typedef union {
-  struct {
-    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
-    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
-    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
-    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
-    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
-    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
-    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
-    UINT64    MustBe1              : 1;  // Must be 1
-    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
-    UINT64    Available            : 3;  // Available for use by system software
-    UINT64    PAT                  : 1;  //
-    UINT64    MustBeZero           : 17; // Must be zero;
-    UINT64    PageTableBaseAddress : 22; // Page Table Base Address
-    UINT64    AvailableHigh        : 11; // Available for use by system software
-    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
-  } Bits;
-  UINT64    Uint64;
-} PAGE_TABLE_1G_ENTRY;
-
-#pragma pack()
 
 /**
   Calculate the maximum support address.
@@ -186,17 +83,15 @@ DumpProcessorSpecificHandlers (
   );
 
 /**
-   Event notification handler. Will dump paging information to disk.
+   Dumps paging information to open EFI_FILE Fs_Handle if provided and the EFI partition otherwise.
 
-  @param[in]  Event     Event whose notification function is being invoked
-  @param[in]  Context   Pointer to the notification function's context
+  @param[in]  Fs_Handle File handle to deposit the paging audit info
 
 **/
 VOID
 EFIAPI
 DumpPagingInfo (
-  IN      EFI_EVENT  Event,
-  IN      VOID       *Context
+  IN      EFI_FILE  *Fs_Handle
   );
 
 /**
@@ -240,6 +135,55 @@ VOID
 EFIAPI
 MemoryAttributesTableDump (
   VOID
+  );
+
+/**
+  Calculate the maximum physical address bits supported.
+
+  @return the maximum support physical address bits supported.
+**/
+UINT8
+EFIAPI
+CalculateMaximumSupportAddressBits (
+  VOID
+  );
+
+/**
+  This helper function walks the page tables to retrieve:
+  - a count of each entry
+  - a count of each directory entry
+  - [optional] a flat list of each entry
+  - [optional] a flat list of each directory entry
+
+  @param[in, out]   Pte1GCount, Pte2MCount, Pte4KCount, PdeCount
+      On input, the number of entries that can fit in the corresponding buffer (if provided).
+      It is expected that this will be zero if the corresponding buffer is NULL.
+      On output, the number of entries that were encountered in the page table.
+  @param[out]       Pte1GEntries, Pte2MEntries, Pte4KEntries, PdeEntries
+      A buffer which will be filled with the entries that are encountered in the tables.
+
+  @retval     EFI_SUCCESS             All requested data has been returned.
+  @retval     EFI_INVALID_PARAMETER   One or more of the count parameter pointers is NULL.
+  @retval     EFI_INVALID_PARAMETER   Presence of buffer counts and pointers is incongruent.
+  @retval     EFI_BUFFER_TOO_SMALL    One or more of the buffers was insufficient to hold
+                                      all of the entries in the page tables. The counts
+                                      have been updated with the total number of entries
+                                      encountered.
+
+**/
+EFI_STATUS
+EFIAPI
+GetFlatPageTableData (
+  IN OUT UINTN  *Pte1GCount,
+  IN OUT UINTN  *Pte2MCount,
+  IN OUT UINTN  *Pte4KCount,
+  IN OUT UINTN  *PdeCount,
+  IN OUT UINTN  *GuardCount,
+  OUT UINT64    *Pte1GEntries,
+  OUT UINT64    *Pte2MEntries,
+  OUT UINT64    *Pte4KEntries,
+  OUT UINT64    *PdeEntries,
+  OUT UINT64    *GuardEntries
   );
 
 /**

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/Driver/SmmPagingAuditDriver.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/Driver/SmmPagingAuditDriver.c
@@ -198,7 +198,7 @@ GdtDumpHandler (
 **/
 STATIC
 EFI_STATUS
-GetFlatPageTableData (
+GetFlatPageTableDataSmm (
   IN OUT UINTN             *Pte1GCount,
   IN OUT UINTN             *Pte2MCount,
   IN OUT UINTN             *Pte4KCount,
@@ -364,13 +364,13 @@ GetFlatPageTableData (
   *PdeCount   = MyPdeCount;
 
   return Status;
-} // GetFlatPageTableData()
+} // GetFlatPageTableDataSmm()
 
 /**
-  This is a helper function that wraps GetFlatPageTableData(),
+  This is a helper function that wraps GetFlatPageTableDataSmm(),
   and abstracts the call->allocate->call pattern.
 
-  @params are virtually identical to GetFlatPageTableData() except:
+  @params are virtually identical to GetFlatPageTableDataSmm() except:
     - all params are OUTs
     - Entries are pointer-pointers to handle buffer allocation
 
@@ -399,7 +399,7 @@ LoadFlatPageTableData (
   *Pte2MCount = 0;
   *Pte4KCount = 0;
   *PdeCount   = 0;
-  Status      = GetFlatPageTableData (Pte1GCount, Pte2MCount, Pte4KCount, PdeCount, NULL, NULL, NULL, NULL);
+  Status      = GetFlatPageTableDataSmm (Pte1GCount, Pte2MCount, Pte4KCount, PdeCount, NULL, NULL, NULL, NULL);
 
   // Allocate buffers if successful.
   if (!EFI_ERROR (Status)) {
@@ -420,7 +420,7 @@ LoadFlatPageTableData (
   // If still good, grab the data.
   if (!EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "%a - Second call to grab the data.\n", __FUNCTION__));
-    Status = GetFlatPageTableData (
+    Status = GetFlatPageTableDataSmm (
                Pte1GCount,
                Pte2MCount,
                Pte4KCount,

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/SmmPagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/SmmPagingAuditCommon.h
@@ -33,6 +33,98 @@ typedef struct {
 #define SMM_PAGE_AUDIT_CLEAR_DATA_REQUEST  0x04
 
 //
+// Page-Map Level-4 Offset (PML4) and
+// Page-Directory-Pointer Offset (PDPE) entries 4K & 2MB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Reserved             : 1;  // Reserved
+    UINT64    MustBeZero           : 2;  // Must Be Zero
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // No Execute bit
+  } Bits;
+  UINT64    Uint64;
+} PAGE_MAP_AND_DIRECTORY_POINTER;
+
+//
+// Page Table Entry 4KB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    PAT                  : 1;  //
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_4K_ENTRY;
+
+//
+// Page Table Entry 2MB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    MustBe1              : 1;  // Must be 1
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PAT                  : 1;  //
+    UINT64    MustBeZero           : 8;  // Must be zero;
+    UINT64    PageTableBaseAddress : 31; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_ENTRY;
+
+//
+// Page Table Entry 1GB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    MustBe1              : 1;  // Must be 1
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PAT                  : 1;  //
+    UINT64    MustBeZero           : 17; // Must be zero;
+    UINT64    PageTableBaseAddress : 22; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_1G_ENTRY;
+
+//
 // Structures for page table entries and miscellaneous memory
 // information from SMM.
 //

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -1,22 +1,159 @@
 /** @file -- PagingAuditProcessor.c
-Platform specific memory handler dump function. Handler(s) need to be in compliance
-with existed Windows\PagingReportGenerator.py, i.e. TSEG.
+
+Platform specific memory audit functions.
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
-/**
 
-Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
-
-SPDX-License-Identifier: BSD-2-Clause-Patent
-
-**/
-
+#include "../PagingAuditCommon.h"
 #include <Register/Msr.h>
 #include <Library/UefiCpuLib.h>
-#include "../PagingAuditCommon.h"
+#include <Pi/PiHob.h>
+#include <Library/HobLib.h>
+
+#define AMD_64_SMM_ADDR  0xC0010112
+#define AMD_64_SMM_MASK  0xC0010113
+
+#define VALID_SMRR_LOW_POS   BIT17
+#define VALID_SMRR_HIGH_POS  BIT51
+#define VALID_SMRR_BIT_MASK  (~(~(BIT51 - 1) | (BIT17 - 1)))
+
+extern MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol;
+
+//
+// Page-Map Level-4 Offset (PML4) and
+// Page-Directory-Pointer Offset (PDPE) entries 4K & 2MB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Reserved             : 1;  // Reserved
+    UINT64    MustBeZero           : 2;  // Must Be Zero
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // No Execute bit
+  } Bits;
+  UINT64    Uint64;
+} PAGE_MAP_AND_DIRECTORY_POINTER;
+
+//
+// Page Table Entry 4KB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    PAT                  : 1;  //
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PageTableBaseAddress : 40; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_4K_ENTRY;
+
+//
+// Page Table Entry 2MB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    MustBe1              : 1;  // Must be 1
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PAT                  : 1;  //
+    UINT64    MustBeZero           : 8;  // Must be zero;
+    UINT64    PageTableBaseAddress : 31; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_ENTRY;
+
+//
+// Page Table Entry 1GB
+//
+typedef union {
+  struct {
+    UINT64    Present              : 1;  // 0 = Not present in memory, 1 = Present in memory
+    UINT64    ReadWrite            : 1;  // 0 = Read-Only, 1= Read/Write
+    UINT64    UserSupervisor       : 1;  // 0 = Supervisor, 1=User
+    UINT64    WriteThrough         : 1;  // 0 = Write-Back caching, 1=Write-Through caching
+    UINT64    CacheDisabled        : 1;  // 0 = Cached, 1=Non-Cached
+    UINT64    Accessed             : 1;  // 0 = Not accessed, 1 = Accessed (set by CPU)
+    UINT64    Dirty                : 1;  // 0 = Not Dirty, 1 = written by processor on access to page
+    UINT64    MustBe1              : 1;  // Must be 1
+    UINT64    Global               : 1;  // 0 = Not global page, 1 = global page TLB not cleared on CR3 write
+    UINT64    Available            : 3;  // Available for use by system software
+    UINT64    PAT                  : 1;  //
+    UINT64    MustBeZero           : 17; // Must be zero;
+    UINT64    PageTableBaseAddress : 22; // Page Table Base Address
+    UINT64    AvailableHigh        : 11; // Available for use by system software
+    UINT64    Nx                   : 1;  // 0 = Execute Code, 1 = No Code Execution
+  } Bits;
+  UINT64    Uint64;
+} PAGE_TABLE_1G_ENTRY;
+
+/**
+  Calculate the maximum physical address bits supported.
+
+  @return the maximum support physical address bits supported.
+**/
+UINT8
+EFIAPI
+CalculateMaximumSupportAddressBits (
+  VOID
+  )
+{
+  UINT32  RegEax;
+  UINT8   PhysicalAddressBits;
+  VOID    *Hob;
+
+  //
+  // Get physical address bits supported.
+  //
+  Hob = GetFirstHob (EFI_HOB_TYPE_CPU);
+  if (Hob != NULL) {
+    PhysicalAddressBits = ((EFI_HOB_CPU *)Hob)->SizeOfMemorySpace;
+  } else {
+    // Ref. 1: Intel Software Developer's Manual Vol.2, Chapter 3, Section "CPU-Identification".
+    // Ref. 2: AMD Software Developer's Manual Vol. 3, Appendix E.
+    // Use the 0x80000000 in EAX to determine the largest extended function this CPU supports
+    AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
+    if (RegEax >= 0x80000008) {
+      // If 0x80000008 is supported, query the supported physical address size with it
+      AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
+      PhysicalAddressBits = (UINT8)RegEax;
+    } else {
+      // Note: below assumption is only found in Intel Software Developer's Manual Vol.3A, 11.11.2.3
+      // If CPUID.80000008H is not available, software may assume that the processor supports
+      // a 36-bit physical address size
+      PhysicalAddressBits = 36;
+    }
+  }
+
+  return PhysicalAddressBits;
+}
 
 /**
   Initializes the valid bits mask and valid address mask for MTRRs.
@@ -371,6 +508,215 @@ TSEGDumpHandler (
 
   return EFI_SUCCESS;
 }
+
+/**
+  This helper function walks the page tables to retrieve:
+  - a count of each entry
+  - a count of each directory entry
+  - [optional] a flat list of each entry
+  - [optional] a flat list of each directory entry
+
+  @param[in, out]   Pte1GCount, Pte2MCount, Pte4KCount, PdeCount
+      On input, the number of entries that can fit in the corresponding buffer (if provided).
+      It is expected that this will be zero if the corresponding buffer is NULL.
+      On output, the number of entries that were encountered in the page table.
+  @param[out]       Pte1GEntries, Pte2MEntries, Pte4KEntries, PdeEntries
+      A buffer which will be filled with the entries that are encountered in the tables.
+
+  @retval     EFI_SUCCESS             All requested data has been returned.
+  @retval     EFI_INVALID_PARAMETER   One or more of the count parameter pointers is NULL.
+  @retval     EFI_INVALID_PARAMETER   Presence of buffer counts and pointers is incongruent.
+  @retval     EFI_BUFFER_TOO_SMALL    One or more of the buffers was insufficient to hold
+                                      all of the entries in the page tables. The counts
+                                      have been updated with the total number of entries
+                                      encountered.
+
+**/
+EFI_STATUS
+EFIAPI
+GetFlatPageTableData (
+  IN OUT UINTN  *Pte1GCount,
+  IN OUT UINTN  *Pte2MCount,
+  IN OUT UINTN  *Pte4KCount,
+  IN OUT UINTN  *PdeCount,
+  IN OUT UINTN  *GuardCount,
+  OUT UINT64    *Pte1GEntries,
+  OUT UINT64    *Pte2MEntries,
+  OUT UINT64    *Pte4KEntries,
+  OUT UINT64    *PdeEntries,
+  OUT UINT64    *GuardEntries
+  )
+{
+  EFI_STATUS                      Status = EFI_SUCCESS;
+  PAGE_MAP_AND_DIRECTORY_POINTER  *Work;
+  PAGE_MAP_AND_DIRECTORY_POINTER  *Pml4;
+  PAGE_TABLE_1G_ENTRY             *Pte1G;
+  PAGE_TABLE_ENTRY                *Pte2M;
+  PAGE_TABLE_4K_ENTRY             *Pte4K;
+  UINTN                           Index1;
+  UINTN                           Index2;
+  UINTN                           Index3;
+  UINTN                           Index4;
+  UINTN                           MyGuardCount        = 0;
+  UINTN                           MyPdeCount          = 0;
+  UINTN                           My4KCount           = 0;
+  UINTN                           My2MCount           = 0;
+  UINTN                           My1GCount           = 0;
+  UINTN                           NumPage4KNotPresent = 0;
+  UINTN                           NumPage2MNotPresent = 0;
+  UINTN                           NumPage1GNotPresent = 0;
+  UINT64                          Address;
+
+  //
+  // First, fail fast if some of the parameters don't look right.
+  //
+  // ALL count parameters should be provided.
+  if ((Pte1GCount == NULL) || (Pte2MCount == NULL) || (Pte4KCount == NULL) || (PdeCount == NULL) || (GuardCount == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // If a count is greater than 0, the corresponding buffer pointer MUST be provided.
+  // It will be assumed that all buffers have space for any corresponding count.
+  if (((*Pte1GCount > 0) && (Pte1GEntries == NULL)) || ((*Pte2MCount > 0) && (Pte2MEntries == NULL)) ||
+      ((*Pte4KCount > 0) && (Pte4KEntries == NULL)) || ((*PdeCount > 0) && (PdeEntries == NULL)) ||
+      ((*GuardCount > 0) && (GuardEntries == NULL)))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Alright, let's get to work.
+  //
+  Pml4 = (PAGE_MAP_AND_DIRECTORY_POINTER *)AsmReadCr3 ();
+  // Increase the count.
+  // If we have room for more PDE Entries, add one.
+  MyPdeCount++;
+  if (MyPdeCount <= *PdeCount) {
+    PdeEntries[MyPdeCount-1] = (UINT64)(UINTN)Pml4;
+  }
+
+  for (Index4 = 0x0; Index4 < 0x200; Index4++) {
+    if (!Pml4[Index4].Bits.Present) {
+      continue;
+    }
+
+    Pte1G = (PAGE_TABLE_1G_ENTRY *)(UINTN)(Pml4[Index4].Bits.PageTableBaseAddress << 12);
+    // Increase the count.
+    // If we have room for more PDE Entries, add one.
+    MyPdeCount++;
+    if (MyPdeCount <= *PdeCount) {
+      PdeEntries[MyPdeCount-1] = (UINT64)(UINTN)Pte1G;
+    }
+
+    for (Index3 = 0x0; Index3 < 0x200; Index3++ ) {
+      if (!Pte1G[Index3].Bits.Present) {
+        NumPage1GNotPresent++;
+        continue;
+      }
+
+      //
+      // MustBe1 is the bit that indicates whether the pointer is a directory
+      // pointer or a page table entry.
+      //
+      if (!(Pte1G[Index3].Bits.MustBe1)) {
+        //
+        // We have to cast 1G and 2M directories to this to
+        // get all of their address bits.
+        //
+        Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte1G;
+        Pte2M = (PAGE_TABLE_ENTRY *)(UINTN)(Work[Index3].Bits.PageTableBaseAddress << 12);
+        // Increase the count.
+        // If we have room for more PDE Entries, add one.
+        MyPdeCount++;
+        if (MyPdeCount <= *PdeCount) {
+          PdeEntries[MyPdeCount-1] = (UINT64)(UINTN)Pte2M;
+        }
+
+        for (Index2 = 0x0; Index2 < 0x200; Index2++ ) {
+          if (!Pte2M[Index2].Bits.Present) {
+            NumPage2MNotPresent++;
+            continue;
+          }
+
+          if (!(Pte2M[Index2].Bits.MustBe1)) {
+            Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte2M;
+            Pte4K = (PAGE_TABLE_4K_ENTRY *)(UINTN)(Work[Index2].Bits.PageTableBaseAddress << 12);
+            // Increase the count.
+            // If we have room for more PDE Entries, add one.
+            MyPdeCount++;
+            if (MyPdeCount <= *PdeCount) {
+              PdeEntries[MyPdeCount-1] = (UINT64)(UINTN)Pte4K;
+            }
+
+            for (Index1 = 0x0; Index1 < 0x200; Index1++ ) {
+              if (!Pte4K[Index1].Bits.Present) {
+                NumPage4KNotPresent++;
+                Address = IndexToAddress (Index4, Index3, Index2, Index1);
+                if ((mMemoryProtectionProtocol != NULL) && (mMemoryProtectionProtocol->IsGuardPage (Address))) {
+                  MyGuardCount++;
+                  if (MyGuardCount <= *GuardCount) {
+                    GuardEntries[MyGuardCount - 1] = Address;
+                  }
+
+                  continue;
+                }
+              }
+
+              // Increase the count.
+              // If we have room for more Page Table entries, add one.
+              My4KCount++;
+              if (My4KCount <= *Pte4KCount) {
+                Pte4KEntries[My4KCount-1] = Pte4K[Index1].Uint64;
+              }
+            }
+          } else {
+            // Increase the count.
+            // If we have room for more Page Table entries, add one.
+            My2MCount++;
+            if (My2MCount <= *Pte2MCount) {
+              Pte2MEntries[My2MCount-1] = Pte2M[Index2].Uint64;
+            }
+          }
+        }
+      } else {
+        // Increase the count.
+        // If we have room for more Page Table entries, add one.
+        My1GCount++;
+        if (My1GCount <= *Pte1GCount) {
+          Pte1GEntries[My1GCount-1] = Pte1G[Index3].Uint64;
+        }
+      }
+    }
+  }
+
+  DEBUG ((DEBUG_ERROR, "Pages used for Page Tables   = %d\n", MyPdeCount));
+  DEBUG ((DEBUG_ERROR, "Number of   4K Pages active  = %d - NotPresent = %d\n", My4KCount, NumPage4KNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   2M Pages active  = %d - NotPresent = %d\n", My2MCount, NumPage2MNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   1G Pages active  = %d - NotPresent = %d\n", My1GCount, NumPage1GNotPresent));
+  DEBUG ((DEBUG_ERROR, "Number of   Guard Pages active  = %d\n", MyGuardCount));
+
+  //
+  // determine whether any of the buffers were too small.
+  // Only matters if a given buffer was provided.
+  //
+  if (((Pte1GEntries != NULL) && (*Pte1GCount < My1GCount)) || ((Pte2MEntries != NULL) && (*Pte2MCount < My2MCount)) ||
+      ((Pte4KEntries != NULL) && (*Pte4KCount < My4KCount)) || ((PdeEntries != NULL) && (*PdeCount < MyPdeCount)) ||
+      ((GuardEntries != NULL) && (*GuardCount < MyGuardCount)))
+  {
+    Status = EFI_BUFFER_TOO_SMALL;
+  }
+
+  //
+  // Update all the return pointers.
+  //
+  *Pte1GCount = My1GCount;
+  *Pte2MCount = My2MCount;
+  *Pte4KCount = My4KCount;
+  *PdeCount   = MyPdeCount;
+  *GuardCount = MyGuardCount;
+
+  return Status;
+} // GetFlatPageTableData()
 
 /**
    Dump platform specific handler. Created handler(s) need to be compliant with


### PR DESCRIPTION
## Description

Update the DxePagingAuditTestApp and DxePagingAuditDriver to enable the collection of Arm64 translation tables.

The interfaces remain the same. However, this update changes the behavior of DxePagingAuditTestApp to write the paging output to the volume containing the app itself instead of the EFI partition (if possible) which is much more convenient because the files don't need to be copied out of the partition for parsing and an OS image isn't necessary to audit the page table on QEMU.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The x86 side was tested via the page table parsing scripts to ensure the output is comparable. The Arm64 translation table collection was tested on ARM Surface platforms and our QEMU-based ARM platform. The collected data was tested using the updates to the parsing scripts in a separate PR.

## Integration Instructions

N/A
