### PR TITLE
PcBdsPkg: Fix previous CodeQL change (51c7dc2)

### DIFF
--- a/PcBdsPkg/Include/Library/MsBootPolicyLib.h
+++ b/PcBdsPkg/Include/Library/MsBootPolicyLib.h
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
  * application is at PcsBdsPkg/MsBootPolicy.
  *
  * Boot Policy Applications can be created to meet a platform's requirements. The PcBdsPkg
- * example aplication impelements USB, PXE and HDD boot sequences, in addition to a default
+ * example application impelements USB, PXE and HDD boot sequences, in addition to a default
  * sequences of HDD, USB, PXE.
 **/
 typedef enum {

--- a/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
+++ b/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
@@ -421,7 +421,6 @@ RegisterFvBootOption (
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
     if (BootOptions == NULL) {
-      // ASSERT (BootOptions != NULL);
       DEBUG ((DEBUG_INFO, "No boot options found. Proceeding to add boot options.\n"));
     }
 
@@ -450,7 +449,6 @@ RegisterFvBootOption (
       BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
       if (BootOptions == NULL) {
-        // ASSERT (BootOptions != NULL);
         DEBUG ((DEBUG_INFO, "No boot options found. Skipping deletion.\n"));
       }
 

--- a/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
+++ b/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
@@ -395,7 +395,7 @@ CreateFvBootOption (
  * @param OptionalDataSize  Size of the optional data of the boot option.
  *
  * @return UINTN      If boot option number of the registered boot option
- * 
+ *
  */
 static
 UINTN
@@ -421,7 +421,7 @@ RegisterFvBootOption (
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
     if (BootOptions == NULL) {
-      //ASSERT (BootOptions != NULL);
+      // ASSERT (BootOptions != NULL);
       DEBUG ((DEBUG_INFO, "No boot options found. Proceeding to add boot options.\n"));
     }
 
@@ -450,7 +450,7 @@ RegisterFvBootOption (
       BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
       if (BootOptions == NULL) {
-        //ASSERT (BootOptions != NULL);
+        // ASSERT (BootOptions != NULL);
         DEBUG ((DEBUG_INFO, "No boot options found. Skipping deletion.\n"));
       }
 

--- a/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
+++ b/PcBdsPkg/Library/MsBootOptionsLib/MsBootOptionsLib.c
@@ -394,10 +394,8 @@ CreateFvBootOption (
  * @param OptionalData      Optional data of the boot option.
  * @param OptionalDataSize  Size of the optional data of the boot option.
  *
- * @return UINTN      If a value is returned that is smaller
- *                    than MAX_UINTN we registered successfully.
- * @return MAX_UINTN  We were unable to get Load Options and failed
- *                    to register the boot option.
+ * @return UINTN      If boot option number of the registered boot option
+ * 
  */
 static
 UINTN
@@ -423,8 +421,8 @@ RegisterFvBootOption (
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
     if (BootOptions == NULL) {
-      ASSERT (BootOptions != NULL);
-      return MAX_UINTN;
+      //ASSERT (BootOptions != NULL);
+      DEBUG ((DEBUG_INFO, "No boot options found. Proceeding to add boot options.\n"));
     }
 
     OptionIndex = EfiBootManagerFindLoadOption (&NewOption, BootOptions, BootOptionCount);
@@ -452,8 +450,8 @@ RegisterFvBootOption (
       BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
       if (BootOptions == NULL) {
-        ASSERT (BootOptions != NULL);
-        return MAX_UINTN;
+        //ASSERT (BootOptions != NULL);
+        DEBUG ((DEBUG_INFO, "No boot options found. Skipping deletion.\n"));
       }
 
       for (i = 0; i < BootOptionCount; i++) {
@@ -484,31 +482,11 @@ MsBootOptionsLibRegisterDefaultBootOptions (
   )
 {
   DEBUG ((DEBUG_INFO, "%a\n", __FUNCTION__));
-  UINTN  BootOption;
 
-  BootOption = RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_SDD_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_SDD_BOOT_PARM, sizeof (MS_SDD_BOOT_PARM));
-  if (BootOption == MAX_UINTN) {
-    DEBUG ((DEBUG_ERROR, "Failed to register Boot Option.  Description: %s\n", MS_SDD_BOOT));
-    ASSERT (BootOption != MAX_UINTN);
-  }
-
-  BootOption = RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_USB_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_USB_BOOT_PARM, sizeof (MS_USB_BOOT_PARM));
-  if (BootOption == MAX_UINTN) {
-    DEBUG ((DEBUG_ERROR, "Failed to register Boot Option.  Description: %s\n", MS_USB_BOOT));
-    ASSERT (BootOption != MAX_UINTN);
-  }
-
-  BootOption = RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_PXE_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_PXE_BOOT_PARM, sizeof (MS_PXE_BOOT_PARM));
-  if (BootOption == MAX_UINTN) {
-    DEBUG ((DEBUG_ERROR, "Failed to register Boot Option.  Description: %s\n", MS_PXE_BOOT));
-    ASSERT (BootOption != MAX_UINTN);
-  }
-
-  BootOption = RegisterFvBootOption (PcdGetPtr (PcdShellFile), INTERNAL_UEFI_SHELL_NAME, (UINTN)-1, LOAD_OPTION_ACTIVE, NULL, 0);
-  if (BootOption == MAX_UINTN) {
-    DEBUG ((DEBUG_ERROR, "Failed to register Boot Option.  Description: %s\n", INTERNAL_UEFI_SHELL_NAME));
-    ASSERT (BootOption != MAX_UINTN);
-  }
+  RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_SDD_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_SDD_BOOT_PARM, sizeof (MS_SDD_BOOT_PARM));
+  RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_USB_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_USB_BOOT_PARM, sizeof (MS_USB_BOOT_PARM));
+  RegisterFvBootOption (&gMsBootPolicyFileGuid, MS_PXE_BOOT, (UINTN)-1, LOAD_OPTION_ACTIVE, (UINT8 *)MS_PXE_BOOT_PARM, sizeof (MS_PXE_BOOT_PARM));
+  RegisterFvBootOption (PcdGetPtr (PcdShellFile), INTERNAL_UEFI_SHELL_NAME, (UINTN)-1, LOAD_OPTION_ACTIVE, NULL, 0);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes a previous CodeQL fix (51c7dc2) that was checking for NULL return values.  In this case a NULL return value is valid so instead of returning a bogus boot option let the function continue.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Physical hardware devices to confirm boot.  Also confirmed CodeQL passes.

## Integration Instructions

N/A
