### PR TITLE
Adding customizable GUID for BERT extra variables support

### DIFF
--- a/MsWheaPkg/HwErrBert/HwErrBert.inf
+++ b/MsWheaPkg/HwErrBert/HwErrBert.inf
@@ -57,6 +57,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision
   gMsWheaPkgTokenSpaceGuid.PcdBertEntriesVariableNames
+  gMsWheaPkgTokenSpaceGuid.PcdBertEntriesVariableGuid
 
 [Guids]
   gEfiHardwareErrorVariableGuid       ## CONSUMES

--- a/MsWheaPkg/MsWheaPkg.dec
+++ b/MsWheaPkg/MsWheaPkg.dec
@@ -71,6 +71,11 @@
   gMsWheaPkgTokenSpaceGuid.PcdDeviceIdentifierGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}|VOID*|0x00000004
 
   # Variable names intended for extra BERT table entries, should be unicode string separated by ';'.
-  # Note: The variables for potential BERT candidate should be stored under GUID gEfiHardwareErrorVariableGuid.
-  #       If such variable exists, its content MUST comply with CPER error format.
+  # Note: The variables for potential BERT candidate should be stored under namespace GUID PcdBertEntriesVariableGuid.
+  #       If such variables exist, its content MUST comply with CPER error format.
   gMsWheaPkgTokenSpaceGuid.PcdBertEntriesVariableNames|L""|VOID*|0x00000007
+
+  # Variable Guid intended for extra BERT table entries, default to gEfiHardwareErrorVariableGuid.
+  # Variables stored with PcdBertEntriesVariableGuid as GUID and PcdBertEntriesVariableNames as names
+  # will be collected and convert into BERT table during boot table for error reporting purpose.
+  gMsWheaPkgTokenSpaceGuid.PcdBertEntriesVariableGuid|{GUID("414E6BDD-E47B-47CC-B244-BB61020CF516")}|VOID*|0x00000008


### PR DESCRIPTION
## Description

Current implement will allow extra variables with names specified under
`PcdBertEntriesVariableNames` and namespace GUID being
`gEfiHardwareErrorVariableGuid` to be collected into BERT table for OS
consumption.

However, variables under `gEfiHardwareErrorVariableGuid` has certain
restrictions that does not allow random variable names to be used and
could potentially clash with `HwErrRec####` occupied by other firmware
entities.

This change will add the flexibility for the platform to specify their own
variable GUID to be collected during boot for BERT table usage.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on QEMU virtual systems and proprietary physical devices.

## Integration Instructions

For platforms that need to support specific CPER formatted variables
coalition into the BERT table, one should override the PCD value of
`gMsWheaPkgTokenSpaceGuid.PcdBertEntriesVariableGuid` of their choices.
Otherwise, `gEfiHardwareErrorVariableGuid` will be the default value and
certain variable naming schema might restrict the specific use case.
