### PR TITLE
Add Stack and NULL Page Data Collection to the DXE Paging Audit

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -47,6 +47,7 @@
   PeCoffGetEntryPointLib
   HobLib
   DxeServicesTableLib
+  DxeMemoryProtectionHobLib
 
 [LibraryClasses.AARCH64]
   ArmLib
@@ -58,11 +59,13 @@
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
   gMuEventPreExitBootServicesGuid
+  gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
 
 [Protocols]
   gEfiBlockIoProtocolGuid
   gMemoryProtectionDebugProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
+  gCpuMpDebugProtocolGuid
 
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -64,6 +64,7 @@
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
+  gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
 
 [Protocols]
   gEfiBlockIoProtocolGuid
@@ -71,6 +72,7 @@
   gEfiSimpleFileSystemProtocolGuid
   gMemoryProtectionSpecialRegionProtocolGuid
   gEfiShellParametersProtocolGuid
+  gCpuMpDebugProtocolGuid
 
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -1271,15 +1271,11 @@ SpecialMemoryDump (
   while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
     MemoryHob = Hob.MemoryAllocation;
     if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
-      StackBase   = MemoryHob->AllocDescriptor.MemoryBaseAddress;
-      StackLength = MemoryHob->AllocDescriptor.MemoryLength;
+      StackBase   = (EFI_PHYSICAL_ADDRESS)((MemoryHob->AllocDescriptor.MemoryBaseAddress / EFI_PAGE_SIZE) * EFI_PAGE_SIZE);
+      StackLength = (EFI_PHYSICAL_ADDRESS)(EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (MemoryHob->AllocDescriptor.MemoryLength)));
 
       // Capture the stack guard
