### PR TITLE
[REBASE && FF] MemoryProtectionTestApp Updates

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
@@ -59,6 +59,7 @@
 
 [Guids]
   gMemoryProtectionExceptionHandlerGuid               ## CONSUMES
+  gEfiHobMemoryAllocStackGuid                         ## CONSUMES
 
 [Protocols]
   gEfiSmmCommunicationProtocolGuid
@@ -66,6 +67,7 @@
   gMemoryProtectionNonstopModeProtocolGuid      ## CONSUMES
   gMemoryProtectionDebugProtocolGuid            ## CONSUMES
   gEfiMemoryAttributeProtocolGuid               ## CONSUMES
+  gCpuMpDebugProtocolGuid                       ## CONSUMES
 
 [Guids]
   gEdkiiPiSmmCommunicationRegionTableGuid

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
@@ -14,11 +14,30 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 CHAR8  *MEMORY_TYPES[] = { "ReservedMemoryType", "LoaderCode", "LoaderData", "BootServicesCode", "BootServicesData", "RuntimeServicesCode", "RuntimeServicesData", "ConventionalMemory", "UnusableMemory", "ACPIReclaimMemory", "ACPIMemoryNVS", "MemoryMappedIO", "MemoryMappedIOPortSpace", "PalCode", "PersistentMemory" };
 
+////
+// Reset:                   Test will be run by violating the memory protection policy with the expectation that the system
+//                          will reboot each time. The test will take roughly 45 minutes to run with a strict protection policy.
+//
+// ClearFaults:             Test will be run by violating the memory protection policy with the expectation that the exception
+//                          handler will clear the faulting page(s) and allow the test to continue. The test will take roughly
+//                          5 seconds to run with a strict protection policy.
+//
+// MemoryAttributeProtocol: The protection policy will be validated by using the Memory Attribute Protocol to
+//                          get the memory attributes of the page(s) which are expected to be protected. The test will take roughly
+//                          5 seconds to run with a strict protection policy.
+////
+typedef enum {
+  MemoryProtectionTestReset,
+  MemoryProtectionTestClearFaults,
+  MemoryProtectionTestMemoryAttributeProtocol,
+  MemoryProtectionTestMax
+} MEMORY_PROTECTION_TESTING_METHOD;
+
 typedef struct _MEMORY_PROTECTION_TEST_CONTEXT {
-  UINT64     TargetMemoryType;
-  UINT64     TestProgress;
-  UINT8      GuardAlignment;
-  BOOLEAN    DynamicActive;
+  UINT64                              TargetMemoryType;
+  UINT64                              TestProgress;
+  UINT8                               GuardAlignment;
+  MEMORY_PROTECTION_TESTING_METHOD    TestingMethod;
 } MEMORY_PROTECTION_TEST_CONTEXT;
 
 #define MEMORY_PROTECTION_TEST_POOL          1

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
@@ -12,7 +12,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma pack(1)
 
-CHAR8  *MEMORY_TYPES[] = { "ReservedMemoryType", "LoaderCode", "LoaderData", "BootServicesCode", "BootServicesData", "RuntimeServicesCode", "RuntimeServicesData", "ConventionalMemory", "UnusableMemory", "ACPIReclaimMemory", "ACPIMemoryNVS", "MemoryMappedIO", "MemoryMappedIOPortSpace", "PalCode", "PersistentMemory" };
+CHAR8  *MEMORY_TYPES[] = {
+  "ReservedMemoryType",      "LoaderCode",          "LoaderData",          "BootServicesCode",
+  "BootServicesData",        "RuntimeServicesCode", "RuntimeServicesData", "ConventionalMemory",
+  "UnusableMemory",          "ACPIReclaimMemory",   "ACPIMemoryNVS",       "MemoryMappedIO",
+  "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory"
+};
 
 ////
 // Reset:                   Test will be run by violating the memory protection policy with the expectation that the system
