### PR TITLE
ci.yaml: add PrEval entry

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
+++ b/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "AdvLoggerPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "AdvLoggerPkg.dsc"

--- a/HidPkg/HidPkg.ci.yaml
+++ b/HidPkg/HidPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "HidPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "HidPkg.dsc"

--- a/MfciPkg/MfciPkg.ci.yaml
+++ b/MfciPkg/MfciPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "MfciPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "MfciPkg.dsc"

--- a/MsCorePkg/MsCorePkg.ci.yaml
+++ b/MsCorePkg/MsCorePkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "MsCorePkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "MsCorePkg.dsc"

--- a/MsGraphicsPkg/MsGraphicsPkg.ci.yaml
+++ b/MsGraphicsPkg/MsGraphicsPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "MsGraphicsPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "MsGraphicsPkg.dsc"

--- a/MsWheaPkg/MsWheaPkg.ci.yaml
+++ b/MsWheaPkg/MsWheaPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "MsWheaPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "MsWheaPkg.dsc"

--- a/PcBdsPkg/PcBdsPkg.ci.yaml
+++ b/PcBdsPkg/PcBdsPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "PcBdsPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "PcBdsPkg.dsc"

--- a/UefiTestingPkg/UefiTestingPkg.ci.yaml
+++ b/UefiTestingPkg/UefiTestingPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "UefiTestingPkg.dsc",
+    },
     ## options defined ci/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "UefiTestingPkg.dsc"

--- a/XmlSupportPkg/XmlSupportPkg.ci.yaml
+++ b/XmlSupportPkg/XmlSupportPkg.ci.yaml
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    "PrEval": {
+        "DscPath": "XmlSupportPkg.dsc",
+    },
     ## options defined .pytool/Plugin/CompilerPlugin
     "CompilerPlugin": {
         "DscPath": "XmlSupportPkg.dsc"


### PR DESCRIPTION
## Description

Adds PrEval entries for all packages to enable the new PrEval Policy 5.
- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
