### PR TITLE
Add a check on the `PcdAdvancedFileLoggerFlush` for exit boot services

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -78,15 +78,6 @@
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedFileLoggerForceEnable|TRUE|BOOLEAN|0x00010184
 
-  ## PcdAdvancedFileLoggerFlush - When the in memory log is flushed to media
-  # The values supported are:
-  # 0 = Never
-  # 1 = Ready To Boot
-  # 2 = Exit Boot Services
-  #
-  # The values can be combined eg. 3 == Ready To Boot and Exit Boot Services.
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedFileLoggerFlush|1|UINT8|0x00010187
-
 
 [PcdsFixedAtBuild]
   ## Advanced Logger Base - NULL = UEFI starts with PEI or DXE, and there is no SEC, or SEC

--- a/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.c
@@ -553,21 +553,27 @@ ProcessPreExitBootServicesRegistration (
 {
   EFI_EVENT   InitEvent;
   EFI_STATUS  Status;
+  UINT8       FlushFlags;
 
-  //
-  // Register notify function for writing the log files.
-  //
-  Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,
-                  TPL_CALLBACK,
-                  OnPreExitBootServicesNotification,
-                  gImageHandle,
-                  &gMuEventPreExitBootServicesGuid,
-                  &InitEvent
-                  );
+  FlushFlags = FixedPcdGet8 (PcdAdvancedFileLoggerFlush);
 
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - Create Event Ex for ExitBootServices. Code = %r\n", __FUNCTION__, Status));
+  Status = EFI_SUCCESS;
+  if (FlushFlags & ADV_PCD_FLUSH_TO_MEDIA_FLAGS_EXIT_BOOT_SERVICES) {
+    //
+    // Register notify function for writing the log files.
+    //
+    Status = gBS->CreateEventEx (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    OnPreExitBootServicesNotification,
+                    gImageHandle,
+                    &gMuEventPreExitBootServicesGuid,
+                    &InitEvent
+                    );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - Create Event Ex for ExitBootServices. Code = %r\n", __FUNCTION__, Status));
+    }
   }
 
   return Status;


### PR DESCRIPTION
## Description

The definition of `PcdAdvancedFileLoggerFlush` mentioned this should be a bitmask for both exit boot services and ready to boot. However, the bit for exit boot services was ignored and a callback was registered regardless of the setting.

This change adds a check to honor the PCD setting and removed the duplicated definition from package dec file.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested on Q35 platform and booted to Windows.

## Integration Instructions

N/A
