### PR TITLE
Fix LineParserTestApp Ticks Calculation

### DIFF
--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -128,7 +128,8 @@ InternalGetPerformanceCounter (
   UINT64           TimeInMs;
   UINT64           TimeInNs;
   UINT64           Frequency;
-  STATIC   UINT64  Ticks = 0;
+  UINT32           Remainder = 0;
+  STATIC   UINT64  Ticks     = 0;
 
   if (Ticks != 0) {
     return Ticks;
@@ -171,7 +172,7 @@ InternalGetPerformanceCounter (
   //
   // Do multiply first, then divide, to keep as many bits as possible
   //
-  Ticks    = DivU64x32 (MultU64x64 (TimeInMs, Frequency), 1000u);
+  Ticks    = DivU64x32Remainder (MultU64x64 (TimeInMs, Frequency), 1000u, &Remainder) + Remainder;
   TimeInNs = GetTimeInNanoSecond (Ticks);
 
   UT_ASSERT_TRUE (TimeInMs == (TimeInNs / 1000000u));


### PR DESCRIPTION
## Description

(TimeInMs * Frequency) / 1000 == Ticks is algebraically correct but can result in a remainder. By chance, the chosen TimeInMs and platform frequency has not previously resulted in a remainder that mattered for the precision of the platform's GetTimeInNanoSecond() function but on Q35 the remainder breaks the test.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the test on Q35

## Integration Instructions

N/A