-      if ((StackLength > EFI_PAGE_SIZE) &&
-          ((StackBase & (EFI_PAGE_SIZE - 1)) == 0) &&
-          ((StackLength & (EFI_PAGE_SIZE - 1)) == 0) &&
-          (gDxeMps.CpuStackGuard == TRUE))
-      {
+      if (gDxeMps.CpuStackGuard == TRUE) {
         AsciiSPrint (
           TempString,
           MAX_STRING_SIZE,

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -14,6 +14,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Pi/PiHob.h>
 #include <Library/HobLib.h>
 #include <Library/DxeServicesTableLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
+#include <Protocol/CpuMpDebug.h>
 
 #define NEXT_MEMORY_SPACE_DESCRIPTOR(MemoryDescriptor, Size) \
   ((EFI_GCD_MEMORY_SPACE_DESCRIPTOR *)((UINT8 *)(MemoryDescriptor) + (Size)))
@@ -83,6 +85,7 @@ OpenVolumeSFS (
   );
 
 MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol = NULL;
+CPU_MP_DEBUG_PROTOCOL             *mCpuMpDebugProtocol       = NULL;
 EFI_FILE                          *mFs_Handle;
 extern CHAR8                      *mMemoryInfoDatabaseBuffer;
 extern UINTN                      mMemoryInfoDatabaseSize;
@@ -105,6 +108,25 @@ PopulateHeapGuardDebugProtocol (
   }
 
   return gBS->LocateProtocol (&gMemoryProtectionDebugProtocolGuid, NULL, (VOID **)&mMemoryProtectionProtocol);
+}
+
+/**
+  Populates the CPU MP debug protocol global
+
+  @retval EFI_SUCCESS Protocol is already populated or was successfully populated
+  @retval other       Return value of LocateProtocol
+**/
+STATIC
+EFI_STATUS
+PopulateCpuMpDebugProtocol (
+  VOID
+  )
+{
+  if (mCpuMpDebugProtocol != NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return gBS->LocateProtocol (&gCpuMpDebugProtocolGuid, NULL, (VOID **)&mCpuMpDebugProtocol);
 }
 
 /**
@@ -1217,6 +1239,124 @@ FlushAndClearMemoryInfoDatabase (
   return EFI_SUCCESS;
 } // FlushAndClearMemoryInfoDatabase()
 
+/*
+  Writes the NULL page and stack information to the memory info database
+ */
+VOID
+EFIAPI
+SpecialMemoryDump (
+  VOID
+  )
+{
+  CHAR8                      TempString[MAX_STRING_SIZE];
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryHob;
+  EFI_STATUS                 Status;
+  LIST_ENTRY                 *List;
+  CPU_MP_DEBUG_PROTOCOL      *Entry;
+  EFI_PHYSICAL_ADDRESS       StackBase;
+  UINT64                     StackLength;
+
+  // Capture the NULL address
+  AsciiSPrint (
+    TempString,
+    MAX_STRING_SIZE,
+    "Null,0x%016lx\n",
+    NULL
+    );
+  AppendToMemoryInfoDatabase (TempString);
+
+  Hob.Raw = GetHobList ();
+
+  while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
+    MemoryHob = Hob.MemoryAllocation;
+    if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
+      StackBase   = MemoryHob->AllocDescriptor.MemoryBaseAddress;
+      StackLength = MemoryHob->AllocDescriptor.MemoryLength;
+
+      // Capture the stack guard
+      if ((StackLength > EFI_PAGE_SIZE) &&
+          ((StackBase & (EFI_PAGE_SIZE - 1)) == 0) &&
+          ((StackLength & (EFI_PAGE_SIZE - 1)) == 0) &&
+          (gDxeMps.CpuStackGuard == TRUE))
+      {
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "StackGuard,0x%016lx,0x%x\n",
+          StackBase,
+          EFI_PAGE_SIZE
+          );
+        AppendToMemoryInfoDatabase (TempString);
+        StackBase   += EFI_PAGE_SIZE;
+        StackLength -= EFI_PAGE_SIZE;
+      }
+
+      // Capture the stack
+      AsciiSPrint (
+        TempString,
+        MAX_STRING_SIZE,
+        "Stack,0x%016lx,0x%016lx\n",
+        StackBase,
+        StackLength
+        );
+      AppendToMemoryInfoDatabase (TempString);
+
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  Status = PopulateCpuMpDebugProtocol ();
+
+  // The protocol should only be published if CpuStackGuard is active
+  if (!EFI_ERROR (Status)) {
+    for (List = mCpuMpDebugProtocol->Link.ForwardLink; List != &mCpuMpDebugProtocol->Link; List = List->ForwardLink) {
+      Entry = CR (
+                List,
+                CPU_MP_DEBUG_PROTOCOL,
+                Link,
+                CPU_MP_DEBUG_SIGNATURE
+                );
+
+      StackBase   = (EFI_PHYSICAL_ADDRESS)Entry->ApStackBuffer;
+      StackLength = (EFI_PHYSICAL_ADDRESS)Entry->ApStackSize;
+
+      if ((StackLength > EFI_PAGE_SIZE) &&
+          ((StackBase & (EFI_PAGE_SIZE - 1)) == 0) &&
+          ((StackLength & (EFI_PAGE_SIZE - 1)) == 0) &&
+          (gDxeMps.CpuStackGuard == TRUE))
+      {
+        // Capture the AP stack guard
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "ApStackGuard,0x%016lx,0x%016lx,0x%x\n",
+          StackBase,
+          EFI_PAGE_SIZE,
+          Entry->CpuNumber
+          );
+        AppendToMemoryInfoDatabase (TempString);
+
+        StackBase   += EFI_PAGE_SIZE;
+        StackLength -= EFI_PAGE_SIZE;
+      }
+
+      // Capture the AP stack
+      AsciiSPrint (
+        TempString,
+        MAX_STRING_SIZE,
+        "ApStack,0x%016lx,0x%016lx,0x%x\n",
+        StackBase,
+        StackLength,
+        Entry->CpuNumber
+        );
+      AppendToMemoryInfoDatabase (TempString);
+    }
+  }
+}
+
 /**
    Dumps paging information to open EFI_FILE Fs_Handle if provided and the EFI partition otherwise.
 
@@ -1294,6 +1434,7 @@ DumpPagingInfo (
   MemoryMapDumpHandler ();
   LoadedImageTableDump ();
   MemoryAttributesTableDump ();
+  SpecialMemoryDump ();
   FlushAndClearMemoryInfoDatabase (L"MemoryInfoDatabase");
 
 Cleanup:

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -1319,40 +1319,48 @@ SpecialMemoryDump (
                 Link,
                 CPU_MP_DEBUG_SIGNATURE
                 );
+      StackBase   = (EFI_PHYSICAL_ADDRESS)((Entry->ApStackBuffer / EFI_PAGE_SIZE) * EFI_PAGE_SIZE);
+      StackLength = (EFI_PHYSICAL_ADDRESS)(EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (Entry->ApStackSize)));
 
-      StackBase   = (EFI_PHYSICAL_ADDRESS)Entry->ApStackBuffer;
-      StackLength = (EFI_PHYSICAL_ADDRESS)Entry->ApStackSize;
+      if (!Entry->IsSwitchStack) {
+        if (gDxeMps.CpuStackGuard == TRUE) {
+          // Capture the AP stack guard
+          AsciiSPrint (
+            TempString,
+            MAX_STRING_SIZE,
+            "ApStackGuard,0x%016lx,0x%016lx,0x%x\n",
+            StackBase,
+            EFI_PAGE_SIZE,
+            Entry->CpuNumber
+            );
+          AppendToMemoryInfoDatabase (TempString);
 
-      if ((StackLength > EFI_PAGE_SIZE) &&
-          ((StackBase & (EFI_PAGE_SIZE - 1)) == 0) &&
-          ((StackLength & (EFI_PAGE_SIZE - 1)) == 0) &&
-          (gDxeMps.CpuStackGuard == TRUE))
-      {
-        // Capture the AP stack guard
+          StackBase   += EFI_PAGE_SIZE;
+          StackLength -= EFI_PAGE_SIZE;
+        }
+
+        // Capture the AP stack
         AsciiSPrint (
           TempString,
           MAX_STRING_SIZE,
-          "ApStackGuard,0x%016lx,0x%016lx,0x%x\n",
+          "ApStack,0x%016lx,0x%016lx,0x%x\n",
           StackBase,
-          EFI_PAGE_SIZE,
+          StackLength,
           Entry->CpuNumber
           );
         AppendToMemoryInfoDatabase (TempString);
-
-        StackBase   += EFI_PAGE_SIZE;
-        StackLength -= EFI_PAGE_SIZE;
+      } else {
+        // Capture the AP switch stack
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "ApSwitchStack,0x%016lx,0x%016lx,0x%x\n",
+          StackBase,
+          StackLength,
+          Entry->CpuNumber
+          );
+        AppendToMemoryInfoDatabase (TempString);
       }
-
-      // Capture the AP stack
-      AsciiSPrint (
-        TempString,
-        MAX_STRING_SIZE,
-        "ApStack,0x%016lx,0x%016lx,0x%x\n",
-        StackBase,
-        StackLength,
-        Entry->CpuNumber
-        );
-      AppendToMemoryInfoDatabase (TempString);
     }
   }
 }

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 
 #include <Protocol/SmmCommunication.h>
+#include <Protocol/CpuMpDebug.h>
 
 #include <Register/Msr.h>
 #include <Register/Cpuid.h>
@@ -28,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/DebugImageInfoTable.h>
 #include <Guid/MemoryAttributesTable.h>
 #include <Guid/PiSmmCommunicationRegionTable.h>
+#include <Guid/DxeMemoryProtectionSettings.h>
 
 #include "../../PagingAuditCommon.h"
 #include "../SmmPagingAuditCommon.h"
@@ -35,9 +37,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 VOID   *mPiSmmCommonCommBufferAddress = NULL;
 UINTN  mPiSmmCommonCommBufferSize;
 
-CHAR8  *mMemoryInfoDatabaseBuffer   = NULL;
-UINTN  mMemoryInfoDatabaseSize      = 0;
-UINTN  mMemoryInfoDatabaseAllocSize = 0;
+CHAR8                           *mMemoryInfoDatabaseBuffer   = NULL;
+UINTN                           mMemoryInfoDatabaseSize      = 0;
+UINTN                           mMemoryInfoDatabaseAllocSize = 0;
+// Added to satisfy gDxeMps use in PagingAuditCommon.c
+DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps                      = DXE_MEMORY_PROTECTION_SETTINGS_OFF;
 
 /**
   This helper function will call to the SMM agent to retrieve the entire contents of the

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
@@ -37,11 +37,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 VOID   *mPiSmmCommonCommBufferAddress = NULL;
 UINTN  mPiSmmCommonCommBufferSize;
 
-CHAR8                           *mMemoryInfoDatabaseBuffer   = NULL;
-UINTN                           mMemoryInfoDatabaseSize      = 0;
-UINTN                           mMemoryInfoDatabaseAllocSize = 0;
+CHAR8  *mMemoryInfoDatabaseBuffer   = NULL;
+UINTN  mMemoryInfoDatabaseSize      = 0;
+UINTN  mMemoryInfoDatabaseAllocSize = 0;
 // Added to satisfy gDxeMps use in PagingAuditCommon.c
-DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps                      = DXE_MEMORY_PROTECTION_SETTINGS_OFF;
+DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps = DXE_MEMORY_PROTECTION_SETTINGS_OFF;
 
 /**
   This helper function will call to the SMM agent to retrieve the entire contents of the

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -49,6 +49,7 @@
   gEfiBlockIoProtocolGuid
   gEfiSmmCommunicationProtocolGuid
   gMemoryProtectionDebugProtocolGuid
+  gCpuMpDebugProtocolGuid
 
 [Guids]
   gEdkiiPiSmmCommunicationRegionTableGuid       ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -54,6 +54,7 @@
   gEdkiiPiSmmCommunicationRegionTableGuid       ## SOMETIMES_CONSUMES ## GUID
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
+  gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
 
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES


### PR DESCRIPTION
## Description

This update adds reporting of the NULL page, DXE stack, and AP stacks via the memory info database.

https://github.com/microsoft/mu_plus/issues/102

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running the Paging Audit on Q35

## Integration Instructions

N/A
