### PR TITLE
Fix SUIT bitmap set bounds - shouldn't apply a second translation to the new bounds origin.

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/Bitmap.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/Bitmap.c
@@ -47,20 +47,11 @@ SetControlBounds (
   IN SWM_RECT  Bounds
   )
 {
-  EFI_STATUS  Status  = EFI_SUCCESS;
-  INT32       XOffset = (Bounds.Left - this->m_BitmapBounds.Left);
-  INT32       YOffset = (Bounds.Top  - this->m_BitmapBounds.Top);
+  EFI_STATUS  Status = EFI_SUCCESS;
 
-  // Translate (and possibly truncate) the current bitmap bounding box.
+  // Translate the current bitmap bounding box.
   //
   CopyMem (&this->m_BitmapBounds, &Bounds, sizeof (SWM_RECT));
-
-  // Also translate the bounding box limit.
-  //
-  this->m_BitmapBounds.Left   += XOffset;
-  this->m_BitmapBounds.Right  += XOffset;
-  this->m_BitmapBounds.Top    += YOffset;
-  this->m_BitmapBounds.Bottom += YOffset;
 
   return Status;
 }


### PR DESCRIPTION
## Description

The SUIT bitmap element's setbounds routine should not apply a secondary offset to the bounds provided (this was meant to adjust the max bounds in other elements but it doesn't exist for a bitmap element).

- [ ] Breaking change?

This is not a breaking change and fixes placement, usually when added to the canvas via a grid.

## How This Was Tested

Tested with a custom program (cBMR download application which will be pushed shortly). FrontPage is currently not displaying any bitmaps.

BACKPORT from 202208

(cherry picked from commit 60d3c459e981af7fc7b3ae44ab79b2f27176b200)