### PR TITLE
Update Paging Audit Parsing Script to Better Handle Page Splitting

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
@@ -220,12 +220,9 @@ class MemoryRange(object):
     Type                    : %s
     PhysicalStart           : 0x%010X
     PhysicalEnd             : 0x%010X
-    VirtualStart            : 0x%010X
-    NumberOfPages           : 0x%010X
     Attribute               : 0x%010X
     PhysicalSize            : 0x%010X
-    GcdType                 : 0x%010X
-""" % (self.GetMemoryTypeDescription(), self.PhysicalStart, self.PhysicalEnd, self.VirtualStart, self.NumberOfPages, self.Attribute, self.PhysicalSize, self.GcdType)
+""" % (self.GetMemoryTypeDescription(), self.PhysicalStart, self.PhysicalEnd, self.Attribute, self.PhysicalSize)
 
     #
     # intitalizes memory contents description

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
@@ -119,7 +119,7 @@ class ParsingTool(object):
             page = self.PageDirectoryInfo[index]
             for mr in self.MemoryRangeInfo:
                 if page.overlap(mr):
-                    if (mr.MemoryType is not None) or (mr.GcdType is not None):
+                    if (mr.MemoryType is not None) or (mr.GcdType is not None) or (mr.ImageName is not None) or (mr.SystemMemoryType is not None):
                         if (page.PhysicalStart < mr.PhysicalStart):
                             next = page.split(mr.PhysicalStart-1)
                             self.PageDirectoryInfo.insert(index+1, next)
@@ -132,31 +132,33 @@ class ParsingTool(object):
                             next = page.split(mr.PhysicalEnd)
                             self.PageDirectoryInfo.insert(index +1, next)
 
-                        if page.MemoryType is None:
-                            page.MemoryType = mr.MemoryType
-                        else:
-                            logging.error("Multiple memory types found for one region " + page.pageDebugStr() +" " + mr.MemoryRangeToString())
-                            self.ErrorMsg.append("Multiple memory types found for one region.  Base: 0x%X.  EFI Memory Type: %d and %d"% (page.PhysicalStart, page.MemoryType,mr.MemoryType))
+                        if mr.MemoryType is not None:
+                            if page.MemoryType is None or page.MemoryType == mr.MemoryType:
+                                page.MemoryType = mr.MemoryType
+                            else:
+                                logging.error("Multiple memory types found for one region " + page.pageDebugStr() +" " + mr.MemoryRangeToString())
+                                self.ErrorMsg.append("Multiple memory types found for one region.  Base: 0x%X.  EFI Memory Type: %d and %d"% (page.PhysicalStart, page.MemoryType,mr.MemoryType))
 
-                        if page.GcdType is None:
-                            page.GcdType = mr.GcdType
-                        else:
-                            logging.error("Multiple memory types found for one region " + page.pageDebugStr() +" " + mr.MemoryRangeToString())
-                            self.ErrorMsg.append("Multiple memory types found for one region.  Base: 0x%X.  GCD Memory Type: %d and %d"% (page.PhysicalStart, page.GcdType,mr.GcdType))
+                        if mr.GcdType is not None:
+                            if page.GcdType is None or page.GcdType == mr.GcdType:
+                                page.GcdType = mr.GcdType
+                            else:
+                                logging.error("Multiple memory types found for one region " + page.pageDebugStr() +" " + mr.MemoryRangeToString())
+                                self.ErrorMsg.append("Multiple memory types found for one region.  Base: 0x%X.  GCD Memory Type: %d and %d"% (page.PhysicalStart, page.GcdType,mr.GcdType))
 
-                    if mr.ImageName is not None:
-                        if page.ImageName is None:
-                            page.ImageName = mr.ImageName
-                        else:
-                            self.ErrorMsg.append("Multiple memory contents found for one region.  Base: 0x%X.  Memory Contents: %s and %s" % (page.PhysicalStart, page.ImageName, mr.ImageName ))
-                            logging.error("Multiple memory contents found for one region " + page.pageDebugStr() + " " +  mr.LoadedImageEntryToString())
+                        if mr.ImageName is not None:
+                            if page.ImageName is None:
+                                page.ImageName = mr.ImageName
+                            else:
+                                self.ErrorMsg.append("Multiple memory contents found for one region.  Base: 0x%X.  Memory Contents: %s and %s" % (page.PhysicalStart, page.ImageName, mr.ImageName ))
+                                logging.error("Multiple memory contents found for one region " + page.pageDebugStr() + " " +  mr.LoadedImageEntryToString())
 
-                    if mr.SystemMemoryType is not None:
-                        if page.SystemMemoryType is None:
-                            page.SystemMemoryType = mr.SystemMemoryType
-                        else:
-                            self.ErrorMsg.append("Multiple System Memory types found for one region.  Base: 0x%X.  System Memory Type: %s and %s."% (page.PhysicalStart,page.GetSystemMemoryType(), mr.GetSystemMemoryType()))
-                            logging.error("Multiple system memory types found for one region " + page.pageDebugStr() + " " +  mr.pageDebugStr())
+                        if mr.SystemMemoryType is not None:
+                            if page.SystemMemoryType is None:
+                                page.SystemMemoryType = mr.SystemMemoryType
+                            else:
+                                self.ErrorMsg.append("Multiple System Memory types found for one region.  Base: 0x%X.  System Memory Type: %s and %s."% (page.PhysicalStart,page.GetSystemMemoryType(), mr.GetSystemMemoryType()))
+                                logging.error("Multiple system memory types found for one region " + page.pageDebugStr() + " " +  mr.pageDebugStr())
                     
                     # A CPU Number present in a memory range object implies it represents an AP stack. Capture the CPU
                     # number for printing a CPU identifier for each AP stack.


### PR DESCRIPTION
## Description

When working through the page table, it's possible page groups should be split if there is an image or system memory type present in that range. Also, not all objects which can be interpreted as memory ranges have set (non-None) VirtualStart or NumberOfPages fields for debug printing.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running on SBSA and Q35 produced page tables

## Integration Instructions

N/A
