### PR TITLE
Change GCD Type Print Formatting to Fix Paging Audit Parsing

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -796,7 +796,7 @@ MemoryMapDumpHandler (
       AsciiSPrint (
         TempString,
         MAX_STRING_SIZE,
-        "MemoryMap,0x%016lx,0x%016lx,0x%016lx,0x%016lx,0x%016lx,0x%016lx\n",
+        "MemoryMap,0x%016lx,0x%016lx,0x%016lx,0x%016lx,0x%016lx,0x%x\n",
         EfiMemNext->Type,
         EfiMemNext->PhysicalStart,
         EfiMemNext->VirtualStart,


### PR DESCRIPTION
## Description

When dumping the MemoryInfoDatabase.dat on some platforms, the printed GCD type (MemorySpaceType) had its most significant bit set which caused the GCD type to not be parsed. MemorySpaceType is an enum, so the bit being set was just a print formatting artifact. To remove this artifact, this update prints MemorySpaceType as %x instead 0f %x016lx.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running the audit

## Integration Instructions

N/A