### PR TITLE
Close ReadyToBoot and ExitBootServices events if a reset is notified.

### DIFF
--- a/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
@@ -16,6 +16,9 @@ VOID        *mFileSystemRegistration = NULL;
 LIST_ENTRY  mLoggingDeviceHead       = INITIALIZE_LIST_HEAD_VARIABLE (mLoggingDeviceHead);
 UINT32      mWritingSemaphore        = 0;
 
+EFI_EVENT  mReadyToBootEvent      = NULL;
+EFI_EVENT  mExitBootServicesEvent = NULL;
+
 /**
     WriteLogFiles
 
@@ -94,6 +97,10 @@ OnResetNotification (
   } else {
     DEBUG ((DEBUG_ERROR, "Unable to write log at reset\n"));
   }
+
+  // Close ready to boot and exit boot services event.
+  gBS->CloseEvent (mReadyToBootEvent);
+  gBS->CloseEvent (mExitBootServicesEvent);
 
   return;
 }
@@ -507,7 +514,6 @@ ProcessReadyToBootRegistration (
   VOID
   )
 {
-  EFI_EVENT   InitEvent;
   EFI_STATUS  Status;
   UINT8       FlushFlags;
 
@@ -524,7 +530,7 @@ ProcessReadyToBootRegistration (
                     OnReadyToBootNotification,
                     gImageHandle,
                     &gEfiEventReadyToBootGuid,
-                    &InitEvent
+                    &mReadyToBootEvent
                     );
 
     if (EFI_ERROR (Status)) {
@@ -551,7 +557,6 @@ ProcessPreExitBootServicesRegistration (
   VOID
   )
 {
-  EFI_EVENT   InitEvent;
   EFI_STATUS  Status;
 
   //
@@ -563,7 +568,7 @@ ProcessPreExitBootServicesRegistration (
                   OnPreExitBootServicesNotification,
                   gImageHandle,
                   &gMuEventPreExitBootServicesGuid,
-                  &InitEvent
+                  &mExitBootServicesEvent
                   );
 
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

Close the ReadyToBoot and ExitBootServices events in the reset notification. This prevents the file logger from trying to access the file system after its reset notification has run in the event that the platform implementation invokes one of those notifications in the reset path (which it shouldn't, but some do). 

- [ ] Impacts functionality?
  - Should not impact functionality since the reset notification is expected to be the last point at which file log can be flushed on most architectures. 
- [ ] Impacts security?
  -  No security impact
- [ ] Breaking change?
  - Not breaking change. 
- [ ] Includes tests?
  - No tests included as no new functionality is introduced.
- [ ] Includes documentation?
  - No docs changed as no new functionality is introduced.

## How This Was Tested

Executed reset, confirmed that file log is flushed as expected. On a system that also invokes the exit boot services notification in the reset path, confirmed that log file is not flushed in the exit boot services notification. Confirmed that on normal boot path to OS, log flush is executed in the exit boot path notification.

## Integration Instructions

N/A
