### PR TITLE
Added the cache flushing before sending to C3 and fixing a stack mis-calculation

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -55,9 +55,10 @@ ASM_PFX(AsmApEntryPoint):
 
 JumpToCFunction:
 // Calculate stack address
-  // x2 contains the index for the current processor plus 1
+  // x2 contains the index for the current processor
   ldr x0, gApStacksBase
   ldr x1, gApStackSize
+  add x2, x2, 1               // x2 = ProcessorIndex + 1
   mul x3, x2, x1              // x3 = (ProcessorIndex + 1) * gApStackSize
   add sp, x0, x3              // sp = gApStacksBase + x3
   mov x29, xzr

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -58,7 +58,7 @@ JumpToCFunction:
   // x2 contains the index for the current processor
   ldr x0, gApStacksBase
   ldr x1, gApStackSize
-  add x2, x2, 1               // x2 = ProcessorIndex + 1
+  add x2, x2, 1               // x2 = ProcessorIndex + 1, preemptively adding 1 so that the calculated sp will be at the bottom of the stack.
   mul x3, x2, x1              // x3 = (ProcessorIndex + 1) * gApStackSize
   add sp, x0, x3              // sp = gApStacksBase + x3
   mov x29, xzr

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -586,6 +586,9 @@ CpuArchSleep (
     goto Done;
   }
 
+  ArmDisableMmu ();
+  ArmCleanInvalidateDataCache ();
+
   Status = ArmPsciSuspendHelper (PowerState, (UINTN)AsmApEntryPoint, 0);
 
 Done:


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change fixed an issue when suspending the BSP to C3, the returned context could be randomly corrupted, which was due to the core number calculation was incorrect, which made the BSP uses the beginning of allocated buffer as the stack bottom.

In the meantime, not flushing the cache makes the debugger not able to identify the memory write through stack pointer corruptions.

This change should fix both of them.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is verified on proprietary hardware platform.

## Integration Instructions

N/A
