### PR TITLE
MsCorePkg/PlatformBootManagerLib: Remove boot mode condition for con var update [Rebase & FF]

### DIFF
--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -236,34 +236,24 @@ PlatformBootManagerBeforeConsole (
     FreePool (ConsoleOut);
   }
 
-  //
-  // Fill ConIn/ConOut in Full Configuration boot mode
-  //
-  DEBUG ((DEBUG_INFO, "%a - %x\n", __FUNCTION__, mBootMode));
-  if ((mBootMode == BOOT_WITH_FULL_CONFIGURATION) ||
-      (mBootMode == BOOT_WITH_DEFAULT_SETTINGS) ||
-      (mBootMode == BOOT_WITH_FULL_CONFIGURATION_PLUS_DIAGNOSTICS) ||
-      (mBootMode == BOOT_IN_RECOVERY_MODE))
-  {
-    if (PlatformConsoles != NULL) {
-      while ((*PlatformConsoles).DevicePath != NULL) {
-        //
-        // Update the console variable with the connect type
-        //
-        if (((*PlatformConsoles).ConnectType & CONSOLE_IN) == CONSOLE_IN) {
-          EfiBootManagerUpdateConsoleVariable (ConIn, (*PlatformConsoles).DevicePath, NULL);
-        }
-
-        if (((*PlatformConsoles).ConnectType & CONSOLE_OUT) == CONSOLE_OUT) {
-          EfiBootManagerUpdateConsoleVariable (ConOut, (*PlatformConsoles).DevicePath, NULL);
-        }
-
-        if (((*PlatformConsoles).ConnectType & STD_ERROR) == STD_ERROR) {
-          EfiBootManagerUpdateConsoleVariable (ErrOut, (*PlatformConsoles).DevicePath, NULL);
-        }
-
-        PlatformConsoles++;
+  if (PlatformConsoles != NULL) {
+    while ((*PlatformConsoles).DevicePath != NULL) {
+      //
+      // Update the console variable with the connect type
+      //
+      if (((*PlatformConsoles).ConnectType & CONSOLE_IN) == CONSOLE_IN) {
+        EfiBootManagerUpdateConsoleVariable (ConIn, (*PlatformConsoles).DevicePath, NULL);
       }
+
+      if (((*PlatformConsoles).ConnectType & CONSOLE_OUT) == CONSOLE_OUT) {
+        EfiBootManagerUpdateConsoleVariable (ConOut, (*PlatformConsoles).DevicePath, NULL);
+      }
+
+      if (((*PlatformConsoles).ConnectType & STD_ERROR) == STD_ERROR) {
+        EfiBootManagerUpdateConsoleVariable (ErrOut, (*PlatformConsoles).DevicePath, NULL);
+      }
+
+      PlatformConsoles++;
     }
   }
 

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -237,20 +237,20 @@ PlatformBootManagerBeforeConsole (
   }
 
   if (PlatformConsoles != NULL) {
-    while ((*PlatformConsoles).DevicePath != NULL) {
+    while (PlatformConsoles->DevicePath != NULL) {
       //
       // Update the console variable with the connect type
       //
-      if (((*PlatformConsoles).ConnectType & CONSOLE_IN) == CONSOLE_IN) {
-        EfiBootManagerUpdateConsoleVariable (ConIn, (*PlatformConsoles).DevicePath, NULL);
+      if ((PlatformConsoles->ConnectType & CONSOLE_IN) == CONSOLE_IN) {
+        EfiBootManagerUpdateConsoleVariable (ConIn, PlatformConsoles->DevicePath, NULL);
       }
 
-      if (((*PlatformConsoles).ConnectType & CONSOLE_OUT) == CONSOLE_OUT) {
-        EfiBootManagerUpdateConsoleVariable (ConOut, (*PlatformConsoles).DevicePath, NULL);
+      if ((PlatformConsoles->ConnectType & CONSOLE_OUT) == CONSOLE_OUT) {
+        EfiBootManagerUpdateConsoleVariable (ConOut, PlatformConsoles->DevicePath, NULL);
       }
 
-      if (((*PlatformConsoles).ConnectType & STD_ERROR) == STD_ERROR) {
-        EfiBootManagerUpdateConsoleVariable (ErrOut, (*PlatformConsoles).DevicePath, NULL);
+      if ((PlatformConsoles->ConnectType & STD_ERROR) == STD_ERROR) {
+        EfiBootManagerUpdateConsoleVariable (ErrOut, PlatformConsoles->DevicePath, NULL);
       }
 
       PlatformConsoles++;


### PR DESCRIPTION
## Description

Some platforms may not reach BDS on a boot mode expected by the
current implementation to update the ConIn variable with a new
console input device.

For example, support for a new device might be added in a firmware
update, the update is performed, and the system is reset one or
more times before reaching PlatformBootManagerBeforeConsole().

This change always evaluates a potential update to ConIn regardless
of boot mode to reduce ConIn update complexity.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the build and boot with the change. Since only the boot mode check
is removed, the underlying behavior within the boot mode condition remains
the same.

## Integration Instructions

Review the change to when console may be updated relative to boot mode in
change and the implementation of `EfiBootManagerUpdateConsoleVariable()`
being used by the platform to determine if you would like to make any
changes to that function. No required changes are expected.