@@ -44,9 +49,6 @@ typedef struct _MEMORY_PROTECTION_TEST_CONTEXT {
 #define MEMORY_PROTECTION_TEST_PAGE          2
 #define MEMORY_PROTECTION_TEST_NULL_POINTER  3
 
-#define MEMORY_TYPE_CONVENTIONAL  7
-#define MEMORY_TYPE_PERSISTENT    14
-
 typedef struct _MEMORY_PROTECTION_TEST_COMM_BUFFER {
   UINT16                            Function;
   MEMORY_PROTECTION_TEST_CONTEXT    Context;
@@ -61,14 +63,8 @@ typedef struct _MEMORY_PROTECTION_TEST_COMM_BUFFER {
 
 EFI_GUID  gMemoryProtectionTestSmiHandlerGuid = MEMORY_PROTECTION_TEST_SMI_HANDLER_GUID;
 
-#define NUM_MEMORY_TYPES  15
-#define MAX_STRING_SIZE   0x1000
-#define ADDRESS_BITS      0x0000007FFFFFF000ull
-
 STATIC CONST UINT16  mPoolSizeTable[] = {
   128, 256, 384, 640, 1024, 1664, 2688, 4352, 7040, 11392, 18432, 29824, 30000
 };
-
-#define NUM_POOL_SIZES  13
 
 #endif // _MEMORY_PROTECTION_TEST_COMMON_H_

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Readme.md
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Readme.md
@@ -19,8 +19,9 @@ the attributes using the memory attribute protocol. The test has a few methods o
 This method is the slowest, reaching upwards of 45 minutes with a strict protection policy
 (benchmarked on a Q35 DEBUG build). The test will intentionally cause faults for each
 protection policy and use a custom installed fault handler for IA32_PAGE_FAULT exceptions
-which simply performs a warm reset on a fault. This method can be run on either X64
-or ARM64 platforms.
+which simply performs a warm reset on a fault. This method can be run on x86 based platforms.
+Currently, the test doesn't install a synchronous handler for initiating a reset on ARM
+platforms.
 
 ## Testing by Clearing Faults
 
@@ -35,8 +36,9 @@ This method takes less than 5 seconds to run. Instead of intentionally causing f
 this method checks the attributes of the region which should fault against the expected
 protection attributes. For example, instead of intentionally causing a stack overflow to
 check the stack guard, the test will find the stack base and check that the attributes
-are EFI_MEMORY_RP using the Memory Attribute Protocol. This method can be run on either
-X64 or ARM64 platforms.
+are EFI_MEMORY_RP using the Memory Attribute Protocol (because the page at the stack base
+is a guard page marked EFI_MEMORY_RP). This method can be run on either X64 or
+ARM64 platforms.
 
 ## Running the Test
 

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Readme.md
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Readme.md
@@ -1,4 +1,4 @@
-# Memory Protection Tests
+# Memory Protection Test App
 
 ## Copyright
 
@@ -7,15 +7,47 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 ## About This Test
 
-This is set of tests to ensure that heap guard, stack guard, null pointer detection, and nx protections are working properly.
+This test verifies the memory protection features of Project Mu. The test checks the
+memory protection policy of the system and adds a test for each memory type of each
+protection type active. For example, if the system protection policy has NX protection
+on EfiBootServicesData, the test will allocate a buffer of that type and check the
+attributes of that buffer either by attempting to execute code within it or by fetching
+the attributes using the memory attribute protocol. The test has a few methods of running.
 
-It consists of:
+## Testing using Resets
 
-- An SMM driver
-- A Shell-based test app
+This method is the slowest, reaching upwards of 45 minutes with a strict protection policy
+(benchmarked on a Q35 DEBUG build). The test will intentionally cause faults for each
+protection policy and use a custom installed fault handler for IA32_PAGE_FAULT exceptions
+which simply performs a warm reset on a fault. This method can be run on either X64
+or ARM64 platforms.
 
-The Shell-based app may be built at any time and run from Shell. The app can use the SMM driver to preform SMM tests if the
-SMM driver is installed.
+## Testing by Clearing Faults
 
-It is not the intention of this test to include the driver in production systems. They should only be used for purpose-built
-test images.
+This method takes less than 5 seconds to run. The test will intentionally cause faults for
+each protection policy with the expectation that the Project Mu fault handler will clear the
+fault and allow the test to continue. Project Mu currently only supports this method of
+running the test on x86 based platforms.
+
+## Testing by using the Memory Attribute Protocol
+
+This method takes less than 5 seconds to run. Instead of intentionally causing faults,
+this method checks the attributes of the region which should fault against the expected
+protection attributes. For example, instead of intentionally causing a stack overflow to
+check the stack guard, the test will find the stack base and check that the attributes
+are EFI_MEMORY_RP using the Memory Attribute Protocol. This method can be run on either
+X64 or ARM64 platforms.
+
+## Running the Test
+
+The test is run from the shell using the command `MemoryProtectionTestApp.efi`. By default,
+the test will try to run using the Memory Attribute Protocol method, then the Clearing
+Faults method, then the warm reset method. If none of these methods are available, the
+test will fail. The test can be run using a specific method by passing in one of the
+following arguments:
+
+'--Reset'
+
+'--ClearFaults'
+
+'--MemoryAttribute'


### PR DESCRIPTION
1. Add the ability to use the Memory Attribute Protocol in MemoryProtectionTestApp
2. Update the MemoryProtectionTestApp.c file to add comments and function headers, and remove unused functions and logic.