### PR TITLE
MsGraphicsPkg/FrameBufferMemDrawLib: Fix function declaration mismatch

### DIFF
--- a/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLib.h
+++ b/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLib.h
@@ -6,6 +6,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#ifndef FRAMEBUFFER_MEM_DRAW_LIB_INTERNAL_H_
+#define FRAMEBUFFER_MEM_DRAW_LIB_INTERNAL_H_
+
 /**
   Get pertenant information about the frame buffer
 
@@ -16,3 +19,5 @@ EFI_STATUS
 GetGraphicsInfo (
   EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE  **Mode
   );
+
+#endif

--- a/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLibDxe.c
+++ b/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLibDxe.c
@@ -22,7 +22,6 @@ STATIC EFI_GRAPHICS_OUTPUT_PROTOCOL  *mGraphicsOutput = NULL;
  Get Graphics Information
 */
 EFI_STATUS
-EFIAPI
 GetGraphicsInfo (
   EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE  **Mode
   )

--- a/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLibPeim.c
+++ b/MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLibPeim.c
@@ -23,7 +23,6 @@ STATIC BOOLEAN                               mInitialized = FALSE;
  Get Graphics Information
 */
 EFI_STATUS
-EFIAPI
 GetGraphicsInfo (
   EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE  **Mode
   )


### PR DESCRIPTION
## Description

Fixes the following issues with `GetGraphicsInfo()`.

1. Removes `EFIAPI`. This is an internal function to the library
   implementation and the explicit calling convention is not needed.        
   In turn, this makes the function prototype in the C files match
   the header file.
2. Add an include guard to the local library header file.

Resolves the following GCC warning:

  MsGraphicsPkg/Library/FrameBufferMemDrawLib/FrameBufferMemDrawLib.h:16:1: 
  warning: type of ‘GetGraphicsInfo’ does not match original declaration [-Wlto-type-mismatch]
    16 | GetGraphicsInfo (
       | ^

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI build.

## Integration Instructions

N/A