### PR TITLE
Fix for PR 194.  Fix SetCurrentTextString when textbox is not grayed out.

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/EditBox.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/EditBox.c
@@ -323,7 +323,8 @@ SetCurrentTextString (
     if (UIT_EDITBOX_TYPE_PASSWORD != this->m_Type) {
       StrnCpyS (this->m_EditBoxDisplayText, sizeof (this->m_EditBoxDisplayText)/sizeof (CHAR16), NewTextString, (UIT_EDITBOX_MAX_STRING_LENGTH - 1));
     } else {
-      MaxLen = MIN(sizeof(this->m_EditBoxDisplayText), NewTextLen * sizeof (CHAR16));
+      MaxLen = MIN (sizeof (this->m_EditBoxDisplayText), NewTextLen * sizeof (CHAR16));
+
       SetMem16 (this->m_EditBoxDisplayText, MaxLen, CHAR_BULLET_UNICODE);
     }
 

--- a/MsGraphicsPkg/Library/SimpleUIToolKit/EditBox.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/EditBox.c
@@ -306,8 +306,9 @@ SetCurrentTextString (
   IN        CHAR16   *NewTextString
   )
 {
-  BOOLEAN  RenderRequired = FALSE;
   UINT32   NewTextLen;
+  UINT32   MaxLen;
+  BOOLEAN  RenderRequired = FALSE;
 
   NewTextLen = (UINT32)StrnLenS (NewTextString, (UIT_EDITBOX_MAX_STRING_LENGTH - 1));
   // Return a pointer to the editbox string to the caller.
@@ -319,6 +320,13 @@ SetCurrentTextString (
   } else {
     RenderRequired = 0 != StrnCmp (this->m_EditBoxText, NewTextString, UIT_EDITBOX_MAX_STRING_LENGTH - 1);
     StrnCpyS (this->m_EditBoxText, sizeof (this->m_EditBoxText)/sizeof (CHAR16), NewTextString, (UIT_EDITBOX_MAX_STRING_LENGTH - 1));
+    if (UIT_EDITBOX_TYPE_PASSWORD != this->m_Type) {
+      StrnCpyS (this->m_EditBoxDisplayText, sizeof (this->m_EditBoxDisplayText)/sizeof (CHAR16), NewTextString, (UIT_EDITBOX_MAX_STRING_LENGTH - 1));
+    } else {
+      MaxLen = MIN(sizeof(this->m_EditBoxDisplayText), NewTextLen * sizeof (CHAR16));
+      SetMem16 (this->m_EditBoxDisplayText, MaxLen, CHAR_BULLET_UNICODE);
+    }
+
     this->m_CurrentPosition = NewTextLen;
   }
 


### PR DESCRIPTION
# Preface

Fixes #194  

## Description

The EditBox doesn't display initial text when not grayed out.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested


## Integration Instructions

N/A
