### PR TITLE
Remove Optimizations from MemoryProtectionTestApp GCC5 Build Command

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -77,3 +77,4 @@
 [BuildOptions]
   GCC:*_CLANG40WIN_AARCH64_CC_FLAGS = -Wno-infinite-recursion
   MSFT:*_*_*_CC_FLAGS  = /wd4054 /wd4055 /wd4717
+  GCC:*_GCC5_X64_CC_FLAGS = -O0 # Optimization can cause an invalid opcode exception on GCC5 builds

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -81,4 +81,4 @@
   # due to the instruction "ud2" being inserted by the compiler after a NULL pointer dereference.
   # Removing optimization prevents the invalid opcode instruction from being inserted and enables
   # the interrupt handler to clear the fault and return to the test.
-  GCC:*_GCC5_X64_CC_FLAGS = -O0
+  GCC:DEBUG_GCC5_X64_CC_FLAGS = -O0

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -77,4 +77,8 @@
 [BuildOptions]
   GCC:*_CLANG40WIN_AARCH64_CC_FLAGS = -Wno-infinite-recursion
   MSFT:*_*_*_CC_FLAGS  = /wd4054 /wd4055 /wd4717
-  GCC:*_GCC5_X64_CC_FLAGS = -O0 # Optimization can cause an invalid opcode exception on GCC5 builds
+  # An invalid opcode exception can be triggered during the NULL detection test on GCC5 builds
+  # due to the instruction "ud2" being inserted by the compiler after a NULL pointer dereference.
+  # Removing optimization prevents the invalid opcode instruction from being inserted and enables
+  # the interrupt handler to clear the fault and return to the test.
+  GCC:*_GCC5_X64_CC_FLAGS = -O0

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -81,4 +81,4 @@
   # due to the instruction "ud2" being inserted by the compiler after a NULL pointer dereference.
   # Removing optimization prevents the invalid opcode instruction from being inserted and enables
   # the interrupt handler to clear the fault and return to the test.
-  GCC:DEBUG_GCC5_X64_CC_FLAGS = -O0
+  GCC:*_GCC5_X64_CC_FLAGS = -O0


### PR DESCRIPTION
## Description

Runs of the MemoryProtectionTestApp on GCC5 builds can cause an invalid opcode after returning from a cleared exception due to the insertion of the "ud2" instruction after a NULL dereference.

"[ud2] Generates an invalid opcode. This instruction is provided for software testing to explicitly generate an invalid opcode. The opcode for this instruction is reserved for this purpose. Other than raising the invalid opcode exception, this instruction is the same as the NOP instruction. This instruction's operation is the same in non-64-bit modes and 64-bit mode."

Because we are purposefully dereferencing NULL, we don't want these instructions inserted. Turning off optimizations solves this problem.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the test on Q35 GCC5 build

## Integration Instructions

N/A
