### PR TITLE
Modify TPL manipulation in DfciManager RunProcessMailboxes() to be symmetric.

### DIFF
--- a/DfciPkg/DfciManager/DfciManager.c
+++ b/DfciPkg/DfciManager/DfciManager.c
@@ -83,7 +83,8 @@ RunProcessMailBoxes (
 
   ProcessMailBoxes ();
 
-  gBS->RaiseTPL (OldTpl);
+  gBS->RaiseTPL (TPL_NOTIFY);
+  gBS->RestoreTPL (OldTpl);
   return;
 }
 


### PR DESCRIPTION
## Description

Modify TPL manipulation in RunProcessMailBoxes() to be symmetric. This is technically not required by spec, but some partner code makes assumption about TPL symmetry that this helps address.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted with the change on target platforms.

## Integration Instructions

N/A
