### PR TITLE
AdvLoggerPkg: fix AdvLoggerSerialPortLib class

### DIFF
--- a/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.c
@@ -17,6 +17,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Library/AdvancedLoggerLib.h>
 
+#include <Library/SerialPortLib.h>
+
 /**
   Initialize the serial device hardware.
 

--- a/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.c
@@ -13,8 +13,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <AdvancedLoggerInternal.h>
 
-#include <Protocol/SerialIo.h>
-
 #include <Library/AdvancedLoggerLib.h>
 
 #include <Library/SerialPortLib.h>

--- a/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.inf
@@ -10,7 +10,6 @@
 [Defines]
   INF_VERSION                    = 1.26
   BASE_NAME                      = AdvLoggerSerialPortLib
-  MODULE_UNI_FILE                = AdvLoggerSerialPortLib.uni
   FILE_GUID                      = 2532f02a-a36a-451a-84f4-9e94c2256a83
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0

--- a/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerSerialPortLib/AdvLoggerSerialPortLib.inf
@@ -14,7 +14,7 @@
   FILE_GUID                      = 2532f02a-a36a-451a-84f4-9e94c2256a83
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = AdvLoggerSerialPortLib
+  LIBRARY_CLASS                  = SerialPortLib
 
 #
 #  VALID_ARCHITECTURES           = X64 AARCH64
@@ -29,10 +29,3 @@
 
 [LibraryClasses]
    AdvancedLoggerLib
-
-[Protocols]
-
-[Pcd]
-
-[Depex]
-  TRUE


### PR DESCRIPTION
## Description

AdvLoggerSerialPortLib was using a library class that was not a true library class (not defined in any .dec file or have an associated .h).

This changes the library class to use the correct library class, SerialPortLib.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Successfully build multiple platforms and pass the newly added BaseTools change for verifying library override class names.

## Integration Instructions

Any library class definitions in a dsc using AdvLoggerSerialPortLib needs to be switched to SerialPortLib.