### PR TITLE
Update UXN/PXN Parsing and Fix Filters in Paging Audit

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -57,18 +57,13 @@
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon2">UX Attribute</span>
-                                <select id="UxFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
+                                <span class="input-group-addon" id="basic-addon2">Execute Attribute</span>
+                                <select id="ExecuteFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                                 <span class="input-group-addon" id="basic-addon3">Read/Write Attribute</span>
                                 <select id="RWFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon3"></select>
-                        </div>
-                        <p></p>
-                        <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon8">PX Attribute</span>
-                                <select id="PxFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon8"></select>
                         </div>
                         <p></p>
                         <p>
@@ -121,8 +116,7 @@
                             <th># of Pages</th>
                             <th>Access Flag</th>
                             <th>Read/Write</th>
-                            <th>UX</th>
-                            <th>PX</th>
+                            <th>Execute</th>
                             <th>UEFI Memory Type</th>
                             <th>GCD Memory Type</th>
                             <th>Section Type</th>
@@ -299,35 +293,31 @@
                         "targets": [5],
                     },
                     {
-                        "data": "UX",
+                        "data": "Execute",
                         "targets": [6],
                     },
                     {
-                        "data": "PX",
-                        "targets": [7],
-                    },
-                    {
                         "data": "Memory Type",
-                        "targets": [8],
+                        "targets": [7],
                         "defaultContent": "None"
                     },
                     {
                         "data": "GCD Memory Type",
-                        "targets": [9],
+                        "targets": [8],
                         "defaultContent": "None"
                     },
                     {
                         "data": "Section Type",
-                        "targets": [10]
+                        "targets": [9]
                     },
                     {
                         "data": "System Memory",
-                        "targets": [11],
+                        "targets": [10],
                         "defaultContent": "SYSTEM"
                     },
                     {
                         "data": "Memory Contents",
-                        "targets": [12],
+                        "targets": [11],
                         "defaultContent": "Nothing Found"
                     }
                 ], //end of column def
