### PR TITLE
Added logic to delete the Memory Type Information variable on a capsule update.

### DIFF
--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -349,8 +349,8 @@ PlatformBootManagerAfterConsole (
   )
 {
   EFI_STATUS  Status;
-  UINTN       VariableSize;
   UINT32      Attributes;
+  UINTN       VariableSize = 0;
 
   //  EFI_INPUT_KEY                 Key;
 
@@ -398,7 +398,7 @@ PlatformBootManagerAfterConsole (
                       &VariableSize,
                       NULL
                       );
-      if (!EFI_ERROR (Status) || (Status == EFI_BUFFER_TOO_SMALL)) {
+      if (Status == EFI_BUFFER_TOO_SMALL) {
         Status = gRT->SetVariable (
                         EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
                         &gEfiMemoryTypeInformationGuid,

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -349,6 +349,8 @@ PlatformBootManagerAfterConsole (
   )
 {
   EFI_STATUS  Status;
+  UINTN       VariableSize;
+  UINT32      Attributes,
 
   //  EFI_INPUT_KEY                 Key;
 
@@ -389,13 +391,24 @@ PlatformBootManagerAfterConsole (
       EfiBootManagerConnectAll ();
       DEBUG ((DEBUG_INFO, "[%a] - signalling capsules are ready for processing\n", __FUNCTION__));
       DEBUG ((DEBUG_INFO, "[%a] - Deleting Memory Type Information variable for capsule update\n", __FUNCTION__));
-      Status = gRT->SetVariable (
+      Status = gRT->GetVariable (
                       EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
                       &gEfiMemoryTypeInformationGuid,
-                      EFI_VARIABLE_NON_VOLATILE  | EFI_VARIABLE_BOOTSERVICE_ACCESS,
-                      0,
+                      &Attributes,
+                      &VariableSize,
                       NULL
                       );
+      if (!EFI_ERROR (Status) || (Status == EFI_BUFFER_TOO_SMALL)) {
+        Status = gRT->SetVariable (
+                        EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
+                        &gEfiMemoryTypeInformationGuid,
+                        Attributes,
+                        0,
+                        NULL
+                        );
+        ASSERT_EFI_ERROR (Status);
+      }
+
       EfiEventGroupSignal (&gMuReadyToProcessCapsulesNotifyGuid);
       Status = ProcessCapsules ();
 

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -350,7 +350,7 @@ PlatformBootManagerAfterConsole (
 {
   EFI_STATUS  Status;
   UINTN       VariableSize;
-  UINT32      Attributes,
+  UINT32      Attributes;
 
   //  EFI_INPUT_KEY                 Key;
 

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -388,6 +388,14 @@ PlatformBootManagerAfterConsole (
     case BOOT_ON_FLASH_UPDATE:
       EfiBootManagerConnectAll ();
       DEBUG ((DEBUG_INFO, "[%a] - signalling capsules are ready for processing\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "[%a] - Deleting Memory Type Information variable for capsule update\n", __FUNCTION__));
+      Status = gRT->SetVariable (
+                    EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
+                    &gEfiMemoryTypeInformationGuid,
+                    EFI_VARIABLE_NON_VOLATILE  | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                    0,
+                    NULL
+                    );
       EfiEventGroupSignal (&gMuReadyToProcessCapsulesNotifyGuid);
       Status = ProcessCapsules ();
 

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -390,12 +390,12 @@ PlatformBootManagerAfterConsole (
       DEBUG ((DEBUG_INFO, "[%a] - signalling capsules are ready for processing\n", __FUNCTION__));
       DEBUG ((DEBUG_INFO, "[%a] - Deleting Memory Type Information variable for capsule update\n", __FUNCTION__));
       Status = gRT->SetVariable (
-                    EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
-                    &gEfiMemoryTypeInformationGuid,
-                    EFI_VARIABLE_NON_VOLATILE  | EFI_VARIABLE_BOOTSERVICE_ACCESS,
-                    0,
-                    NULL
-                    );
+                      EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
+                      &gEfiMemoryTypeInformationGuid,
+                      EFI_VARIABLE_NON_VOLATILE  | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                      0,
+                      NULL
+                      );
       EfiEventGroupSignal (&gMuReadyToProcessCapsulesNotifyGuid);
       Status = ProcessCapsules ();
 

--- a/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
+++ b/MsCorePkg/Library/PlatformBootManagerLib/BdsPlatform.h
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Guid/CapsuleVendor.h>
 
+#include <Guid/MemoryTypeInformation.h>
 #include <Guid/EventGroup.h>
 #include <Guid/GlobalVariable.h>
 #include <Guid/MemoryOverwriteControl.h>


### PR DESCRIPTION
## Description

Added logic to delete the Memory Type Information variable on a capsule update.  This is because in rare circumstance where a new memory type is added (or a memory type is removed) a capsule update will cause a mismatch of memory types.  Removing the variable and thus forcing a clean memory bucket discovery solves this issue.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a platform where there is a capsule update between two versions of firmware with a different amount of memory types.  Without this change the transition from temp ram to permanent memory breaks but with this change the device correctly goes to the default memory bucket configuration and is able to boot.

## Integration Instructions

N/A
