### PR TITLE
[REBASE && FF] DxePagingAudit Updates

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditAArch64.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditAArch64.h
@@ -1,0 +1,12 @@
+#include <Library/ArmLib.h>
+#include <Chipset/AArch64Mmu.h>
+
+#define AARCH64_IS_TABLE(page, level)  ((level == 3) ? FALSE : (((page) & TT_TYPE_MASK) == TT_TYPE_TABLE_ENTRY))
+#define AARCH64_IS_BLOCK(page, level)  ((level == 3) ? (((page) & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3) : ((page & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY))
+#define AARCH64_ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
+#define AARCH64_IS_VALID  0x1
+#define AARCH64_IS_READ_WRITE(page)  (((page & TT_AP_RW_RW) != 0) || ((page & TT_AP_MASK) == 0))
+#define AARCH64_IS_EXECUTABLE(page)  ((page & TT_UXN_MASK) == 0 || (page & TT_PXN_MASK) == 0)
+#define AARCH64_IS_ACCESSIBLE(page)  ((page & TT_AF) != 0)
+
+#define AARCH64_ADDRESS_MASK  0x000FFFFFFFFFF000ULL

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -150,7 +150,7 @@ GetFlatPageTableData (
               if (!IS_BLOCK (Pte4K[Index3], 3)) {
                 NumPage4KNotPresent++;
                 Address = IndexToAddress (Index0, Index1, Index2, Index3);
-                if ((mMemoryProtectionProtocol != NULL) && (mMemoryProtectionProtocol->IsGuardPage (Address))) {
+                if (IsGuardPage (Address)) {
                   MyGuardCount++;
                   if (MyGuardCount <= *GuardCount) {
                     GuardEntries[MyGuardCount - 1] = Address;

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
@@ -6,18 +6,8 @@
 
 **/
 
-#include <Library/ArmLib.h>
-#include <Chipset/AArch64Mmu.h>
 #include "../DxePagingAuditTestApp.h"
-
-#define TT_ADDRESS_MASK  (0xFFFFFFFFFULL << 12)
-#define IS_TABLE(page, level)  ((level == 3) ? FALSE : (((page) & TT_TYPE_MASK) == TT_TYPE_TABLE_ENTRY))
-#define IS_BLOCK(page, level)  ((level == 3) ? (((page) & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3) : ((page & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY))
-#define ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
-#define IS_VALID  0x1
-#define IS_READ_WRITE(page)  (((page & TT_AP_RW_RW) != 0) || ((page & TT_AP_MASK) == 0))
-#define IS_EXECUTABLE(page)  ((page & TT_UXN_MASK) == 0 || (page & TT_PXN_MASK) == 0)
-#define IS_ACCESSIBLE(page)  ((page & TT_AF) != 0)
+#include "../../../AArch64/PagingAuditAArch64.h"
 
 /**
   Check the page table for Read/Write/Execute regions.
@@ -49,96 +39,90 @@ NoReadWriteExecute (
   FoundRWXAddress = FALSE;
 
   Pml0           = (UINT64 *)ArmGetTTBR0BaseAddress ();
-  RootEntryCount = ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
+  RootEntryCount = AARCH64_ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
 
   for (Index0 = 0x0; Index0 < RootEntryCount; Index0++) {
     Index1 = 0;
     Index2 = 0;
     Index3 = 0;
 
-    if (!IS_TABLE (Pml0[Index0], 0)) {
+    if (!AARCH64_IS_TABLE (Pml0[Index0], 0)) {
       continue;
     }
 
     // Level 0 must always be table entries
-    Pte1G = (UINT64 *)(Pml0[Index0] & TT_ADDRESS_MASK);
+    Pte1G = (UINT64 *)(Pml0[Index0] & AARCH64_ADDRESS_MASK);
 
     for (Index1 = 0x0; Index1 < TT_ENTRY_COUNT; Index1++ ) {
       Index2 = 0;
       Index3 = 0;
 
       // If the entry is not valid, skip it
-      if ((Pte1G[Index1] & IS_VALID) == 0) {
+      if ((Pte1G[Index1] & AARCH64_IS_VALID) == 0) {
         continue;
       }
 
-      if (!IS_BLOCK (Pte1G[Index1], 1)) {
+      if (!AARCH64_IS_BLOCK (Pte1G[Index1], 1)) {
         // This is a table
-        Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
+        Pte2M = (UINT64 *)(Pte1G[Index1] & AARCH64_ADDRESS_MASK);
 
         for (Index2 = 0x0; Index2 < TT_ENTRY_COUNT; Index2++ ) {
           Index3 = 0;
 
           // If the entry is not valid, skip it
-          if ((Pte2M[Index2] & IS_VALID) == 0) {
+          if ((Pte2M[Index2] & AARCH64_IS_VALID) == 0) {
             continue;
           }
 
-          if (!IS_BLOCK (Pte2M[Index2], 2)) {
+          if (!AARCH64_IS_BLOCK (Pte2M[Index2], 2)) {
             // This is a table
-            Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
+            Pte4K = (UINT64 *)(Pte2M[Index2] & AARCH64_ADDRESS_MASK);
 
             for (Index3 = 0x0; Index3 < TT_ENTRY_COUNT; Index3++ ) {
               // If the entry is not valid, skip it
-              if ((Pte4K[Index3] & IS_VALID) == 0) {
+              if ((Pte4K[Index3] & AARCH64_IS_VALID) == 0) {
                 continue;
               }
 
               // This is a block
-              if (IS_READ_WRITE (Pte4K[Index3]) &&     // Read/Write
-                  IS_EXECUTABLE (Pte4K[Index3]) &&     // Execute
-                  IS_ACCESSIBLE (Pte4K[Index3]))       // Access Flag (0 for guard pages)
+              if (AARCH64_IS_READ_WRITE (Pte4K[Index3]) &&     // Read/Write
+                  AARCH64_IS_EXECUTABLE (Pte4K[Index3]) &&     // Execute
+                  AARCH64_IS_ACCESSIBLE (Pte4K[Index3]))       // Access Flag (0 for guard pages)
               {
                 Address = IndexToAddress (Index0, Index1, Index2, Index3);
 
                 if (!CanRegionBeRWX (Address, SIZE_4KB)) {
                   UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_4KB);
                   FoundRWXAddress = TRUE;
-                } else {
-                  UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_4KB);
                 }
               }
             }
           } else {
             // This is an block
-            if (IS_READ_WRITE (Pte2M[Index2]) &&   // Read/Write
-                IS_EXECUTABLE (Pte2M[Index2]) &&   // Execute
-                IS_ACCESSIBLE (Pte2M[Index2]))     // Access Flag (0 for guard pages)
+            if (AARCH64_IS_READ_WRITE (Pte2M[Index2]) &&   // Read/Write
+                AARCH64_IS_EXECUTABLE (Pte2M[Index2]) &&   // Execute
+                AARCH64_IS_ACCESSIBLE (Pte2M[Index2]))     // Access Flag (0 for guard pages)
             {
               Address = IndexToAddress (Index0, Index1, Index2, Index3);
 
               if (!CanRegionBeRWX (Address, SIZE_2MB)) {
                 UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_2MB);
                 FoundRWXAddress = TRUE;
-              } else {
-                UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_2MB);
               }
             }
           }
         }
       } else {
         // This is an block
-        if (IS_READ_WRITE (Pte1G[Index1]) &&     // Read/Write
-            IS_EXECUTABLE (Pte1G[Index1]) &&     // Execute
-            IS_ACCESSIBLE (Pte1G[Index1]))       // Access Flag (0 for guard pages)
+        if (AARCH64_IS_READ_WRITE (Pte1G[Index1]) &&     // Read/Write
+            AARCH64_IS_EXECUTABLE (Pte1G[Index1]) &&     // Execute
+            AARCH64_IS_ACCESSIBLE (Pte1G[Index1]))       // Access Flag (0 for guard pages)
         {
           Address = IndexToAddress (Index0, Index1, Index2, Index3);
 
           if (!CanRegionBeRWX (Address, SIZE_1GB)) {
             UT_LOG_ERROR ("Memory Range 0x%llx-0x%llx is Read/Write/Execute\n", Address, Address + SIZE_1GB);
             FoundRWXAddress = TRUE;
-          } else {
-            UT_LOG_WARNING ("Memory Range 0x%llx-0x%llx is Read/Write/Execute. This range is excepted from the test.\n", Address, Address + SIZE_1GB);
           }
         }
       }

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -304,7 +304,7 @@ OpenAppSFS (
 
 CleanUp:
   if (HandleBuffer != NULL) {
-    FreePool (HandleBuffer);
+    gBS->FreePool (HandleBuffer);
   }
 
   return Status;

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.h
@@ -8,9 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "../../PagingAuditCommon.h"
-
-#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
-#include <Protocol/MemoryProtectionDebug.h>
 #include <Library/UnitTestLib.h>
 
 /**
@@ -40,6 +37,22 @@ NoReadWriteExecute (
 **/
 BOOLEAN
 CanRegionBeRWX (
+  IN UINT64  Address,
+  IN UINT64  Length
+  );
+
+/**
+  Checks if a region is allowed to be read/write/execute based on the special region array
+  and non protected image list
+
+  @param[in] Address            Start address of the region
+  @param[in] Length             Length of the region
+
+  @retval TRUE                  The region is allowed to be read/write/execute
+  @retval FALSE                 The region is not allowed to be read/write/execute
+**/
+BOOLEAN
+CheckProjectMuRWXExemption (
   IN UINT64  Address,
   IN UINT64  Length
   );

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/ProjectMuFunctionality.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/ProjectMuFunctionality.c
@@ -1,0 +1,332 @@
+#include "DxePagingAuditTestApp.h"
+#include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
+#include <Protocol/MemoryProtectionDebug.h>
+#include <Protocol/CpuMpDebug.h>
+#include <Protocol/MemoryProtectionDebug.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
+#include <Library/HobLib.h>
+
+MEMORY_PROTECTION_SPECIAL_REGION  *mSpecialRegions           = NULL;
+IMAGE_RANGE_DESCRIPTOR            *mNonProtectedImageList    = NULL;
+UINTN                             mSpecialRegionCount        = 0;
+MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol = NULL;
+CPU_MP_DEBUG_PROTOCOL             *mCpuMpDebugProtocol       = NULL;
+
+/**
+  Populates the heap guard protocol global
+
+  @retval EFI_SUCCESS Protocol is already populated or was successfully populated
+  @retval other       Return value of LocateProtocol
+**/
+EFI_STATUS
+PopulateHeapGuardDebugProtocol (
+  VOID
+  )
+{
+  if (mMemoryProtectionProtocol != NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return gBS->LocateProtocol (&gMemoryProtectionDebugProtocolGuid, NULL, (VOID **)&mMemoryProtectionProtocol);
+}
+
+/**
+  Populates the CPU MP debug protocol global
+
+  @retval EFI_SUCCESS Protocol is already populated or was successfully populated
+  @retval other       Return value of LocateProtocol
+**/
+EFI_STATUS
+PopulateCpuMpDebugProtocol (
+  VOID
+  )
+{
+  if (mCpuMpDebugProtocol != NULL) {
+    return EFI_SUCCESS;
+  }
+
+  return gBS->LocateProtocol (&gCpuMpDebugProtocolGuid, NULL, (VOID **)&mCpuMpDebugProtocol);
+}
+
+/*
+  Writes the NULL page and stack information to the memory info database
+ */
+VOID
+ProjectMuSpecialMemoryDump (
+  VOID
+  )
+{
+  CHAR8                      TempString[MAX_STRING_SIZE];
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryHob;
+  EFI_STATUS                 Status;
+  LIST_ENTRY                 *List;
+  CPU_MP_DEBUG_PROTOCOL      *Entry;
+  EFI_PHYSICAL_ADDRESS       StackBase;
+  UINT64                     StackLength;
+
+  // Capture the NULL address
+  AsciiSPrint (
+    TempString,
+    MAX_STRING_SIZE,
+    "Null,0x%016lx\n",
+    NULL
+    );
+  AppendToMemoryInfoDatabase (TempString);
+
+  Hob.Raw = GetHobList ();
+
+  while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
+    MemoryHob = Hob.MemoryAllocation;
+    if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
+      StackBase   = (EFI_PHYSICAL_ADDRESS)((MemoryHob->AllocDescriptor.MemoryBaseAddress / EFI_PAGE_SIZE) * EFI_PAGE_SIZE);
+      StackLength = (EFI_PHYSICAL_ADDRESS)(EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (MemoryHob->AllocDescriptor.MemoryLength)));
+
+      // Capture the stack guard
+      if (gDxeMps.CpuStackGuard == TRUE) {
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "StackGuard,0x%016lx,0x%x\n",
+          StackBase,
+          EFI_PAGE_SIZE
+          );
+        AppendToMemoryInfoDatabase (TempString);
+        StackBase   += EFI_PAGE_SIZE;
+        StackLength -= EFI_PAGE_SIZE;
+      }
+
+      // Capture the stack
+      AsciiSPrint (
+        TempString,
+        MAX_STRING_SIZE,
+        "Stack,0x%016lx,0x%016lx\n",
+        StackBase,
+        StackLength
+        );
+      AppendToMemoryInfoDatabase (TempString);
+
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  Status = PopulateCpuMpDebugProtocol ();
+
+  // The protocol should only be published if CpuStackGuard is active
+  if (!EFI_ERROR (Status)) {
+    for (List = mCpuMpDebugProtocol->Link.ForwardLink; List != &mCpuMpDebugProtocol->Link; List = List->ForwardLink) {
+      Entry = CR (
+                List,
+                CPU_MP_DEBUG_PROTOCOL,
+                Link,
+                CPU_MP_DEBUG_SIGNATURE
+                );
+      StackBase   = (EFI_PHYSICAL_ADDRESS)((Entry->ApStackBuffer / EFI_PAGE_SIZE) * EFI_PAGE_SIZE);
+      StackLength = (EFI_PHYSICAL_ADDRESS)(EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (Entry->ApStackSize)));
+
+      if (!Entry->IsSwitchStack) {
+        if (gDxeMps.CpuStackGuard == TRUE) {
+          // Capture the AP stack guard
+          AsciiSPrint (
+            TempString,
+            MAX_STRING_SIZE,
+            "ApStackGuard,0x%016lx,0x%016lx,0x%x\n",
+            StackBase,
+            EFI_PAGE_SIZE,
+            Entry->CpuNumber
+            );
+          AppendToMemoryInfoDatabase (TempString);
+
+          StackBase   += EFI_PAGE_SIZE;
+          StackLength -= EFI_PAGE_SIZE;
+        }
+
+        // Capture the AP stack
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "ApStack,0x%016lx,0x%016lx,0x%x\n",
+          StackBase,
+          StackLength,
+          Entry->CpuNumber
+          );
+        AppendToMemoryInfoDatabase (TempString);
+      } else {
+        // Capture the AP switch stack
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "ApSwitchStack,0x%016lx,0x%016lx,0x%x\n",
+          StackBase,
+          StackLength,
+          Entry->CpuNumber
+          );
+        AppendToMemoryInfoDatabase (TempString);
+      }
+    }
+  }
+}
+
+/**
+  Populates the non protected image list global
+
+  @retval EFI_SUCCESS            The non-protected image list was populated
+  @retval EFI_INVALID_PARAMETER  The non-protected image list was already populated
+  @retval other                  The non-protected image list was not populated
+**/
+EFI_STATUS
+GetNonProtectedImageList (
+  VOID
+  )
+{
+  EFI_STATUS                        Status;
+  MEMORY_PROTECTION_DEBUG_PROTOCOL  *MemoryProtectionProtocol;
+
+  MemoryProtectionProtocol = NULL;
+
+  if (mNonProtectedImageList != NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gMemoryProtectionDebugProtocolGuid,
+                  NULL,
+                  (VOID **)&MemoryProtectionProtocol
+                  );
+
+  if (!EFI_ERROR (Status)) {
+    Status = MemoryProtectionProtocol->GetImageList (
+                                         &mNonProtectedImageList,
+                                         NonProtected
+                                         );
+  }
+
+  return Status;
+}
+
+/**
+  Populates the special region array global
+**/
+EFI_STATUS
+GetSpecialRegions (
+  VOID
+  )
+{
+  EFI_STATUS                                 Status;
+  MEMORY_PROTECTION_SPECIAL_REGION_PROTOCOL  *SpecialRegionProtocol;
+
+  SpecialRegionProtocol = NULL;
+
+  if (mSpecialRegions != NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gMemoryProtectionSpecialRegionProtocolGuid,
+                  NULL,
+                  (VOID **)&SpecialRegionProtocol
+                  );
+
+  if (!EFI_ERROR (Status)) {
+    Status = SpecialRegionProtocol->GetSpecialRegions (
+                                      &mSpecialRegions,
+                                      &mSpecialRegionCount
+                                      );
+  }
+
+  return Status;
+}
+
+/**
+  Checks if the address is a guard page.
+
+  @param[in] Address            Address to check
+
+  @retval TRUE                  The address is a guard page
+  @retval FALSE                 The address is not a guard page
+**/
+BOOLEAN
+IsGuardPage (
+  IN UINT64  Address
+  )
+{
+  if (mMemoryProtectionProtocol != NULL) {
+    return mMemoryProtectionProtocol->IsGuardPage (Address);
+  }
+
+  return FALSE;
+}
+
+/**
+  In processors implementing the AMD64 architecture, SMBASE relocation is always supported.
+  However, there are some virtual platforms that does not really support them. This PCD check
+  is to allow these virtual platforms to skip the SMRR check.
+
+  @retval TRUE                  Skip the SMRR check
+  @retval FALSE                 Do not skip the SMRR check
+**/
+BOOLEAN
+SkipSmrr (
+  VOID
+  )
+{
+  return FixedPcdGetBool (PcdPlatformSmrrUnsupported);
+}
+
+/**
+  Checks if a region is allowed to be read/write/execute based on the special region array
+  and non protected image list
+
+  @param[in] Address            Start address of the region
+  @param[in] Length             Length of the region
+
+  @retval TRUE                  The region is allowed to be read/write/execute
+  @retval FALSE                 The region is not allowed to be read/write/execute
+**/
+BOOLEAN
+CheckProjectMuRWXExemption (
+  IN UINT64  Address,
+  IN UINT64  Length
+  )
+{
+  LIST_ENTRY              *NonProtectedImageLink;
+  IMAGE_RANGE_DESCRIPTOR  *NonProtectedImage;
+  UINTN                   SpecialRegionIndex;
+
+  if (mSpecialRegions != NULL) {
+    for (SpecialRegionIndex = 0; SpecialRegionIndex < mSpecialRegionCount; SpecialRegionIndex++) {
+      if (CHECK_SUBSUMPTION (
+            mSpecialRegions[SpecialRegionIndex].Start,
+            mSpecialRegions[SpecialRegionIndex].Start + mSpecialRegions[SpecialRegionIndex].Length,
+            Address,
+            Address + Length
+            ) &&
+          (mSpecialRegions[SpecialRegionIndex].EfiAttributes == 0))
+      {
+        return TRUE;
+      }
+    }
+  }
+
+  if (mNonProtectedImageList != NULL) {
+    for (NonProtectedImageLink = mNonProtectedImageList->Link.ForwardLink;
+         NonProtectedImageLink != &mNonProtectedImageList->Link;
+         NonProtectedImageLink = NonProtectedImageLink->ForwardLink)
+    {
+      NonProtectedImage = CR (NonProtectedImageLink, IMAGE_RANGE_DESCRIPTOR, Link, IMAGE_RANGE_DESCRIPTOR_SIGNATURE);
+      if (CHECK_SUBSUMPTION (
+            NonProtectedImage->Base,
+            NonProtectedImage->Base + NonProtectedImage->Length,
+            Address,
+            Address + Length
+            ))
+      {
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/ProjectMuFunctionalityNull.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/ProjectMuFunctionalityNull.c
@@ -1,0 +1,117 @@
+#include "DxePagingAuditTestApp.h"
+
+/**
+  Populates the heap guard protocol global
+
+  @retval EFI_SUCCESS Protocol is already populated or was successfully populated
+  @retval other       Return value of LocateProtocol
+**/
+EFI_STATUS
+PopulateHeapGuardDebugProtocol (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Populates the CPU MP debug protocol global
+
+  @retval EFI_SUCCESS Protocol is already populated or was successfully populated
+  @retval other       Return value of LocateProtocol
+**/
+EFI_STATUS
+PopulateCpuMpDebugProtocol (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/*
+  Writes the NULL page and stack information to the memory info database
+ */
+VOID
+ProjectMuSpecialMemoryDump (
+  VOID
+  )
+{
+  return;
+}
+
+/**
+  Populates the non protected image list global
+
+  @retval EFI_SUCCESS            The non-protected image list was populated
+  @retval EFI_INVALID_PARAMETER  The non-protected image list was already populated
+  @retval other                  The non-protected image list was not populated
+**/
+EFI_STATUS
+GetNonProtectedImageList (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Populates the special region array global
+**/
+EFI_STATUS
+GetSpecialRegions (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Checks if the address is a guard page.
+
+  @param[in] Address            Address to check
+
+  @retval TRUE                  The address is a guard page
+  @retval FALSE                 The address is not a guard page
+**/
+BOOLEAN
+IsGuardPage (
+  IN UINT64  Address
+  )
+{
+  return FALSE;
+}
+
+/**
+  In processors implementing the AMD64 architecture, SMBASE relocation is always supported.
+  However, there are some virtual platforms that does not really support them. This PCD check
+  is to allow these virtual platforms to skip the SMRR check.
+
+  @retval TRUE                  Skip the SMRR check
+  @retval FALSE                 Do not skip the SMRR check
+**/
+BOOLEAN
+SkipSmrr (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  Checks if a region is allowed to be read/write/execute based on the special region array
+  and non protected image list
+
+  @param[in] Address            Start address of the region
+  @param[in] Length             Length of the region
+
+  @retval TRUE                  The region is allowed to be read/write/execute
+  @retval FALSE                 The region is not allowed to be read/write/execute
+**/
+BOOLEAN
+CheckProjectMuRWXExemption (
+  IN UINT64  Address,
+  IN UINT64  Length
+  )
+{
+  return FALSE;
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
@@ -54,13 +54,13 @@ NoReadWriteExecute (
 
   while (Status == RETURN_BUFFER_TOO_SMALL) {
     if ((Map != NULL) && (PagesAllocated > 0)) {
-      FreePages (Map, PagesAllocated);
+      gBS->FreePages ((EFI_PHYSICAL_ADDRESS)(UINTN)Map, PagesAllocated);
     }
 
     PagesAllocated = EFI_SIZE_TO_PAGES (MapCount * sizeof (IA32_MAP_ENTRY));
-    Map            = AllocatePages (PagesAllocated);
+    Status         = gBS->AllocatePages (AllocateAnyPages, EfiBootServicesData, PagesAllocated, (EFI_PHYSICAL_ADDRESS *)(UINTN)&Map);
 
-    UT_ASSERT_NOT_NULL (Map);
+    UT_ASSERT_NOT_EFI_ERROR (Status);
     Status = PageTableParse (AsmReadCr3 (), PagingMode, Map, &MapCount);
   }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/X64/DxePagingAuditTests.c
@@ -7,8 +7,6 @@
 **/
 
 #include <Library/CpuPageTableLib.h>
-#include <Library/DxeMemoryProtectionHobLib.h>
-
 #include "../DxePagingAuditTestApp.h"
 
 /**

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -25,9 +25,11 @@
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
+  X64/PagingAuditX64.h
 
 [Sources.AARCH64]
   AArch64/PagingAuditProcessor.c
+  AArch64/PagingAuditAArch64.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -25,12 +25,14 @@
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
+  X64/PagingAuditX64.h
   Dxe/App/X64/DxePagingAuditTests.c
 
 [Sources.AARCH64]
   AArch64/PagingAuditProcessor.c
+  AArch64/PagingAuditAArch64.h
   Dxe/App/AArch64/DxePagingAuditTests.c
-  
+
 [Packages.AARCH64]
   ArmPkg/ArmPkg.dec
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -60,7 +60,6 @@
 
 [LibraryClasses.X64]
   UefiCpuLib
-  CpuPageTableLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -21,6 +21,7 @@
   Dxe/App/DxePagingAuditTestApp.h
   PagingAuditCommon.c
   PagingAuditCommon.h
+  Dxe/App/ProjectMuFunctionalityNull.c
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
@@ -38,7 +39,6 @@
   MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
   ShellPkg/ShellPkg.dec
-  UefiTestingPkg/UefiTestingPkg.dec
 
 [LibraryClasses]
   PrintLib
@@ -51,7 +51,6 @@
   HobLib
   DxeServicesTableLib
   UnitTestLib
-  DxeMemoryProtectionHobLib
   FileHandleLib
 
 [LibraryClasses.AARCH64]
@@ -68,11 +67,5 @@
 
 [Protocols]
   gEfiBlockIoProtocolGuid
-  gMemoryProtectionDebugProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gMemoryProtectionSpecialRegionProtocolGuid
   gEfiShellParametersProtocolGuid
-  gCpuMpDebugProtocolGuid
-
-[FixedPcd]
-  gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -24,8 +24,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DevicePathLib.h>
 
 #include <Protocol/SimpleFileSystem.h>
-#include <Register/Cpuid.h>
-#include <Register/Amd/Cpuid.h>
 
 #include <Guid/EventGroup.h>
 #include <Guid/DebugImageInfoTable.h>

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -17,7 +17,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
-#include <Library/MemoryAllocationLib.h>
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/ProjectMuDxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/ProjectMuDxePagingAuditTestApp.inf
@@ -1,76 +1,79 @@
-## @file DxePagingAuditDriver.inf
-# This DXE Driver writes page table and memory map information to SFS when triggered
-# by an event.
+## @file DxePagingAuditTestApp.inf
+# This Shell App writes page table and memory map information to SFS.
 #
 ##
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) Microsoft Corporation.
+## SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
 
 [Defines]
   INF_VERSION         = 0x00010017
-  BASE_NAME           = DxePagingAuditDriver
-  FILE_GUID           = 8C8CEAB1-6062-4777-BD21-7A1C034EF034
+  BASE_NAME           = DxePagingAuditTestApp
+  FILE_GUID           = 39D7EF60-4569-41FB-9139-09A10DDF9150
   VERSION_STRING      = 1.0
-  MODULE_TYPE         = DXE_DRIVER
-  ENTRY_POINT         = PagingAuditDriverEntryPoint
+  MODULE_TYPE         = UEFI_APPLICATION
+  ENTRY_POINT         = DxePagingAuditTestAppEntryPoint
 
 
 [Sources]
-  Dxe/Driver/DxePagingAuditDriver.c
+  Dxe/App/DxePagingAuditTestApp.c
+  Dxe/App/DxePagingAuditTestApp.h
   PagingAuditCommon.c
   PagingAuditCommon.h
   Dxe/App/ProjectMuFunctionality.c
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
+  Dxe/App/X64/DxePagingAuditTests.c
 
 [Sources.AARCH64]
   AArch64/PagingAuditProcessor.c
+  Dxe/App/AArch64/DxePagingAuditTests.c
+
+[Packages.AARCH64]
+  ArmPkg/ArmPkg.dec
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
+  ShellPkg/ShellPkg.dec
   UefiTestingPkg/UefiTestingPkg.dec
-  
-[Packages.AARCH64]
-  ArmPkg/ArmPkg.dec
 
 [LibraryClasses]
-  UefiDriverEntryPoint
   PrintLib
   DebugLib
   UefiBootServicesTableLib
   UefiLib
   PeCoffGetEntryPointLib
+  UefiApplicationEntryPoint
+  ShellLib
   HobLib
   DxeServicesTableLib
+  UnitTestLib
   DxeMemoryProtectionHobLib
+  FileHandleLib
 
 [LibraryClasses.AARCH64]
   ArmLib
 
 [LibraryClasses.X64]
   UefiCpuLib
+  CpuPageTableLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
-  gMuEventPreExitBootServicesGuid
-  gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
+  gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES ## SystemTable
 
 [Protocols]
   gEfiBlockIoProtocolGuid
-  gMemoryProtectionDebugProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gCpuMpDebugProtocolGuid
-  gMemoryProtectionSpecialRegionProtocolGuid
+  gEfiShellParametersProtocolGuid
   gMemoryProtectionDebugProtocolGuid
+  gMemoryProtectionSpecialRegionProtocolGuid
+  gCpuMpDebugProtocolGuid
 
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES
-
-[Depex]
-  gEfiSimpleFileSystemProtocolGuid

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/ProjectMuDxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/ProjectMuDxePagingAuditTestApp.inf
@@ -25,10 +25,12 @@
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
+  X64/PagingAuditX64.h
   Dxe/App/X64/DxePagingAuditTests.c
 
 [Sources.AARCH64]
   AArch64/PagingAuditProcessor.c
+  AArch64/PagingAuditAArch64.h
   Dxe/App/AArch64/DxePagingAuditTests.c
 
 [Packages.AARCH64]

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Smm/App/SmmPagingAuditTestApp.c
@@ -29,7 +29,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/DebugImageInfoTable.h>
 #include <Guid/MemoryAttributesTable.h>
 #include <Guid/PiSmmCommunicationRegionTable.h>
-#include <Guid/DxeMemoryProtectionSettings.h>
 
 #include "../../PagingAuditCommon.h"
 #include "../SmmPagingAuditCommon.h"
@@ -40,8 +39,6 @@ UINTN  mPiSmmCommonCommBufferSize;
 CHAR8  *mMemoryInfoDatabaseBuffer   = NULL;
 UINTN  mMemoryInfoDatabaseSize      = 0;
 UINTN  mMemoryInfoDatabaseAllocSize = 0;
-// Added to satisfy gDxeMps use in PagingAuditCommon.c
-DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps = DXE_MEMORY_PROTECTION_SETTINGS_OFF;
 
 /**
   This helper function will call to the SMM agent to retrieve the entire contents of the

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditDriver.inf
@@ -29,7 +29,6 @@
   Smm/SmmPagingAuditCommon.h
   PagingAuditCommon.h
 
-
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -21,6 +21,7 @@
   Smm/SmmPagingAuditCommon.h
   PagingAuditCommon.c
   PagingAuditCommon.h
+  Dxe/App/ProjectMuFunctionalityNull.c
 
 [Sources.X64]
   X64/PagingAuditProcessor.c
@@ -56,6 +57,3 @@
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
   gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
-
-[FixedPcd]
-  gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -20,8 +20,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define VALID_SMRR_HIGH_POS  BIT51
 #define VALID_SMRR_BIT_MASK  (~(~(BIT51 - 1) | (BIT17 - 1)))
 
-extern MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol;
-
 //
 // Page-Map Level-4 Offset (PML4) and
 // Page-Directory-Pointer Offset (PDPE) entries 4K & 2MB
@@ -278,7 +276,7 @@ LookupSmrrIntel (
   // However, there are some virtual platforms that does not really support them. This PCD check
   // is to allow these virtual platforms to skip the SMRR check.
   //
-  if (FixedPcdGetBool (PcdPlatformSmrrUnsupported)) {
+  if (SkipSmrr ()) {
     Status = EFI_UNSUPPORTED;
   }
 
@@ -337,7 +335,7 @@ LookupSmrrAMD (
   // However, there are some virtual platforms that does not really support them. This PCD check
   // is to allow these virtual platforms to skip the SMRR check.
   //
-  if (FixedPcdGetBool (PcdPlatformSmrrUnsupported)) {
+  if (SkipSmrr ()) {
     Status = EFI_UNSUPPORTED;
   } else {
     Status = EFI_SUCCESS;
@@ -656,7 +654,7 @@ GetFlatPageTableData (
               if (!Pte4K[Index1].Bits.Present) {
                 NumPage4KNotPresent++;
                 Address = IndexToAddress (Index4, Index3, Index2, Index1);
-                if ((mMemoryProtectionProtocol != NULL) && (mMemoryProtectionProtocol->IsGuardPage (Address))) {
+                if (IsGuardPage (Address)) {
                   MyGuardCount++;
                   if (MyGuardCount <= *GuardCount) {
                     GuardEntries[MyGuardCount - 1] = Address;

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "../PagingAuditCommon.h"
+#include "PagingAuditX64.h"
 #include <Register/Msr.h>
 #include <Library/UefiCpuLib.h>
 #include <Pi/PiHob.h>

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -456,9 +456,9 @@ TSEGDumpHandler (
       }
     }
 
-    TempBuffer = AllocatePool (NumberOfTseg * sizeof (EFI_PHYSICAL_ADDRESS));
-    if (TempBuffer == NULL) {
-      ASSERT (TempBuffer != NULL);
+    Status = gBS->AllocatePool (EfiBootServicesData, NumberOfTseg * sizeof (EFI_PHYSICAL_ADDRESS), (VOID **)&TempBuffer);
+    if (EFI_ERROR (Status)) {
+      ASSERT (!EFI_ERROR (Status));
       DEBUG ((DEBUG_ERROR, "%a Failed to allocate memory for TSEG ranges!\n", __FUNCTION__));
       return EFI_OUT_OF_RESOURCES;
     }
@@ -506,7 +506,7 @@ TSEGDumpHandler (
     }
 
     if (TempBuffer != NULL) {
-      FreePool (TempBuffer);
+      gBS->FreePool (TempBuffer);
     }
   }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditX64.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditX64.h
@@ -1,0 +1,14 @@
+#include <Register/Cpuid.h>
+#include <Register/Amd/Cpuid.h>
+
+#define X64_PAGE_TABLE_PRESENT         0x1ULL
+#define X64_PAGE_TABLE_RW              0x2ULL
+#define X64_PAGE_TABLE_NX              0x8000000000000000ULL
+#define X64_PAGE_TABLE_PAGE_SIZE_FLAG  0x80ULL
+
+#define X64_IS_READ_WRITE(page)  ((page & X64_PAGE_TABLE_RW) != 0)
+#define X64_IS_EXECUTABLE(page)  ((page & X64_PAGE_TABLE_NX) == 0)
+#define X64_IS_PRESENT(page)     ((page & X64_PAGE_TABLE_PRESENT) != 0)
+#define X64_IS_LEAF(page)        ((page & X64_PAGE_TABLE_PAGE_SIZE_FLAG) != 0)
+
+#define X64_PAGE_TABLE_ADDRESS_MASK  0x000FFFFFFFFFF000ULL

--- a/UefiTestingPkg/UefiTestingPkg.dsc
+++ b/UefiTestingPkg/UefiTestingPkg.dsc
@@ -150,8 +150,6 @@
 [Components.X64]
   # NOTE: These currently have source files that are only implemented for X64.
   #       If needed on IA32, should port the functions.
-  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
-  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
   UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
   UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
 
@@ -159,6 +157,11 @@
   # NOTE: These currently have source files that are only implemented for AARCH64.
   #       If needed on X86, should port (and test) the functions.
   UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
+
+[Components.X64, Components.AARCH64]
+  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+  UefiTestingPkg/AuditTests/PagingAudit/UEFI/ProjectMuDxePagingAuditTestApp.inf
 
 [BuildOptions]
 #force deprecated interfaces off


### PR DESCRIPTION
## Description

1. Remove the reliance on MemoryAllocationLib and instead use gBS directly.
2. Separate out Project Mu specific functionality so the DxePagingAuditApp can be run on any EDK2-based UEFI, and the DxePagingAudit binary is cross platform compatible.
3. Add headers containing macros for X64 and AARCH64 page/translation tables so they don't need to be defined twice.
4. Update the X64 table walk logic to no longer need struct definitions or CpuPageTableLib.