@@ -350,7 +340,7 @@
 
                     this.api().column(6).every( function() {
                         var column = this;
-                        var select = $("#UxFilter").on( 'change', function () {     
+                        var select = $("#ExecuteFilter").on( 'change', function () {     
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
                              column
@@ -399,19 +389,7 @@
                         });
                     }); //column 5 - RW attribute
                     
-                    this.api().column(7).every( function() {
-                        var column = this;
-                        var select = $("#PxFilter").on( 'change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column.search(SearchRegex, true, false).draw();
-                        }); // on change
-
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
-                    }); //column 7 - Privilege (User / Supervisor)
-
-                    this.api().column(10).every( function() {
+                    this.api().column(9).every( function() {
                         var column = this;
                         var select = $("#SectionFilter").on( 'change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
@@ -423,7 +401,7 @@
                         });
                     }); //column 10 - Section Type for code/data sections
 
-                    this.api().column(8).every( function() {
+                    this.api().column(7).every( function() {
                         var column = this;
                         var select = $("#MemoryTypeFilter").on( 'change', function () { 
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
@@ -438,7 +416,7 @@
                         });
                     }); //column 8 - Memory Type
 
-                    this.api().column(9).every( function() {
+                    this.api().column(8).every( function() {
                         var column = this;
                         var select = $("#MemorySpaceTypeFilter").on( 'change', function () { 
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
@@ -453,7 +431,7 @@
                         });
                     }); //column 9 - GCD Memory Type
 
-                    this.api().column(11).every( function() {
+                    this.api().column(10).every( function() {
                         var column = this;
                         var select = $("#SpecialMemoryRegionsFilter").on( 'change', function () {     
                             //var SelectedValues = $(this).val() || [];
@@ -471,7 +449,7 @@
                     }); //column 11 - special Memory Type
                     
 
-                    this.api().column(12).every( function() {
+                    this.api().column(11).every( function() {
                         var column = this;
                         var select = $("#MemoryContentsFilter").on( 'change', function () {     
                             //var SelectedValues = $(this).val() || [];
@@ -497,8 +475,7 @@
             {"Page Size": "4k", 
             "Present": "Yes",
             "Read/Write": "Enabled", 
-            "Execute": "Disabled", 
-            "Privilege": "User"
+            "Execute": "UX/PX",
             "Start": "0x0000058000", 
             "End": "0x0000058FFF", 
             "Number of Entries": 1, 
@@ -513,42 +490,39 @@
             var SavedFilters = [];
             SavedFilters.push({"Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute", 
                 "Filter": function(mrObject) {
-                    if( (mrObject["UX"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Access Flag"] === "Yes")) {
+                    if( (mrObject["Execute"] !== "Disabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Access Flag"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("UxFilter", ["Enabled"]))
-                    {
-                        return false
-                    }
-                    if(!SetMultiselectTo("AccessFlagFilter", ["Yes"]))
-                    {
-                        return false
-                    }
-                    return SetMultiselectTo("RWFilter", ["Enabled"]);
+                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX"])
+                    SetMultiselectTo("AccessFlagFilter", ["Yes"])
+                    SetMultiselectTo("RWFilter", ["Enabled"])
+                    SetMultiselectTo("MemorySpaceTypeFilter",
+                        ["EfiGcdMemoryTypeReserved",
+                        "EfiGcdMemoryTypeSystemMemory",
+                        "EfiGcdMemoryTypeMemoryMappedIo",
+                        "EfiGcdMemoryTypePersistent",
+                        "EfiGcdMemoryTypePersistentMemory",
+                        "EfiGcdMemoryTypeMoreReliable",
+                        "EfiGcdMemoryTypeMaximum"])
+                    return true;
                 } //end of configuring filter inputs
             });
 
             SavedFilters.push({"Name": "Data Sections are No-Execute", "Description": "Image data sections should be no-execute", "Filter": function(mrObject) {
-                    if((mrObject["UX"] === "Enabled") && (mrObject["Section Type"] === "DATA")) {
+                    if((mrObject["Execute"] !== "Disabled") && (mrObject["Section Type"] === "DATA")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("UxFilter", ["Disabled"]))
-                    {
-                        return false;
-                    }
-                    if(!SetMultiselectTo("SectionFilter", ["DATA"]))
-                    {
-                        return false;
-                    }
-                    return SetMultiselectTo("MemoryTypeFilter", ["EfiRuntimeServicesCode"]);
+                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX"])
+                    SetMultiselectTo("SectionFilter", ["DATA"])
+                    return true;
                 } //end of configuring filter inputs
             });
 
@@ -560,14 +534,8 @@
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("RWFilter", ["Enabled"]))
-                    {
-                        return false;
-                    }
-                    if(!SetMultiselectTo("SectionFilter", ["CODE"]))
-                    {
-                        return false;
-                    }
+                    SetMultiselectTo("RWFilter", ["Enabled"])
+                    SetMultiselectTo("SectionFilter", ["CODE"])
                     return true;
                 } //end of configuring filter inputs
             });

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -513,22 +513,25 @@
             var SavedFilters = [];
             SavedFilters.push({"Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute", 
                 "Filter": function(mrObject) {
-                    if( (mrObject["Execute"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Present"] === "Yes")) {
+                    if( (mrObject["Execute"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Present"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("ExecuteFilter", ["Enabled"]))
-                    {
-                        return false
-                    }
-                    if(!SetMultiselectTo("PresentFilter", ["Yes"]))
-                    {
-                        return false
-                    }
-                    return SetMultiselectTo("RWFilter", ["Enabled"]);
+                    SetMultiselectTo("ExecuteFilter", ["Enabled"])
+                    SetMultiselectTo("PresentFilter", ["Yes"])
+                    SetMultiselectTo("RWFilter", ["Enabled"])
+                    SetMultiselectTo("MemorySpaceTypeFilter",
+                        ["EfiGcdMemoryTypeReserved",
+                        "EfiGcdMemoryTypeSystemMemory",
+                        "EfiGcdMemoryTypeMemoryMappedIo",
+                        "EfiGcdMemoryTypePersistent",
+                        "EfiGcdMemoryTypePersistentMemory",
+                        "EfiGcdMemoryTypeMoreReliable",
+                        "EfiGcdMemoryTypeMaximum"])
+                    return true;
                 } //end of configuring filter inputs
             });
 
@@ -540,15 +543,9 @@
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("ExecuteFilter", ["Disabled"]))
-                    {
-                        return false;
-                    }
-                    if(!SetMultiselectTo("SectionFilter", ["DATA"]))
-                    {
-                        return false;
-                    }
-                    return SetMultiselectTo("MemoryTypeFilter", ["EfiRuntimeServicesCode"]);
+                    SetMultiselectTo("ExecuteFilter", ["Disabled"])
+                    SetMultiselectTo("SectionFilter", ["DATA"])
+                    return true;
                 } //end of configuring filter inputs
             });
 
@@ -560,14 +557,8 @@
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    if(!SetMultiselectTo("RWFilter", ["Enabled"]))
-                    {
-                        return false;
-                    }
-                    if(!SetMultiselectTo("SectionFilter", ["CODE"]))
-                    {
-                        return false;
-                    }
+                    SetMultiselectTo("RWFilter", ["Enabled"])
+                    SetMultiselectTo("SectionFilter", ["CODE"])
                     return true;
                 } //end of configuring filter inputs
             });

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
@@ -361,12 +361,20 @@ class MemoryRange(object):
                 else:
                     section_type = "UNKNOWN"
 
+            # Check the execution setting
+            ExecuteString = "Disabled"
+            if (self.Ux and self.Px):
+                ExecuteString = "UX/PX"
+            elif (self.Ux):
+                ExecuteString = "UX"
+            elif (self.Px):
+                ExecuteString = "PX"
+
             return {
                 "Page Size" : self.getPageSizeStr(),
                 "Access Flag" : "Yes" if (self.AccessFlag == 1) else "No",
                 "Read/Write" : "Enabled" if (self.ReadWrite == 1) else "Disabled",
-                "UX" : "Enabled" if (self.Ux == 1) else "Disabled",
-                "PX" : "Enabled" if (self.Px == 1) else "Disabled",
+                "Execute" : ExecuteString,
                 "Start" : "0x{0:010X}".format(self.PhysicalStart),
                 "End" : "0x{0:010X}".format(self.PhysicalEnd),
                 "Number of Entries" : self.NumberOfEntries if (not self.PageSplit) else str(self.NumberOfEntries) + " (p)" ,


### PR DESCRIPTION
## Description

1. Update the HTML/Javascript filters for RWX to not include GcdNonExistent regions
2. Combine the UX and PX fields into one Execute field to make it easier to check for RWX regions
3. Update the filters to not fail if the multiselect call fails to select all options. This can occur if one of the options does not exist in the paging audit.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the paging audit on Q35 and SBSA

## Integration Instructions

N/A