### PR TITLE
Add Rust Support and Advanced Logger Crate [Rebase & FF]

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v5.0.6
+      ref: refs/tags/v6.0.0
 
 parameters:
 - name: do_ci_build
@@ -67,11 +67,19 @@ parameters:
   displayName: Extra Jobs to be run after build
   type: jobList
   default: []
+- name: rust_build
+  displayName: Whether Rust code is being built
+  type: boolean
+  default: false
 
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:3bf70b5
+    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc
+    ${{ if eq(parameters.rust_build, true) }}:
+      linux_container_options: --security-opt seccomp=unconfined
+      extra_steps:
+      - template: Steps/RustSetupSteps.yml@mu_devops
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
@@ -85,5 +93,18 @@ jobs:
     vm_image: $(vm_image)
     container_build: ${{ parameters.container_build }}
 
-- ${{ parameters.extra_jobs }}
+- ${{ if eq(parameters.rust_build, true) }}:
+  - job: CargoCmds
+    displayName: Workspace Cargo Commands
 
+    container:
+      image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc
+      options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
+
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - template: Steps/RustCargoSteps.yml@mu_devops
+
+- ${{ parameters.extra_jobs }}

--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -27,6 +27,7 @@ extends:
     do_non_ci_setup: true
     do_pr_eval: true
     container_build: true
+    rust_build: true
     os_type: Linux
     build_matrix:
       TARGET_MFCI_XML:

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -26,6 +26,7 @@ extends:
     do_non_ci_build: false
     do_non_ci_setup: true
     do_pr_eval: true
+    rust_build: true
     os_type: Windows_NT
     build_matrix:
       TARGET_MFCI_XML:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tags/
 .vscode/
 *.bak
 BuildConfig.conf
+Cargo.lock
 
 # Repo-specific
 _TEMP_*/
@@ -16,3 +17,6 @@ _TEMP_*/
 /Common
 /Silicon
 /MU_BASECORE
+
+# Ignore Rust build output
+/target

--- a/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
+++ b/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
@@ -77,5 +77,12 @@
           POSTMEM,
           MMARM
         ]
+    },
+
+    "RustHostUnitTestPlugin": {
+        "Coverage": .75,
+        "CoverageOverrides": {
+            "RustAdvancedLoggerDxe": 0.0
+        }
     }
 }

--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/Cargo.toml
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "RustAdvancedLoggerDxe"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "rust_advanced_logger_dxe"
+path = "src/lib.rs"
+
+[dependencies]
+r-efi = {workspace=true}
+spin = {workspace=true}

