### PR TITLE
Continue power management on disabled APs

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/App/MpManagementTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/App/MpManagementTestApp.c
@@ -27,10 +27,10 @@
 #define BSP_SUSPEND_TIMER_US   1000000
 #define US_TO_NS(a)  (a * 1000)
 
-MP_MANAGEMENT_PROTOCOL    *mMpManagement  = NULL;
-EFI_MP_SERVICES_PROTOCOL  *mMpServices    = NULL;
-UINTN                     mBspIndex       = 0;
-UINTN                     mApDutIndex     = 0;
+MP_MANAGEMENT_PROTOCOL    *mMpManagement = NULL;
+EFI_MP_SERVICES_PROTOCOL  *mMpServices   = NULL;
+UINTN                     mBspIndex      = 0;
+UINTN                     mApDutIndex    = 0;
 
 /// ================================================================================================
 /// ================================================================================================
@@ -910,9 +910,9 @@ InitializeTestEnvironment (
   VOID
   )
 {
-  EFI_STATUS                Status;
-  UINTN                     NumCpus;
-  UINTN                     EnabledCpus;
+  EFI_STATUS  Status;
+  UINTN       NumCpus;
+  UINTN       EnabledCpus;
 
   Status = gBS->LocateProtocol (
                   &gEfiMpServiceProtocolGuid,

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/App/MpManagementTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/App/MpManagementTestApp.c
@@ -27,9 +27,10 @@
 #define BSP_SUSPEND_TIMER_US   1000000
 #define US_TO_NS(a)  (a * 1000)
 
-MP_MANAGEMENT_PROTOCOL  *mMpManagement = NULL;
-UINTN                   mBspIndex      = 0;
-UINTN                   mApDutIndex    = 0;
+MP_MANAGEMENT_PROTOCOL    *mMpManagement  = NULL;
+EFI_MP_SERVICES_PROTOCOL  *mMpServices    = NULL;
+UINTN                     mBspIndex       = 0;
+UINTN                     mApDutIndex     = 0;
 
 /// ================================================================================================
 /// ================================================================================================
@@ -102,6 +103,57 @@ PowerOnSingleAp (
 
   return UNIT_TEST_PASSED;
 } // PowerOnSingleAp ()
+
+/**
+  Disable a single AP before we test anything on it.
+
+  @param[in] Context                  Test context applied for this test case
+
+  @retval UNIT_TEST_PASSED            The entry point executed successfully.
+  @retval UNIT_TEST_ERROR_TEST_FAILED Null pointer detected.
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+DisableSingleAp (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mMpServices == NULL) {
+    return UNIT_TEST_ERROR_TEST_FAILED;
+  }
+
+  Status = mMpServices->EnableDisableAP (mMpServices, mApDutIndex, FALSE, NULL);
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  return UNIT_TEST_PASSED;
+} // DisableSingleAp ()
+
+/**
+  Enable a single AP after we test on it.
+
+  @param[in] Context                  Test context applied for this test case
+**/
+VOID
+EFIAPI
+EnableSingleAp (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mMpServices == NULL) {
+    ASSERT (FALSE);
+    return;
+  }
+
+  Status = mMpServices->EnableDisableAP (mMpServices, mApDutIndex, TRUE, NULL);
+
+  ASSERT_EFI_ERROR (Status);
+} // EnableSingleAp ()
 
 /// ================================================================================================
 /// ================================================================================================
@@ -859,14 +911,13 @@ InitializeTestEnvironment (
   )
 {
   EFI_STATUS                Status;
-  EFI_MP_SERVICES_PROTOCOL  *MpServices;
   UINTN                     NumCpus;
   UINTN                     EnabledCpus;
 
   Status = gBS->LocateProtocol (
                   &gEfiMpServiceProtocolGuid,
                   NULL,
-                  (VOID **)&MpServices
+                  (VOID **)&mMpServices
                   );
   if (EFI_ERROR (Status)) {
     // If we're here, we definitely had something weird happen...
@@ -874,13 +925,13 @@ InitializeTestEnvironment (
     goto Done;
   }
 
-  Status = MpServices->GetNumberOfProcessors (MpServices, &NumCpus, &EnabledCpus);
+  Status = mMpServices->GetNumberOfProcessors (mMpServices, &NumCpus, &EnabledCpus);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to get the number of processors!!! - %r\n", __FUNCTION__, Status));
     goto Done;
   }
 
-  Status = MpServices->WhoAmI (MpServices, &mBspIndex);
+  Status = mMpServices->WhoAmI (mMpServices, &mBspIndex);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to get the index of BSP!!! - %r\n", __FUNCTION__, Status));
     goto Done;
@@ -937,6 +988,7 @@ MpManagementTestApp (
   UNIT_TEST_FRAMEWORK_HANDLE  Fw = NULL;
   UNIT_TEST_SUITE_HANDLE      BasicOperationTests;
   UNIT_TEST_SUITE_HANDLE      SuspendOperationTests;
+  UNIT_TEST_SUITE_HANDLE      DisabledApTests;
   UINTN                       Context = PROTOCOL_DOUBLE_CHECK;
 
   DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
@@ -975,6 +1027,16 @@ MpManagementTestApp (
   Status = CreateUnitTestSuite (&SuspendOperationTests, Fw, "Suspend Operation Tests", "MpManagement.Suspend", NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for SuspendOperationTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  //
+  // Populate the DisabledApTests Unit Test Suite.
+  //
+  Status = CreateUnitTestSuite (&DisabledApTests, Fw, "Disabled AP Operation Tests", "MpManagement.DisabledAp", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for DisabledApTests\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto EXIT;
   }
@@ -1023,6 +1085,15 @@ MpManagementTestApp (
   AddTestCase (SuspendOperationTests, "Suspend to C1 on BSP should succeed after a timeout", "MpManagement.SuspendC1.BSP", SuspendBspToC1, NULL, NULL, NULL);
   AddTestCase (SuspendOperationTests, "Suspend to C2 on BSP should succeed after a timeout", "MpManagement.SuspendC2.BSP", SuspendBspToC2, NULL, NULL, NULL);
   AddTestCase (SuspendOperationTests, "Suspend to C3 on BSP should succeed after a timeout", "MpManagement.SuspendC3.BSP", SuspendBspToC3, NULL, NULL, NULL);
+
+  AddTestCase (DisabledApTests, "Disable one AP then turn on all should succeed", "MpManagement.DisabledAp.TurnOnAll", TurnOnAllAps, DisableSingleAp, NULL, NULL);
+  AddTestCase (DisabledApTests, "Suspend all to C1 with one AP disabled should succeed", "MpManagement.DisabledAp.SuspendAllC1", SuspendAllApsToC1, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Resume all from C1 with one AP disabled should succeed", "MpManagement.DisabledAp.ResumeAllC1", ResumeAllAps, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Suspend all to C2 with one AP disabled should succeed", "MpManagement.DisabledAp.SuspendAllC2", SuspendAllApsToC2, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Resume all from C2 with one AP disabled should succeed", "MpManagement.DisabledAp.ResumeAllC2", ResumeAllAps, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Suspend to C3 on BSP should succeed after a timeout", "MpManagement.DisabledAp.SuspendAllC3", SuspendAllApsToC3, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Resume all from C3 with one AP disabled should succeed", "MpManagement.DisabledAp.ResumeAllC3", ResumeAllAps, NULL, NULL, NULL);
+  AddTestCase (DisabledApTests, "Turn off all with one AP disabled should succeed", "MpManagement.DisabledAp.TurnOffAll", TurnOffAllAps, NULL, EnableSingleAp, NULL);
 
   //
   // Execute the tests.

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -80,8 +80,8 @@ IsProcessorEnabled (
   UINTN                         CpuIndex
   )
 {
-  EFI_PROCESSOR_INFORMATION CpuInfo;
-  EFI_STATUS                Status;
+  EFI_PROCESSOR_INFORMATION  CpuInfo;
+  EFI_STATUS                 Status;
 
   if (Mp == NULL) {
     DEBUG ((DEBUG_ERROR, "%a Input protocol is NULL\n", __FUNCTION__));

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -357,7 +357,6 @@ MpMgmtApOn (
     }
 
     if (!IsProcessorEnabled (mMpServices, Index)) {
-      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -460,7 +459,6 @@ MpMgmtApOff (
     }
 
     if (!IsProcessorEnabled (mMpServices, Index)) {
-      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -598,7 +596,6 @@ MpMgmtApSuspend (
     }
 
     if (!IsProcessorEnabled (mMpServices, Index)) {
-      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -710,7 +707,6 @@ MpMgmtApResume (
     }
 
     if (!IsProcessorEnabled (mMpServices, Index)) {
-      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -42,7 +42,7 @@ volatile MP_MANAGEMENT_METADATA  *mCommonBuffer = NULL;
 **/
 STATIC
 EFI_STATUS
-GetProcessorInformation (
+GetMpInformation (
   IN  EFI_MP_SERVICES_PROTOCOL  *Mp,
   OUT UINTN                     *NumProcessors,
   OUT UINTN                     *BspIndex
@@ -62,6 +62,39 @@ GetProcessorInformation (
   }
 
   return EFI_SUCCESS;
+}
+
+/**
+  Helper function to query if a processor is enabled.
+
+  @param Mp             MP Services Protocol.
+  @param CpuIndex       Index of processor that is of interest.
+
+  @return TRUE   The processor is enabled.
+  @return FALSE  The processor is disabled.
+**/
+STATIC
+BOOLEAN
+IsProcessorEnabled (
+  IN  EFI_MP_SERVICES_PROTOCOL  *Mp,
+  UINTN                         CpuIndex
+  )
+{
+  EFI_PROCESSOR_INFORMATION CpuInfo;
+  EFI_STATUS                Status;
+
+  if (Mp == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a Input protocol is NULL\n", __FUNCTION__));
+    return FALSE;
+  }
+
+  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __FUNCTION__, CpuIndex, Status));
+    return FALSE;
+  }
+
+  return ((CpuInfo.StatusFlag & PROCESSOR_ENABLED_BIT) != 0);
 }
 
 /** Initialize the common buffer for all APs.
@@ -271,6 +304,11 @@ MpMgmtApOn (
       continue;
     }
 
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
+      continue;
+    }
+
     if (mCommonBuffer[Index].ApStatus == AP_STATE_ON) {
       DEBUG ((DEBUG_WARN, "%a The specified processor (%d) is already in ON\n", __FUNCTION__, Index));
       Status = EFI_ALREADY_STARTED;
@@ -315,6 +353,11 @@ MpMgmtApOn (
   // If successful, print the hellow world (blocking) from the APs.
   for (Index = StartIndex; Index <= EndIndex; Index++) {
     if (Index == mBspIndex) {
+      continue;
+    }
+
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -381,6 +424,11 @@ MpMgmtApOff (
       continue;
     }
 
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
+      continue;
+    }
+
     if (mCommonBuffer[Index].ApStatus == AP_STATE_OFF) {
       DEBUG ((DEBUG_WARN, "%a The specified processor (%d) is already in OFF state\n", __FUNCTION__, Index));
       Status = EFI_ALREADY_STARTED;
@@ -408,6 +456,11 @@ MpMgmtApOff (
   // If successful, print the hellow world (blocking) from the APs.
   for (Index = StartIndex; Index <= EndIndex; Index++) {
     if (Index == mBspIndex) {
+      continue;
+    }
+
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -508,6 +561,11 @@ MpMgmtApSuspend (
       continue;
     }
 
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
+      continue;
+    }
+
     if (mCommonBuffer[Index].ApStatus == InternalApPowerState) {
       DEBUG ((DEBUG_WARN, "%a The specified processor (%d) is already in expected state (%d)\n", __FUNCTION__, Index, InternalApPowerState));
       Status = EFI_ALREADY_STARTED;
@@ -536,6 +594,11 @@ MpMgmtApSuspend (
   // If successful, print the hellow world (blocking) from the APs.
   for (Index = StartIndex; Index <= EndIndex; Index++) {
     if (Index == mBspIndex) {
+      continue;
+    }
+
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -605,6 +668,11 @@ MpMgmtApResume (
       continue;
     }
 
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
+      continue;
+    }
+
     if (mCommonBuffer[Index].ApStatus == AP_STATE_ON) {
       DEBUG ((DEBUG_WARN, "%a The specified processor (%d) is already fully up\n", __FUNCTION__, Index));
       Status = EFI_ALREADY_STARTED;
@@ -638,6 +706,11 @@ MpMgmtApResume (
   // If successful, print the hellow world (blocking) from the APs.
   for (Index = StartIndex; Index <= EndIndex; Index++) {
     if (Index == mBspIndex) {
+      continue;
+    }
+
+    if (!IsProcessorEnabled (mMpServices, Index)) {
+      DEBUG ((DEBUG_INFO, "%a Processor (%d) disabled, skipping processing\n", __FUNCTION__, Index));
       continue;
     }
 
@@ -705,7 +778,7 @@ MpManagementEntryPoint (
     goto Done;
   }
 
-  Status = GetProcessorInformation (mMpServices, &mNumCpus, &mBspIndex);
+  Status = GetMpInformation (mMpServices, &mNumCpus, &mBspIndex);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Error: Failed to fetch processor information.\n"));
     goto Done;

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -88,7 +88,7 @@ IsProcessorEnabled (
     return FALSE;
   }
 
-  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  Status = Mp->GetProcessorInfo (Mp, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __FUNCTION__, CpuIndex, Status));
     return FALSE;


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Current implementation will stop the execution on the APs that are disabled. This behavior will prevent the test suites from full validation, as some cores might be disabled by design.

This change will add a check prior to core power management operations and proceed with the other cores if the AP of interest is disabled.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on ARM FVP virtual platform with 16 cores. A shell based unit test is used for validation.

## Integration Instructions

N/A
