### PR TITLE
Update the MemoryProtectionTestApp to use the MemoryAttributeProtocol for Architecture Agnosticism

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
@@ -1353,14 +1353,14 @@ ImageProtection (
       if ((ImageRangeDescriptor->Type == Code) && ((Attributes & EFI_MEMORY_RO) == 0)) {
         TestFailed = TRUE;
         UT_LOG_ERROR (
-          "Memory Range 0x%llx - 0x%llx should be non-executable!",
+          "Memory Range 0x%llx - 0x%llx should be non-writeable!",
           ImageRangeDescriptor->Base,
           ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
           );
       } else if ((ImageRangeDescriptor->Type == Data) && ((Attributes & EFI_MEMORY_XP) == 0)) {
         TestFailed = TRUE;
         UT_LOG_ERROR (
-          "Memory Range 0x%llx - 0x%llx should be non-writeable!",
+          "Memory Range 0x%llx - 0x%llx should be non-executable!",
           ImageRangeDescriptor->Base,
           ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
           );

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
@@ -33,7 +33,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/ResetSystemLib.h>
 #include <Library/HobLib.h>
 #include <Library/ExceptionPersistenceLib.h>
-#include <Library/CpuPageTableLib.h>
 
 #include <Guid/PiSmmCommunicationRegionTable.h>
 #include <Guid/DxeMemoryProtectionSettings.h>

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -40,7 +40,6 @@
   ShellPkg/ShellPkg.dec
   MsCorePkg/MsCorePkg.dec
 
-
 [LibraryClasses]
   DebugLib
   UefiApplicationEntryPoint
@@ -67,6 +66,7 @@
   gEfiCpuArchProtocolGuid                       ## CONSUMES
   gMemoryProtectionNonstopModeProtocolGuid      ## CONSUMES
   gMemoryProtectionDebugProtocolGuid            ## CONSUMES
+  gEfiMemoryAttributeProtocolGuid               ## CONSUMES
 
 [Guids]
   gEdkiiPiSmmCommunicationRegionTableGuid

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -56,7 +56,6 @@
   HwResetSystemLib
   HobLib
   ExceptionPersistenceLib
-  CpuPageTableLib
 
 [Guids]
   gMemoryProtectionExceptionHandlerGuid               ## CONSUMES


### PR DESCRIPTION
## Description

The previous iteration of the Image Protection Test in the MemoryProtectionTestApp utilized the CpuPageTableLib which only had an X64 implementation. Because the EDK2 community has created AARCH64 and X64 implementations of the Memory Attribute Protocol, this PR updates the Image Protection Test to utilize the protocol instead.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the test app on Q35

## Integration Instructions

N/A
