### PR TITLE
Fix invalid bytes in INF file leading to build warnings

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
@@ -1,4 +1,4 @@
-﻿## @file
+## @file
 # TCBZ3519
 # Uefi Shell based Application that unit tests the Memory Attribute Protocol.
 #
@@ -39,7 +39,7 @@
   UnitTestLib
   UefiBootServicesTableLib
   DebugLib
-  
+
 [LibraryClasses.AARCH64]
   ArmLib
 


### PR DESCRIPTION
## Description

Fixes invalid bytes preceding the first UTF-8 bytes in the MemoryAttributeProtocolFuncTestApp.inf. This fixes build warnings that are occurring in the MU_PLUS CI and Platform builds.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Successfully built locally.

## Integration Instructions

N/A
