### PR TITLE
MsCorePkg: Add LoadOptionVariablePolicyDxe

### DIFF
--- a/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.c
+++ b/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.c
@@ -1,0 +1,379 @@
+/** @file
+  Sets variable policy for Boot Manager load options that are not required to be supported per the UEFI Specification.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+#include <Guid/GlobalVariable.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/VariablePolicyHelperLib.h>
+
+#define PLATFORM_RECOVERY_VARIABLE_NAME  L"PlatformRecovery"
+
+typedef struct {
+  CHAR16    *VariableName;
+  UINT32    VariableAttributes;
+} BM_LOAD_OPTION_VAR_INFO;
+
+//
+// Boot Manager load options that have variable policy applied by this driver.
+//
+GLOBAL_REMOVE_IF_UNREFERENCED BM_LOAD_OPTION_VAR_INFO  mBmLoadOptionInfo[] = {
+  // Fixed-Name Order Variables
+  {
+    EFI_DRIVER_ORDER_VARIABLE_NAME,
+    (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE)
+  },
+  {
+    EFI_SYS_PREP_ORDER_VARIABLE_NAME,
+    (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE)
+  },
+
+  // Wildcard Option Variables
+  {
+    L"Driver####",
+    (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE)
+  },
+  {
+    L"PlatformRecovery####",
+    (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS)
+  },
+  {
+    L"SysPrep####",
+    (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE)
+  }
+};
+
+/**
+  Gets the next UEFI variable name.
+
+  This buffer manages the UEFI variable name buffer, performing memory reallocations as necessary.
+
+  Note: The first time this function is called, VariableNameBufferSize must be 0 and
+  the VariableName buffer pointer must point to NULL.
+
+  @param[in,out] VariableNameBufferSize   On input, a pointer to a buffer that holds the current
+                                          size of the VariableName buffer in bytes.
+                                          On output, a pointer to a buffer that holds the updated
+                                          size of the VariableName buffer in bytes.
+  @param[in,out] VariableName             On input, a pointer to a pointer to a buffer that holds the
+                                          current UEFI variable name.
+                                          On output, a pointer to a pointer to a buffer that holds the
+                                          next UEFI variable name.
+  @param[in,out] VariableGuid             On input, a pointer to a buffer that holds the current UEFI
+                                          variable GUID.
+                                          On output, a pointer to a buffer that holds the next UEFI
+                                          variable GUID.
+
+  @retval    EFI_SUCCESS              The next UEFI variable name was found successfully.
+  @retval    EFI_INVALID_PARAMETER    A pointer argument is NULL or initial input values are invalid.
+  @retval    EFI_OUT_OF_RESOURCES     Insufficient memory resources to allocate a required buffer.
+  @retval    Others                   Return status codes from the UEFI spec define GetNextVariableName() interface.
+
+**/
+EFI_STATUS
+GetNextVariableNameWithDynamicReallocation (
+  IN  OUT UINTN     *VariableNameBufferSize,
+  IN  OUT CHAR16    **VariableName,
+  IN  OUT EFI_GUID  *VariableGuid
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NextVariableNameBufferSize;
+
+  if ((VariableNameBufferSize == NULL) || (VariableName == NULL) || (VariableGuid == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (*VariableNameBufferSize == 0) {
+    if (*VariableName != NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    //
+    // Allocate a buffer to temporarily hold variable names. To reduce memory
+    // allocations, the default buffer size is 256 characters. The buffer can
+    // be reallocated if expansion is necessary (should be very rare).
+    //
+    *VariableNameBufferSize = sizeof (CHAR16) * 256;
+    *VariableName           = AllocateZeroPool (*VariableNameBufferSize);
+    if (*VariableName == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    ZeroMem ((VOID *)VariableGuid, sizeof (EFI_GUID));
+  }
+
+  NextVariableNameBufferSize = *VariableNameBufferSize;
+  Status                     = gRT->GetNextVariableName (
+                                      &NextVariableNameBufferSize,
+                                      *VariableName,
+                                      VariableGuid
+                                      );
+  if (Status == EFI_BUFFER_TOO_SMALL) {
+    *VariableName = ReallocatePool (
+                      *VariableNameBufferSize,
+                      NextVariableNameBufferSize,
+                      *VariableName
+                      );
+    if (*VariableName == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    *VariableNameBufferSize = NextVariableNameBufferSize;
+
+    Status = gRT->GetNextVariableName (
+                    &NextVariableNameBufferSize,
+                    *VariableName,
+                    VariableGuid
+                    );
+    ASSERT (Status != EFI_BUFFER_TOO_SMALL);
+  }
+
+  return Status;
+}
+
+/**
+  Check if a Unicode character is a hexadecimal character.
+
+  Valid hexadecimal characters are L'0' to L'9', L'a' to L'f', or L'A' to L'F'.
+
+  @param[in]  Char  The character to check against.
+
+  @retval TRUE  If the Char is a hexadecimal character.
+  @retval FALSE If the Char is not a hexadecimal character.
+
+**/
+BOOLEAN
+EFIAPI
+IsHexaDecimalDigitCharacter (
+  IN      CHAR16  Char
+  )
+{
+  return (BOOLEAN)((Char >= L'0' && Char <= L'9') || (Char >= L'A' && Char <= L'F') || (Char >= L'a' && Char <= L'f'));
+}
+
+/**
+  Removes pre-existing variables that may have been written during this boot before the load option
+  policy enforced by this driver is active.
+
+**/
+VOID
+RemovePreExistingVariables (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  EFI_STATUS  GetNextVariableStatus;
+  UINT32      Attributes;
+  UINTN       DataSize;
+  UINTN       Index;
+  UINTN       VariableNameBufferSize;
+  UINTN       VariableNameLength;
+  UINTN       VariablePendingDeleteNameBufferSize;
+  EFI_GUID    VariableGuid;
+  BOOLEAN     VariableDeleted;
+  CHAR16      *VariableName;
+  CHAR16      *VariablePendingDeleteName;
+
+  Status                              = EFI_SUCCESS;
+  VariableName                        = NULL;
+  VariablePendingDeleteName           = NULL;
+  VariableDeleted                     = FALSE;
+  VariableNameBufferSize              = 0;
+  VariablePendingDeleteNameBufferSize = 0;
+
+  do {
+    if (!VariableDeleted) {
+      GetNextVariableStatus = GetNextVariableNameWithDynamicReallocation (
+                                &VariableNameBufferSize,
+                                &VariableName,
+                                &VariableGuid
+                                );
+    } else {
+      VariableDeleted = FALSE;
+    }
+
+    if (!EFI_ERROR (GetNextVariableStatus) && CompareGuid (&VariableGuid, &gEfiGlobalVariableGuid)) {
+      VariableNameLength = StrLen (VariableName);
+
+      //
+      // Check that the variable root name is a candidate for a platform recovery load option
+      //
+      if ((VariableNameLength <= 4) || (VariableNameLength - 4 != StrLen (PLATFORM_RECOVERY_VARIABLE_NAME))) {
+        continue;
+      }
+
+      //
+      // Check that the variable root name is a platform recovery load option
+      //
+      if (StrnCmp (VariableName, PLATFORM_RECOVERY_VARIABLE_NAME, VariableNameLength - 4) != 0) {
+        continue;
+      }
+
+      //
+      // Check that the last 4 digits are hex digits
+      //
+      for (Index = VariableNameLength - 4; Index < VariableNameLength; Index++) {
+        if (!IsHexaDecimalDigitCharacter (VariableName[Index])) {
+          // Only variables with hex digits are considered valid per UEFI Specification
+          break;
+        }
+      }
+
+      if (Index == VariableNameLength) {
+        DEBUG ((
+          DEBUG_WARN,
+          "[%a] - The UEFI variable %s was written this boot. It is being deleted per load option policy.\n",
+          __FUNCTION__,
+          VariableName
+          ));
+
+        Attributes = 0;
+        DataSize   = 0;
+        Status     = gRT->GetVariable (
+                            VariableName,
+                            &gEfiGlobalVariableGuid,
+                            &Attributes,
+                            &DataSize,
+                            NULL
+                            );
+        if (Status != EFI_BUFFER_TOO_SMALL) {
+          // A zero size buffer should be too small for a present (enumerable) variable
+          ASSERT (Status == EFI_BUFFER_TOO_SMALL);
+          continue;
+        }
+
+        ASSERT (DataSize > 0);
+        if (Attributes != (EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_BOOTSERVICE_ACCESS)) {
+          // PlatformRecovery#### must have (RT|BS) per UEFI Spec
+          // Assert to bring attention if this is not the case but proceed to delete regardless
+          ASSERT_EFI_ERROR (EFI_SECURITY_VIOLATION);
+        }
+
+        // Prepare a backup name buffer to keep tracking GetNextVariableName() during deletion
+        ASSERT ((VariablePendingDeleteNameBufferSize > 0) || (VariablePendingDeleteName == NULL));
+        if (VariablePendingDeleteNameBufferSize < VariableNameBufferSize) {
+          if (VariablePendingDeleteName != NULL) {
+            FreePool (VariablePendingDeleteName);
+          }
+
+          VariablePendingDeleteName = AllocateZeroPool (VariableNameBufferSize);
+          if (VariablePendingDeleteName == NULL) {
+            Status = EFI_OUT_OF_RESOURCES;
+            ASSERT_EFI_ERROR (Status);
+            goto DeallocateAndExit;
+          }
+
+          VariablePendingDeleteNameBufferSize = VariableNameBufferSize;
+        }
+
+        StrnCpyS (
+          VariablePendingDeleteName,
+          VariableNameBufferSize / sizeof (CHAR16),
+          VariableName,
+          (VariableNameBufferSize / sizeof (CHAR16)) - 1
+          );
+
+        //
+        // Skip to the next variable name since the current name will
+        // be invalid after deletion.
+        //
+        GetNextVariableStatus = GetNextVariableNameWithDynamicReallocation (
+                                  &VariableNameBufferSize,
+                                  &VariableName,
+                                  &VariableGuid
+                                  );
+
+        Status = gRT->SetVariable (
+                        VariablePendingDeleteName,
+                        &gEfiGlobalVariableGuid,
+                        0,
+                        0,
+                        NULL
+                        );
+        ASSERT_EFI_ERROR (Status);
+        VariableDeleted = TRUE;
+      }
+    }
+  } while (!EFI_ERROR (GetNextVariableStatus));
+
+DeallocateAndExit:
+  if (VariableName != NULL) {
+    FreePool (VariableName);
+  }
+
+  if (VariablePendingDeleteName != NULL) {
+    FreePool (VariablePendingDeleteName);
+  }
+}
+
+/**
+  Applies variable policies for the variables protected by this driver.
+
+**/
+VOID
+SetVariablePolicy (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  UINTN                           Index;
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy;
+
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] - Failed to find the variable policy protocol.\n", __FUNCTION__));
+    ASSERT_EFI_ERROR (EFI_NOT_FOUND);
+    return;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mBmLoadOptionInfo); Index++) {
+    Status = RegisterBasicVariablePolicy (
+               VariablePolicy,
+               &gEfiGlobalVariableGuid,
+               mBmLoadOptionInfo[Index].VariableName,
+               VARIABLE_POLICY_NO_MIN_SIZE,
+               VARIABLE_POLICY_NO_MAX_SIZE,
+               mBmLoadOptionInfo[Index].VariableAttributes,
+               ~(mBmLoadOptionInfo[Index].VariableAttributes),
+               VARIABLE_POLICY_TYPE_LOCK_NOW
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "[%a] - RegisterBasicVariablePolicy() returned %r!\n", __FUNCTION__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+  }
+}
+
+/**
+  Driver entry point that performs the main responsibilities of the driver.
+
+  @param[in]  ImageHandle   The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable   A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   This constructor always returns success.
+
+**/
+EFI_STATUS
+EFIAPI
+LoadOptionVariablePolicyDxeEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  DEBUG ((DEBUG_VERBOSE, "[%a] - Entry", __FUNCTION__));
+
+  RemovePreExistingVariables ();
+  SetVariablePolicy ();
+
+  return EFI_SUCCESS;
+}

--- a/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.c
+++ b/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.c
@@ -106,6 +106,7 @@ GetNextVariableNameWithDynamicReallocation (
     *VariableNameBufferSize = sizeof (CHAR16) * 256;
     *VariableName           = AllocateZeroPool (*VariableNameBufferSize);
     if (*VariableName == NULL) {
+      *VariableNameBufferSize = 0;
       return EFI_OUT_OF_RESOURCES;
     }
 

--- a/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
+++ b/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
@@ -18,7 +18,7 @@
 # """
 #
 # Any platform that uses this driver essentially "locks out" these variables from being created and supported
-# by BDS on that platform. Therefore, the following capability bit must not be set in L"BootSuppport" to comply with
+# by BDS on that platform. Therefore, the following capability bit must not be set in L"BootSupport" to comply with
 # the UEFI Specification (`EFI_BOOT_OPTION_SUPPORT_VARIABLE_NAME`): BIT4 - `EFI_BOOT_OPTION_SUPPORT_SYSPREP`.
 #
 # Since PlatformRecovery#### variables can be set during boot, this driver checks if such variables were set prior to
@@ -31,7 +31,7 @@
 ##
 
 [Defines]
-  INF_VERSION         = 0x00010005
+  INF_VERSION         = 0x0001001B
   BASE_NAME           = LoadOptionVariablePolicyDxe
   FILE_GUID           = 47F4201B-6DE1-4A65-B922-5E026E0FF436
   MODULE_TYPE         = DXE_DRIVER

--- a/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
+++ b/MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
@@ -1,0 +1,74 @@
+## @file
+# Sets variable policy for Boot Manager load options that are not required to be supported
+# per the UEFI Specification.
+#
+# This includes:
+#   1. DriverOrder / Driver####
+#   2. PlatformRecovery####
+#   3. SysPrepOrder / SysPrep####
+#
+# The UEFI Specification states the following about support for these variables:
+#
+# """
+# If a platform permits the installation of Load Option Variables, (Boot####, or Driver####, or SysPrep####), the
+# platform must support and recognize all defined values for Attributes within the variable and report these
+# capabilities in BootOptionSupport. If a platform supports installation of Load Option Variables of type Driver####,
+# all installed Driver#### variables must be processed and the indicated driver loaded and initialized during every
+# boot. And all installed SysPrep#### options must be processed prior to processing Boot#### options.
+# """
+#
+# Any platform that uses this driver essentially "locks out" these variables from being created and supported
+# by BDS on that platform. Therefore, the following capability bit must not be set in L"BootSuppport" to comply with
+# the UEFI Specification (`EFI_BOOT_OPTION_SUPPORT_VARIABLE_NAME`): BIT4 - `EFI_BOOT_OPTION_SUPPORT_SYSPREP`.
+#
+# Since PlatformRecovery#### variables can be set during boot, this driver checks if such variables were set prior to
+# the driver called being executed and deletes the variables and then sets the variable policy. This is to ensure
+# consistent behavior where the variable cannot be set regardless of whether the SetVariable() invocation occurred
+# prior or post this driver code executing during boot.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010005
+  BASE_NAME           = LoadOptionVariablePolicyDxe
+  FILE_GUID           = 47F4201B-6DE1-4A65-B922-5E026E0FF436
+  MODULE_TYPE         = DXE_DRIVER
+  VERSION_STRING      = 1.0
+  ENTRY_POINT         = LoadOptionVariablePolicyDxeEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  LoadOptionVariablePolicyDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MsCorePkg/MsCorePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  UefiDriverEntryPoint
+  VariablePolicyHelperLib
+
+[Guids]
+  gEfiGlobalVariableGuid
+
+[Protocols]
+  gEdkiiVariablePolicyProtocolGuid
+
+[Depex]
+  gEfiVariableArchProtocolGuid        AND
+  gEfiVariableWriteArchProtocolGuid   AND
+  gEdkiiVariablePolicyProtocolGuid

--- a/MsCorePkg/MsCorePkg.dsc
+++ b/MsCorePkg/MsCorePkg.dsc
@@ -164,6 +164,7 @@
 ###################################################################################################
 
 [Components]
+  MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
   MsCorePkg/Library/MathLib/MathLib.inf
   MsCorePkg/Library/MemoryTypeInformationChangeLib/MemoryTypeInformationChangeLib.inf
   MsCorePkg/Library/TpmSgNvIndexLib/TpmSgNvIndexLib.inf


### PR DESCRIPTION
## Description

This driver sets UEFI variable policy for Boot Manager load options that
may not be supported by a platform.

This includes:

1. `DriverOrder` / `Driver####`
2. `PlatformRecovery####`
3. `SysPrepOrder` / `SysPrep####`

---

Any platform that uses this driver essentially "locks out" these
variables from being created and supported by BDS on that platform.

Therefore, the following capability bit must not be set in `L"BootSupport"`
to comply with the UEFI Specification
(`EFI_BOOT_OPTION_SUPPORT_VARIABLE_NAME`): BIT4 - `EFI_BOOT_OPTION_SUPPORT_SYSPREP`.

---

Since `PlatformRecovery####` variables can be set during boot, this
driver checks if such variables were set prior to the driver called
being executed and deletes the variables and then sets the variable
policy.

This is to ensure consistent behavior where the variable cannot be set
regardless of whether the `SetVariable()` invocation occurred prior or
post this driver code executing during boot.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified variables are locked with [BootAuditTestApp](https://github.com/microsoft/mu_plus/blob/release/202208/UefiTestingPkg/AuditTests/BootAuditTest/UEFI/BootAuditTestApp.inf)
- Verified variables cannot be written in the OS
- Verified `PlatformRecovery####` variables are deleted if present

## Integration Instructions

Include this driver (`LoadOptionVariablePolicyDxe`) in a platform flash file (FDF)
preferably soon after the UEFI variable driver loads since this is dependent
on the variable read/write architectural protocols and variable policy protocols
both of which should be produced shortly beforehand allowing efficient dispatch
and rapid locking of the variables.

Run `BootAuditTestApp` to confirm variables are locked.