### PR TITLE
Add AARCH64 RWX Test to DxePagingAuditApp

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
@@ -6,7 +6,15 @@
 
 **/
 
+#include <Library/ArmLib.h>
+#include <Chipset/AArch64Mmu.h>
 #include "../DxePagingAuditTestApp.h"
+
+#define TT_ADDRESS_MASK  (0xFFFFFFFFFULL << 12)
+#define IS_TABLE(page, level)  ((level == 3) ? FALSE : (((page) & TT_TYPE_MASK) == TT_TYPE_TABLE_ENTRY))
+#define IS_BLOCK(page, level)  ((level == 3) ? (((page) & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3) : ((page & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY))
+#define ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
+#define IS_VALID  0x1
 
 /**
   Check the page table for Read/Write/Execute regions.
@@ -23,6 +31,124 @@ NoReadWriteExecute (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  UT_LOG_WARNING ("Test not implemented!\n");
+  UINT64      *Pml0;
+  UINT64      *Pte1G;
+  UINT64      *Pte2M;
+  UINT64      *Pte4K;
+  BOOLEAN     FoundRWXAddress;
+  UINT64      Index3;
+  UINT64      Index2;
+  UINT64      Index1;
+  UINT64      Index0;
+  UINT64      RootEntryCount;
+  UINT64      Address;
+  EFI_STATUS  Status;
+
+  Index3          = 0;
+  Index2          = 0;
+  Index1          = 0;
+  Index0          = 0;
+  RootEntryCount  = 0;
+  FoundRWXAddress = FALSE;
+
+  Pml0           = (UINT64 *)ArmGetTTBR0BaseAddress ();
+  RootEntryCount = ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
+
+  for (Index0 = 0x0; Index0 < RootEntryCount; Index0++) {
+    Index1 = 0;
+    Index2 = 0;
+    Index3 = 0;
+
+    if (!IS_TABLE (Pml0[Index0], 0)) {
+      continue;
+    }
+
+    // Level 0 must always be table entries
+    Pte1G = (UINT64 *)(Pml0[Index0] & TT_ADDRESS_MASK);
+
+    for (Index1 = 0x0; Index1 < TT_ENTRY_COUNT; Index1++ ) {
+      Index2 = 0;
+      Index3 = 0;
+
+      // If the entry is not valid, skip it
+      if ((Pte1G[Index1] & IS_VALID) == 0) {
+        continue;
+      }
+
+      if (!IS_BLOCK (Pte1G[Index1], 1)) {
+        // This is a table
+        Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
+
+        for (Index2 = 0x0; Index2 < TT_ENTRY_COUNT; Index2++ ) {
+          Index3 = 0;
+
+          // If the entry is not valid, skip it
+          if ((Pte2M[Index2] & IS_VALID) == 0) {
+            continue;
+          }
+
+          if (!IS_BLOCK (Pte2M[Index2], 2)) {
+            // This is a table
+            Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
+
+            for (Index3 = 0x0; Index3 < TT_ENTRY_COUNT; Index3++ ) {
+              // If the entry is not valid, skip it
+              if ((Pte4K[Index3] & IS_VALID) == 0) {
+                continue;
+              }
+
+              // This is a block
+              if ((Pte4K[Index3] & TT_AP_RW_RW || Pte4K[Index3] & TT_AP_NO_RW) && // Read/Write
+                  (!(Pte4K[Index3] & TT_UXN_MASK)) &&                             // Execute
+                  (!(Pte4K[Index3] & TT_AF)))                                     // Access Flag (0 for guard pages)
+              {
+                Address = IndexToAddress (Index0, Index1, Index2, Index3);
+
+                if (!CanRegionBeRWX (Address, SIZE_4KB)) {
+                  UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_4KB);
+                  FoundRWXAddress = TRUE;
+                } else {
+                  UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_4KB);
+                }
+              }
+            }
+          } else {
+            // This is an block
+            if ((Pte2M[Index2] & TT_AP_RW_RW || Pte2M[Index2] & TT_AP_NO_RW) && // Read/Write
+                (!(Pte2M[Index2] & TT_UXN_MASK)) &&                             // Execute
+                (!(Pte2M[Index2] & TT_AF)))                                     // Access Flag (0 for guard pages)
+            {
+              Address = IndexToAddress (Index0, Index1, Index2, Index3);
+
+              if (!CanRegionBeRWX (Address, SIZE_2MB)) {
+                UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_2MB);
+                FoundRWXAddress = TRUE;
+              } else {
+                UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_2MB);
+              }
+            }
+          }
+        }
+      } else {
+        // This is an block
+        if ((Pte1G[Index1] & TT_AP_RW_RW || Pte1G[Index1] & TT_AP_NO_RW) && // Read/Write
+            (!(Pte1G[Index1] & TT_UXN_MASK)) &&                             // Execute
+            (!(Pte1G[Index1] & TT_AF)))                                     // Access Flag (0 for guard pages)
+        {
+          Address = IndexToAddress (Index0, Index1, Index2, Index3);
+
+          if (!CanRegionBeRWX (Address, SIZE_1GB)) {
+            UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_1GB);
+            FoundRWXAddress = TRUE;
+          } else {
+            UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_1GB);
+          }
+        }
+      }
+    }
+  }
+
+  UT_ASSERT_FALSE (FoundRWXAddress);
+
   return UNIT_TEST_PASSED;
 }

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
@@ -16,7 +16,7 @@
 #define ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
 #define IS_VALID  0x1
 #define IS_READ_WRITE(page)  (((page & TT_AP_RW_RW) != 0) || ((page & TT_AP_MASK) == 0))
-#define IS_EXECUTABLE(page)  ((page & TT_UXN_MASK) == 0)
+#define IS_EXECUTABLE(page)  ((page & TT_UXN_MASK) == 0 || (page & TT_PXN_MASK) == 0)
 #define IS_ACCESSIBLE(page)  ((page & TT_AF) != 0)
 
 /**

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
@@ -28,7 +28,16 @@ NoReadWriteExecute (
   IN UNIT_TEST_CONTEXT  Context
   );
 
-// BEEBE TODO
+/**
+  Checks if a region is allowed to be read/write/execute based on the special region array
+  and non protected image list
+
+  @param[in] Address            Start address of the region
+  @param[in] Length             Length of the region
+
+  @retval TRUE                  The region is allowed to be read/write/execute
+  @retval FALSE                 The region is not allowed to be read/write/execute
+**/
 BOOLEAN
 CanRegionBeRWX (
   IN UINT64  Address,

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
@@ -9,6 +9,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "../../PagingAuditCommon.h"
 
+#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
+#include <Protocol/MemoryProtectionDebug.h>
 #include <Library/UnitTestLib.h>
 
 /**
@@ -24,4 +26,11 @@ UNIT_TEST_STATUS
 EFIAPI
 NoReadWriteExecute (
   IN UNIT_TEST_CONTEXT  Context
+  );
+
+// BEEBE TODO
+BOOLEAN
+CanRegionBeRWX (
+  IN UINT64  Address,
+  IN UINT64  Length
   );

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
@@ -8,13 +8,8 @@
 
 #include <Library/CpuPageTableLib.h>
 #include <Library/DxeMemoryProtectionHobLib.h>
-#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
 
 #include "../DxePagingAuditTestApp.h"
-
-// TRUE if A interval subsumes B interval
-#define CHECK_SUBSUMPTION(AStart, AEnd, BStart, BEnd) \
-  ((AStart <= BStart) && (AEnd >= BEnd))
 
 /**
   Check the page table for Read/Write/Execute regions.
@@ -31,23 +26,19 @@ NoReadWriteExecute (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  IA32_MAP_ENTRY                             *Map                      = NULL;
-  UINTN                                      MapCount                  = 0;
-  UINTN                                      Index                     = 0;
-  BOOLEAN                                    FoundRWXAddress           = FALSE;
-  BOOLEAN                                    IgnoreRWXAddress          = FALSE;
-  MEMORY_PROTECTION_DEBUG_PROTOCOL           *MemoryProtectionProtocol = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION_PROTOCOL  *SpecialRegionProtocol    = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION           *SpecialRegions           = NULL;
-  UINTN                                      SpecialRegionCount        = 0;
-  UINTN                                      SpecialRegionIndex        = 0;
-  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImageList    = NULL;
-  LIST_ENTRY                                 *NonProtectedImageLink    = NULL;
-  IMAGE_RANGE_DESCRIPTOR                     *NonProtectedImage        = NULL;
+  IA32_MAP_ENTRY                             *Map;
+  UINTN                                      MapCount;
+  UINTN                                      Index;
+  BOOLEAN                                    FoundRWXAddress;
   IA32_CR4                                   Cr4;
   PAGING_MODE                                PagingMode;
   UINTN                                      PagesAllocated = 0;
   EFI_STATUS                                 Status;
+
+  Map                      = NULL;
+  MapCount                 = 0;
+  Index                    = 0;
+  FoundRWXAddress          = FALSE;
 
   // Poll CR4 to deterimine the page table depth
   Cr4.UintN = AsmReadCr4 ();
@@ -73,79 +64,9 @@ NoReadWriteExecute (
     Status = PageTableParse (AsmReadCr3 (), PagingMode, Map, &MapCount);
   }
 
-  UT_ASSERT_NOT_EFI_ERROR (
-    gBS->LocateProtocol (
-           &gMemoryProtectionDebugProtocolGuid,
-           NULL,
-           (VOID **)&MemoryProtectionProtocol
-           )
-    );
-
-  UT_ASSERT_NOT_EFI_ERROR (
-    MemoryProtectionProtocol->GetImageList (
-                                &NonProtectedImageList,
-                                NonProtected
-                                )
-    );
-
-  UT_ASSERT_NOT_EFI_ERROR (
-    gBS->LocateProtocol (
-           &gMemoryProtectionSpecialRegionProtocolGuid,
-           NULL,
-           (VOID **)&SpecialRegionProtocol
-           )
-    );
-
-  UT_ASSERT_NOT_EFI_ERROR (
-    SpecialRegionProtocol->GetSpecialRegions (
-                             &SpecialRegions,
-                             &SpecialRegionCount
-                             )
-    );
-
   for ( ; Index < MapCount; Index++) {
     if ((Map[Index].Attribute.Bits.ReadWrite != 0) && (Map[Index].Attribute.Bits.Nx == 0)) {
-      IgnoreRWXAddress = FALSE;
-      if (NonProtectedImageList != NULL) {
-        for (NonProtectedImageLink = NonProtectedImageList->Link.ForwardLink;
-             NonProtectedImageLink != &NonProtectedImageList->Link;
-             NonProtectedImageLink = NonProtectedImageLink->ForwardLink)
-        {
-          NonProtectedImage = CR (
-                                NonProtectedImageLink,
-                                IMAGE_RANGE_DESCRIPTOR,
-                                Link,
-                                IMAGE_RANGE_DESCRIPTOR_SIGNATURE
-                                );
-          if CHECK_SUBSUMPTION (
-               NonProtectedImage->Base,
-               NonProtectedImage->Base + NonProtectedImage->Length,
-               Map[Index].LinearAddress,
-               Map[Index].LinearAddress + Map[Index].Length
-               ) {
-            IgnoreRWXAddress = TRUE;
-            break;
-          }
-        }
-      }
-
-      if ((SpecialRegionCount > 0) && !IgnoreRWXAddress) {
-        for (SpecialRegionIndex = 0; SpecialRegionIndex < SpecialRegionCount; SpecialRegionIndex++) {
-          if (CHECK_SUBSUMPTION (
-                SpecialRegions[SpecialRegionIndex].Start,
-                SpecialRegions[SpecialRegionIndex].Start + SpecialRegions[SpecialRegionIndex].Length,
-                Map[Index].LinearAddress,
-                Map[Index].LinearAddress + Map[Index].Length
-                ) &&
-              (SpecialRegions[SpecialRegionIndex].EfiAttributes == 0))
-          {
-            IgnoreRWXAddress = TRUE;
-            break;
-          }
-        }
-      }
-
-      if (!IgnoreRWXAddress) {
+      if (!CanRegionBeRWX (Map[Index].LinearAddress, Map[Index].Length)) {
         UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Map[Index].LinearAddress, Map[Index].LinearAddress + Map[Index].Length);
         FoundRWXAddress = TRUE;
       } else {

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
@@ -26,19 +26,19 @@ NoReadWriteExecute (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  IA32_MAP_ENTRY                             *Map;
-  UINTN                                      MapCount;
-  UINTN                                      Index;
-  BOOLEAN                                    FoundRWXAddress;
-  IA32_CR4                                   Cr4;
-  PAGING_MODE                                PagingMode;
-  UINTN                                      PagesAllocated = 0;
-  EFI_STATUS                                 Status;
+  IA32_MAP_ENTRY  *Map;
+  UINTN           MapCount;
+  UINTN           Index;
+  BOOLEAN         FoundRWXAddress;
+  IA32_CR4        Cr4;
+  PAGING_MODE     PagingMode;
+  UINTN           PagesAllocated = 0;
+  EFI_STATUS      Status;
 
-  Map                      = NULL;
-  MapCount                 = 0;
-  Index                    = 0;
-  FoundRWXAddress          = FALSE;
+  Map             = NULL;
+  MapCount        = 0;
+  Index           = 0;
+  FoundRWXAddress = FALSE;
 
   // Poll CR4 to deterimine the page table depth
   Cr4.UintN = AsmReadCr4 ();


### PR DESCRIPTION
## Description

Add functionality to the common app logic to allow the addition of an AARCH64 implementation of the RWX test.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 and SBSA

## Integration Instructions

N/A
