### PR TITLE
Bugfix: Change UT_LOG to DEBUG in MsWheaEarlyUnitTest Entry Point

### DIFF
--- a/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
+++ b/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
@@ -538,7 +538,7 @@ MsWheaEarlyUnitTestAppEntryPoint (
   // Only run the following tests if the early storage region can store at least one entry.
   // If the region is too small, log an error to alert the tester to the issue.
   if (MsWheaESGetMaxDataCount () < sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON)) {
-    UT_LOG_ERROR ("Early storage capacity is not large enough to fit an early storage entry! Skipping tests.\n");
+    DEBUG ((DEBUG_ERROR, "%a Early storage region is too small to store a single entry. Skipping tests.\n", __FUNCTION__));
     return EFI_SUCCESS;
   }
 

--- a/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
+++ b/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
@@ -538,7 +538,7 @@ MsWheaEarlyUnitTestAppEntryPoint (
   // Only run the following tests if the early storage region can store at least one entry.
   // If the region is too small, log an error to alert the tester to the issue.
   if (MsWheaESGetMaxDataCount () < sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON)) {
-    DEBUG ((DEBUG_ERROR, "Early storage capacity is not large enough to fit an early storage entry! Skipping tests.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Early storage capacity is not large enough to fit an early storage entry! Skipping tests.\n"));
     return EFI_SUCCESS;
   }
 

--- a/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
+++ b/MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.c
@@ -538,7 +538,7 @@ MsWheaEarlyUnitTestAppEntryPoint (
   // Only run the following tests if the early storage region can store at least one entry.
   // If the region is too small, log an error to alert the tester to the issue.
   if (MsWheaESGetMaxDataCount () < sizeof (MS_WHEA_EARLY_STORAGE_ENTRY_COMMON)) {
-    DEBUG ((DEBUG_ERROR, "%a Early storage region is too small to store a single entry. Skipping tests.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "Early storage capacity is not large enough to fit an early storage entry! Skipping tests.\n", __FUNCTION__));
     return EFI_SUCCESS;
   }
 


### PR DESCRIPTION
## Description

UT_LOG functionality requires the unit tests to be running backed by the unit test engine. Update the UT_LOG in the entry point to a debug statement.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running test on SBSA

## Integration Instructions

N/A