### PR TITLE
PcBdsPkg/ResetIfBootNextFailsDxe: Unregister RSC handler at Exit Boot Services

### DIFF
--- a/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
+++ b/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
@@ -101,7 +101,7 @@ RscHandlerCallback (
       (((Value & EFI_STATUS_CODE_CLASS_MASK)|(Value & EFI_STATUS_CODE_SUBCLASS_MASK)) == (EFI_SOFTWARE | EFI_SOFTWARE_DXE_BS_DRIVER)) &&
       (((Value & EFI_STATUS_CODE_OPERATION_MASK) == EFI_SW_DXE_BS_EC_BOOT_OPTION_FAILED)))
   {
-    DEBUG ((DEBUG_VERBOSE, "[%a] - Checking boot option failure reported from module {%g}.\n", __FUNCTION__, CallerId));
+    DEBUG ((DEBUG_INFO, "[%a] - Checking boot option failure reported from module {%g}.\n", __FUNCTION__, CallerId));
     ProcessLoadOptionFailure (Data);
   }
 

--- a/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
+++ b/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
@@ -101,7 +101,7 @@ RscHandlerCallback (
       (((Value & EFI_STATUS_CODE_CLASS_MASK)|(Value & EFI_STATUS_CODE_SUBCLASS_MASK)) == (EFI_SOFTWARE | EFI_SOFTWARE_DXE_BS_DRIVER)) &&
       (((Value & EFI_STATUS_CODE_OPERATION_MASK) == EFI_SW_DXE_BS_EC_BOOT_OPTION_FAILED)))
   {
-    DEBUG ((DEBUG_INFO, "[%a] - Checking boot option failure reported from module {%g}.\n", __FUNCTION__, CallerId));
+    DEBUG ((DEBUG_VERBOSE, "[%a] - Checking boot option failure reported from module {%g}.\n", __FUNCTION__, CallerId));
     ProcessLoadOptionFailure (Data);
   }
 
@@ -111,13 +111,13 @@ RscHandlerCallback (
 /**
   Unregister the ReportStatusCode handler.
 
-  @param[in]    Event      The Post Ready to Boot event.
+  @param[in]    Event      The Pre-Exit Boot Services event.
   @param[in]    Context    A pointer to the context structure associated with the notification function.
 
 **/
 VOID
 EFIAPI
-OnPostReadyToBootServicesNotification (
+OnPreExitBootServicesNotification (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -171,7 +171,7 @@ ProcessReportStatusCodeHandlerRegistration (
 
 **/
 EFI_STATUS
-ProcessPostReadyToBootServicesRegistration (
+ProcessPreExitBootServicesRegistration (
   VOID
   )
 {
@@ -181,13 +181,13 @@ ProcessPostReadyToBootServicesRegistration (
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
                   TPL_CALLBACK,
-                  OnPostReadyToBootServicesNotification,
+                  OnPreExitBootServicesNotification,
                   gImageHandle,
-                  &gEfiEventPostReadyToBootGuid,
+                  &gMuEventPreExitBootServicesGuid,
                   &InitEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a] - Create Event failed for Post Ready to Boot - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a] - Create Event failed for PreExitBootServices - %r\n", __FUNCTION__, Status));
   }
 
   return Status;
@@ -251,7 +251,7 @@ DxeResetIfBootNextFailsEntry (
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
   } else {
-    Status = ProcessPostReadyToBootServicesRegistration ();
+    Status = ProcessPreExitBootServicesRegistration ();
     ASSERT_EFI_ERROR (Status);
 
     CacheBootNextOption ();

--- a/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
+++ b/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.c
@@ -111,13 +111,13 @@ RscHandlerCallback (
 /**
   Unregister the ReportStatusCode handler.
 
-  @param[in]    Event      The Pre-Exit Boot Services event.
+  @param[in]    Event      The Exit Boot Services event.
   @param[in]    Context    A pointer to the context structure associated with the notification function.
 
 **/
 VOID
 EFIAPI
-OnPreExitBootServicesNotification (
+OnExitBootServicesNotification (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -171,7 +171,7 @@ ProcessReportStatusCodeHandlerRegistration (
 
 **/
 EFI_STATUS
-ProcessPreExitBootServicesRegistration (
+ProcessExitBootServicesRegistration (
   VOID
   )
 {
@@ -181,13 +181,13 @@ ProcessPreExitBootServicesRegistration (
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
                   TPL_CALLBACK,
-                  OnPreExitBootServicesNotification,
+                  OnExitBootServicesNotification,
                   gImageHandle,
-                  &gMuEventPreExitBootServicesGuid,
+                  &gEfiEventExitBootServicesGuid,
                   &InitEvent
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[%a] - Create Event failed for PreExitBootServices - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "[%a] - Create Event failed for ExitBootServices - %r\n", __FUNCTION__, Status));
   }
 
   return Status;
@@ -251,7 +251,7 @@ DxeResetIfBootNextFailsEntry (
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
   } else {
-    Status = ProcessPreExitBootServicesRegistration ();
+    Status = ProcessExitBootServicesRegistration ();
     ASSERT_EFI_ERROR (Status);
 
     CacheBootNextOption ();

--- a/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.inf
+++ b/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.inf
@@ -38,7 +38,7 @@
   UefiRuntimeServicesTableLib
 
 [Guids]
-  gMuEventPreExitBootServicesGuid     ## CONSUMES ## EVENT
+  gEfiEventExitBootServicesGuid       ## CONSUMES ## EVENT
   ## CONSUMES
   ## Variable:L"BootNext"
   ## Variable:L"BootCurrent"

--- a/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.inf
+++ b/PcBdsPkg/ResetIfBootNextFailsDxe/ResetIfBootNextFailsDxe.inf
@@ -38,7 +38,7 @@
   UefiRuntimeServicesTableLib
 
 [Guids]
-  gEfiEventPostReadyToBootGuid     ## CONSUMES ## EVENT
+  gMuEventPreExitBootServicesGuid     ## CONSUMES ## EVENT
   ## CONSUMES
   ## Variable:L"BootNext"
   ## Variable:L"BootCurrent"


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Moves the unregister logic to exit boot services to ensure all
status codes are picked up. We found some expected resets did
not occur at post-Ready to Boot but do at Exit Boot Services.

Avoids the memory issue previously encountered at pre-exit boot
services.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested reset logic and hibernate / non-hibernate boots.

## Integration Instructions

N/A

Co-authored-by: Kenneth Lautner <klautner@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>