### PR TITLE
Added to boot sequence enum additional boot types

### DIFF
--- a/PcBdsPkg/Include/Library/MsBootPolicyLib.h
+++ b/PcBdsPkg/Include/Library/MsBootPolicyLib.h
@@ -14,7 +14,7 @@ typedef enum {
   MsBootPXE4,
   MsBootPXE6,
   MsBootHDD,
-  MsBootUSB
+  MsBootUSB,
   MsBootNvme,
   MsBootOdd,
   MsBootSd,

--- a/PcBdsPkg/Include/Library/MsBootPolicyLib.h
+++ b/PcBdsPkg/Include/Library/MsBootPolicyLib.h
@@ -15,6 +15,10 @@ typedef enum {
   MsBootPXE6,
   MsBootHDD,
   MsBootUSB
+  MsBootNvme,
+  MsBootOdd,
+  MsBootSd,
+  MsBootRamDisk
 } BOOT_SEQUENCE;
 
 /**

--- a/PcBdsPkg/Include/Library/MsBootPolicyLib.h
+++ b/PcBdsPkg/Include/Library/MsBootPolicyLib.h
@@ -9,16 +9,25 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef _MS_BOOT_POLICY_LIB_H_
 #define _MS_BOOT_POLICY_LIB_H_
 
+/**
+ * BOOT_SEQUENCE types are used to describe classes of devices.  The identifiers are used in
+ * boot policy applications to create boot sequences for the EFI_LOAD_OPTIONS. An example
+ * application is at PcsBdsPkg/MsBootPolicy.
+ *
+ * Boot Policy Applications can be created to meet a platform's requirements. The PcBdsPkg
+ * example aplication impelements USB, PXE and HDD boot sequences, in addition to a default
+ * sequences of HDD, USB, PXE.
+**/
 typedef enum {
-  MsBootDone,
-  MsBootPXE4,
-  MsBootPXE6,
-  MsBootHDD,
-  MsBootUSB,
-  MsBootNvme,
-  MsBootOdd,
-  MsBootSd,
-  MsBootRamDisk
+  MsBootDone,       /// Boot Sequence terminator, used to exit boot application
+  MsBootPXE4,       /// Boot devices that support IPV4 PXE
+  MsBootPXE6,       /// Boot devices supporting IPV6 PXE
+  MsBootHDD,        /// Hard Drive type boot devices
+  MsBootUSB,        /// Boot Devices containing a Usb Device
+  MsBootNVME,       /// Nvme boot devices
+  MsBootODD,        /// Optical Disk drive devices
+  MsBootSD,         /// Sd/Emmc type devices
+  MsBootRAMDISK     /// Ram Disk devices
 } BOOT_SEQUENCE;
 
 /**


### PR DESCRIPTION
## Description

Only adding additional enum types to the MsBootPolicyLib.h.

No coding changes, other than to declare other categories of boot devices. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran CI locally.

## Integration Instructions
N/A