--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
@@ -1,0 +1,302 @@
+//! Rust Advanced Logger
+//!
+//! Rust Wrapper for the UEFI Advanced Logger protocol.
+//!
+//! ## Examples and Usage
+//!
+//! ```no_run
+//! use rust_advanced_logger_dxe::{init_debug, debugln, DEBUG_INFO};
+//! use r_efi::efi::Status;
+//! pub extern "efiapi" fn efi_main(
+//!    _image_handle: *const core::ffi::c_void,
+//!    _system_table: *const r_efi::system::SystemTable,
+//!  ) -> u64 {
+//!
+//!    //Initialize debug logging - no output without this.
+//!    init_debug(unsafe { (*_system_table).boot_services});
+//!
+//!    debugln!(DEBUG_INFO, "Hello, World. This is {:} in {:}.", "rust", "UEFI");
+//!
+//!    Status::SUCCESS.as_usize() as u64
+//! }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+#![no_std]
+
+#[cfg(doc)]
+extern crate std; //allow rustdoc links to reference std (e.g. println docs below).
+
+use core::{
+  ffi::c_void,
+  fmt::{self, Write},
+};
+use r_efi::{
+  efi::{Guid, Status},
+  system::BootServices,
+};
+
+//Global static logger instance - this is a singleton.
+static LOGGER: LockedAdvancedLogger = LockedAdvancedLogger::new();
+
+/// Standard UEFI DEBUG_INIT level.
+pub const DEBUG_INIT: usize = 0x00000001;
+/// Standard UEFI DEBUG_WARN level.
+pub const DEBUG_WARN: usize = 0x00000002;
+/// Standard UEFI DEBUG_INFO level.
+pub const DEBUG_INFO: usize = 0x00000040;
+/// Standard UEFI DEBUG_VERBOSE level.
+pub const DEBUG_VERBOSE: usize = 0x00400000;
+/// Standard UEFI DEBUG_ERROR level.
+pub const DEBUG_ERROR: usize = 0x80000000;
+
+// AdvancedLogger protocol definition. Mirrors C definition in AdvLoggerPkg/Include/Protocol/AdvancedLogger.h
+const ADVANCED_LOGGER_PROTOCOL_GUID: Guid =
+  Guid::from_fields(0x434f695c, 0xef26, 0x4a12, 0x9e, 0xba, &[0xdd, 0xef, 0x00, 0x97, 0x49, 0x7c]);
+
+type AdvancedLoggerWriteProtocol = extern "efiapi" fn(*const AdvancedLoggerProtocol, usize, *const u8, usize);
+
+#[repr(C)]
+struct AdvancedLoggerProtocol {
+  signature: u32,
+  version: u32,
+  write_log: AdvancedLoggerWriteProtocol,
+}
+
+// Private un-synchronized AdvancedLogger wrapper. Provides implementation of fmt::Write for AdvancedLogger.
+#[derive(Debug)]
+struct AdvancedLogger {
+  protocol: Option<*mut AdvancedLoggerProtocol>,
+  level: usize,
+}
+impl AdvancedLogger {
+  // creates a new AdvancedLogger
+  const fn new() -> Self {
+    AdvancedLogger { protocol: None, level: DEBUG_INFO }
+  }
+
+  // initialize the AdvancedLogger by acquiring a pointer to the AdvancedLogger protocol.
+  fn init(&mut self, bs: *mut BootServices) {
+    let boot_services = unsafe { bs.as_mut().expect("Boot Services Pointer is NULL") };
+    let mut ptr: *mut c_void = core::ptr::null_mut();
+    let status = (boot_services.locate_protocol)(
+      &ADVANCED_LOGGER_PROTOCOL_GUID as *const Guid as *mut Guid,
+      core::ptr::null_mut(),
+      core::ptr::addr_of_mut!(ptr),
+    );
+    match status {
+      Status::SUCCESS => self.protocol = Some(ptr as *mut AdvancedLoggerProtocol),
+      _ => self.protocol = None,
+    }
+  }
+
+  // log the debug output in `args` at the given log level.
+  fn log(&mut self, level: usize, args: fmt::Arguments) {
+    self.level = level;
+    self.write_fmt(args).expect("Printing to log failed.");
+  }
+}
+
+impl fmt::Write for AdvancedLogger {
+  fn write_str(&mut self, s: &str) -> fmt::Result {
+    let Some(logger) = self.protocol else { return Err(fmt::Error) };
+    let logger = unsafe { logger.as_mut().expect("advanced logger protocol is null") };
+    (logger.write_log)(self.protocol.unwrap(), self.level, s.as_ptr(), s.as_bytes().len());
+    Ok(())
+  }
+}
+
+// private locked wrapper type to provide thread-safety for AdvancedLogger.
+#[derive(Debug)]
+struct LockedAdvancedLogger {
+  inner: spin::Mutex<AdvancedLogger>,
+}
+
+impl LockedAdvancedLogger {
+  // creates a new LockedAdvancedLogger instance.
+  const fn new() -> Self {
+    LockedAdvancedLogger { inner: spin::Mutex::new(AdvancedLogger::new()) }
+  }
+
+  // initializes an advanced logger instance. Typically only called once, but if called more than once will re-init
+  // logger by re-acquiring a pointer to the advanced logger protocol.
+  fn init(&self, bs: *mut BootServices) {
+    self.inner.lock().init(bs);
+  }
+
+  // Log the debug output in `args` at the given log level.
+  fn log(&self, level: usize, args: fmt::Arguments) {
+    self.inner.lock().log(level, args)
+  }
+}
+
+unsafe impl Sync for LockedAdvancedLogger {}
+unsafe impl Send for LockedAdvancedLogger {}
+
+/// Initializes the logging subsystem. The `debug` and `debugln` macros may be called before calling this function, but
+/// output is discarded if the logger has not yet been initialized via this routine.
+pub fn init_debug(bs: *mut BootServices) {
+  LOGGER.init(bs);
+}
+
+#[doc(hidden)]
+pub fn _log(level: usize, args: fmt::Arguments) {
+  LOGGER.log(level, args)
+}
+
+/// Prints to the AdvancedLogger log at the specified level.
+///
+/// This macro uses the same syntax as rust std [`std::println!`] macro, with the addition of a level argument that
+/// indicates what debug level the output is to be written at.
+///
+/// See [`std::fmt`] for details on format strings.
+///
+/// ```no_run
+/// use rust_advanced_logger_dxe::{init_debug, debug, DEBUG_INFO};
+/// use r_efi::efi::Status;
+/// pub extern "efiapi" fn efi_main(
+///    _image_handle: *const core::ffi::c_void,
+///    _system_table: *const r_efi::system::SystemTable,
+///  ) -> u64 {
+///
+///    //Initialize debug logging - no output without this.
+///    init_debug(unsafe { (*_system_table).boot_services});
+///
+///    debug!(DEBUG_INFO, "Hello, World. This is {:} in {:}. ", "rust", "UEFI");
+///    debug!(DEBUG_INFO, "Better add our own newline.\n");
+///
+///    Status::SUCCESS.as_usize() as u64
+/// }
+/// ```
+#[macro_export]
+macro_rules! debug {
+    ($level:expr, $($arg:tt)*) => {
+        $crate::_log($level, format_args!($($arg)*))
+    }
+}
+
+/// Prints to the AdvancedLogger log at the specified level with a newline.
+///
+/// Equivalent to the [`debug!`] macro except that a newline is appended to the format string.
+///
+/// ```no_run
+/// use rust_advanced_logger_dxe::{init_debug, debugln, DEBUG_INFO};
+/// use r_efi::efi::Status;
+/// pub extern "efiapi" fn efi_main(
+///    _image_handle: *const core::ffi::c_void,
+///    _system_table: *const r_efi::system::SystemTable,
+///  ) -> u64 {
+///
+///    //Initialize debug logging - no output without this.
+///    init_debug(unsafe { (*_system_table).boot_services});
+///
+///    debugln!(DEBUG_INFO, "Hello, World. This is {:} in {:}.", "rust", "UEFI");
+///
+///    Status::SUCCESS.as_usize() as u64
+/// }
+/// ```
+#[macro_export]
+macro_rules! debugln {
+    ($level:expr) => ($crate::debug!($level, "\n"));
+    ($level:expr, $fmt:expr) => ($crate::debug!($level, concat!($fmt, "\n")));
+    ($level:expr, $fmt:expr, $($arg:tt)*) => ($crate::debug!($level, concat!($fmt, "\n"), $($arg)*));
+}
+
+#[cfg(test)]
+mod tests {
+  extern crate std;
+  use crate::{
+    init_debug, AdvancedLoggerProtocol, LockedAdvancedLogger, ADVANCED_LOGGER_PROTOCOL_GUID, DEBUG_ERROR, DEBUG_INFO,
+    DEBUG_INIT, DEBUG_VERBOSE, DEBUG_WARN, LOGGER,
+  };
+  use core::{ffi::c_void, mem::MaybeUninit, slice::from_raw_parts};
+  use r_efi::{
+    efi::{Guid, Status},
+    system::BootServices,
+  };
+  use std::{println, str};
+
+  static ADVANCED_LOGGER_INSTANCE: AdvancedLoggerProtocol =
+    AdvancedLoggerProtocol { signature: 0, version: 0, write_log: mock_advanced_logger_write };
+
+  extern "efiapi" fn mock_advanced_logger_write(
+    this: *const AdvancedLoggerProtocol,
+    error_level: usize,
+    buffer: *const u8,
+    buffer_size: usize,
+  ) {
+    assert_eq!(this, &ADVANCED_LOGGER_INSTANCE as *const AdvancedLoggerProtocol);
+    //to avoid dealing with complicated mock state, we assume that tests will produce the same output string:
+    //"This is a <x> test.\n", where <x> depends on the debug level (e.g. "DEBUG_INFO"). In addition,
+    //the string might be built with multiple calls to write, so we just check that it is a substring
+    //of what we expect.
+    let buf: &[u8] = unsafe { from_raw_parts(buffer, buffer_size) };
+    let str = str::from_utf8(buf).unwrap();
+    println!("buffer {buffer:?}:{buffer_size:?}, str: {str:?}");
+    match error_level {
+      DEBUG_INIT => assert!("This is a DEBUG_INIT test.\n".contains(str)),
+      DEBUG_WARN => assert!("This is a DEBUG_WARN test.\n".contains(str)),
+      DEBUG_INFO => assert!("This is a DEBUG_INFO test.\n".contains(str)),
+      DEBUG_VERBOSE => assert!("This is a DEBUG_VERBOSE test.\n".contains(str)),
+      DEBUG_ERROR => assert!("This is a DEBUG_ERROR test.\n".contains(str)),
+      _ => panic!("Unrecognized error string."),
+    }
+  }
+
+  extern "efiapi" fn mock_locate_protocol(
+    protocol: *mut Guid,
+    _registration: *mut c_void,
+    interface: *mut *mut c_void,
+  ) -> Status {
+    let protocol = unsafe { protocol.as_mut().unwrap() };
+    assert_eq!(protocol, &ADVANCED_LOGGER_PROTOCOL_GUID);
+    assert!(!interface.is_null());
+    unsafe {
+      interface.write(&ADVANCED_LOGGER_INSTANCE as *const AdvancedLoggerProtocol as *mut c_void);
+    }
+    Status::SUCCESS
+  }
+
+  fn mock_boot_services() -> BootServices {
+    let boot_services = MaybeUninit::zeroed();
+    let mut boot_services: BootServices = unsafe { boot_services.assume_init() };
+    boot_services.locate_protocol = mock_locate_protocol;
+    boot_services
+  }
+
+  #[test]
+  fn init_should_initialize_logger() {
+    let mut boot_services = mock_boot_services();
+    static TEST_LOGGER: LockedAdvancedLogger = LockedAdvancedLogger::new();
+    TEST_LOGGER.init(&mut boot_services);
+
+    assert_eq!(
+      TEST_LOGGER.inner.lock().protocol.unwrap() as *const AdvancedLoggerProtocol,
+      &ADVANCED_LOGGER_INSTANCE as *const AdvancedLoggerProtocol
+    );
+    assert_eq!(TEST_LOGGER.inner.lock().level, DEBUG_INFO);
+  }
+
+  #[test]
+  fn debug_macro_should_log_things() {
+    let mut boot_services = mock_boot_services();
+    init_debug(&mut boot_services);
+
+    assert_eq!(
+      LOGGER.inner.lock().protocol.unwrap() as *const AdvancedLoggerProtocol,
+      &ADVANCED_LOGGER_INSTANCE as *const AdvancedLoggerProtocol
+    );
+    assert_eq!(LOGGER.inner.lock().level, DEBUG_INFO);
+
+    debugln!(DEBUG_INIT, "This is a DEBUG_INIT test.");
+    debugln!(DEBUG_WARN, "This is a {:} test.", "DEBUG_WARN");
+    debug!(DEBUG_INFO, "This {:} a {:} test.\n", "is", "DEBUG_INFO");
+    debug!(DEBUG_VERBOSE, "This {:} {:} {:} test.\n", "is", "a", "DEBUG_VERBOSE");
+    debug!(DEBUG_ERROR, "{:}", "This is a DEBUG_ERROR test.\n");
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+# Add packages that generate binaries here
+members = [
+    "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe",
+]
+
+# Add packages that generate libraries here
+[workspace.dependencies]
+RustAdvancedLoggerDxe = {path = "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe"}
+
+r-efi = "4.0.0"
+spin = "0.5.2"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,49 @@
+[config]
+default_to_workspace = false
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+RUSTC_BOOTSTRAP = 1
+ARCH = "X64"
+TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
+PACKAGE_TARGET = {value = "-p ${CARGO_MAKE_TASK_ARGS}",condition = { env_true = [ "CARGO_MAKE_TASK_ARGS", ] } }
+
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
+COV_FLAGS = { value = "--out Html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
+
+[env.development]
+RUSTC_PROFILE = "dev"
+RUSTC_TARGET = "debug"
+
+[env.release]
+RUSTC_PROFILE = "release"
+RUSTC_TARGET = "release"
+
+[tasks.build]
+description = """Builds a single rust package.
+
+Customizations:
+    -p [development|release]: Builds in debug or release. Default: development
+    -e ARCH=[IA32|X64|AARCH64|LOCAL]: Builds with specifed arch. Default: X64
+
+Example:
+    `cargo make build RustModule`
+    `cargo make -p release build RustModule`
+    `cargo make -e ARCH=IA32 build RustLib`
+"""
+clear = true
+command = "cargo"
+args = ["build", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
+
+[tasks.test]
+description = "Builds all rust tests in the workspace. Example `cargo make test`"
+clear = true
+command = "cargo"
+args = ["test", "@@split(PACKAGE_TARGET, )", "@@split(TEST_FLAGS, )"]
+
+[tasks.coverage]
+description = "Build and run all tests and calculate coverage."
+clear = true
+command = "cargo"
+args = ["tarpaulin", "@@split(PACKAGE_TARGET, )", "@@split(COV_FLAGS, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.71.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,21 @@
+# rustfmt (and cargo fmt) will automatically pick up this config when run in the workspace.
+
+# Note that some items are included here set to their default values. This is to explicitly
+# reveal settings for more common options.
+
+# Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
+
+edition = "2021"              # This would normally be picked up from Cargo.toml if not specified here
+force_explicit_abi = true     # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
+hard_tabs = false             # Always uses spaces for indentation and alignment
+max_width = 120               # The maximum width of each line
+merge_derives = false         # Do not merge derives into a single line (leave to author discretion).
+imports_granularity = "Crate" # Merge imports from a single crate into separate statements.
+newline_style = "Windows"     # Always use Windows line endings '\r\n'
+reorder_impl_items = false    # Do not force where type and const before macros and methods in impl blocks.
+reorder_imports = true        # Do reorder import and extern crate statements alphabetically for readability.
+reorder_modules = true        # Do reorder mod declarations alphabetically for readability.
+tab_spaces = 2                # Use 2 spaces for indentation (Rust default is 4).
+unstable_features = false     # Do not use unstable rustfmt features.
+use_small_heuristics = "Max"  # Set all granular width settings to the same as max_width (do not use heuristics)
+wrap_comments = false         # Leave comment formatting to author's discretion


### PR DESCRIPTION
Closes #294 

## Description

Updates the repo to add some files needed to support Rust builds and a `RustAdvancedLoggerDxe` library crate.

Because this repo was used to test the Rust build and is adding a new crate in that process, the infrastructure files are added directly in this PR. In the future, these will be synced from `mu_devops`. The file content aligns with the current templates in `mu_devops` so there should be no change in the sync process in this repo. Future repos can simply sync the files with the bot accounts and then add the Rust code in a follow up PR.

The ability to build with Rust is temporarily disabled in the last commit of the PR branch because changes in `mu_devops` need to be completed before the pipeline build in this repo will succeed.

### Commit/Change Overview

---

#### Add initial Rust infrastructure files

Adds workspace level files to build Rust in the repo.

---

#### .azurepipelines: Add Rust build support

Makes the changes needed to build Rust in pipelines on Windows
and Linux.

---

#### AdvLoggerPkg: Add RustAdvancedLoggerDxe

Adds a library crate that serves as a Rust wrapper for access to
Advanced Logger protocol.

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Built container image from mu_devops locally with docker
- Ran container image locally to perform a Rust build
- Ran all changes in this PR in mu_plus pipelines to verify build results
  - [Linux build with Rust](https://dev.azure.com/projectmu/mu/_build/results?buildId=52786&view=results)
  - [Linux build without Rust](https://dev.azure.com/projectmu/mu/_build/results?buildId=52788&view=results)
  - [Windows build with Rust](https://dev.azure.com/projectmu/mu/_build/results?buildId=52747&view=results)

## Integration Instructions

No changes are needed for mu_plus integrators.

Review [general Rust documentation](https://github.com/microsoft/mu_basecore/blob/HEAD/Docs/rust_build.md) in mu_basecore for more info.