### PR TITLE
Changed FreeRamForSEC to not use passed Address since is can be Memory Address

### DIFF
--- a/AdvLoggerPkg/Library/DebugAgent/Sec/ia32/RamForSEC.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/ia32/RamForSEC.c
@@ -248,7 +248,6 @@ FreeRamForSEC (
   UINT64                           MtrrValidBitsMask;
   UINT32                           VariableMtrrCount;
 
-  ASSERT (Address == FixedPcdGet64 (PcdAdvancedLoggerCarBase));
 
   InitializeMtrrMask (&MtrrValidBitsMask, &MtrrValidAddressMask);
 
@@ -261,7 +260,7 @@ FreeRamForSEC (
     Mask.Uint64 = AsmReadMsr64 (MSR_IA32_MTRR_PHYSMASK0 + (Index << 1));
 
     if ((Mask.Bits.V == 1) &&
-        ((Base.Uint64 && MtrrValidAddressMask) == Address))
+        ((Base.Uint64 && MtrrValidAddressMask) == FixedPcdGet64 (PcdAdvancedLoggerCarBase)))
     {
       AsmWriteMsr64 (
         MSR_IA32_MTRR_PHYSMASK0 + (Index << 1),


### PR DESCRIPTION
When FreeRamForSEC is called, the passed address can be a memory address and not CAR base.

This PR removes the assert checking if the passed address matches PcdAdvancedLoggerCarBase, and modifies the MTRR teardown logic to search for the PcdAdvancedLoggerCarBase instead of the passed address. 

## Description

While transitioning to memory, the platform under test was passing a memory address.

In InitializeDebugAgent(), Memory is allocated and the log is transitioned, but the logbuffer was being passed to FreeRamForSEC after it was transitioned to memory, causing the assert to trip. 


- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Ran on emulated platform and verified that logs were still available. 

## Integration Instructions
N/A