### PR TITLE
[REBASE && FF] Publish and Parse PlatformInfo.dat in Paging Audit

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -240,3 +240,42 @@ DumpProcessorSpecificHandlers (
 {
   return;
 }
+
+/**
+  Dumps platorm info required to correctly parse the pages (architecture,
+  execution level, etc.)
+**/
+VOID
+EFIAPI
+DumpPlatforminfo (
+  VOID
+  )
+{
+  CHAR8  TempString[MAX_STRING_SIZE];
+  UINTN  ExecutionLevel;
+  CHAR8  *ElString;
+  UINTN  StringIndex;
+
+  ExecutionLevel = ArmReadCurrentEL ();
+
+  if (ExecutionLevel == AARCH64_EL1) {
+    ElString = "EL1";
+  } else if (ExecutionLevel == AARCH64_EL2) {
+    ElString = "EL2";
+  } else if (ExecutionLevel == AARCH64_EL3) {
+    ElString = "EL3";
+  } else {
+    ElString = "Unknown";
+  }
+
+  // Dump the execution level of UEFI
+  StringIndex = AsciiSPrint (
+                  &TempString[0],
+                  MAX_STRING_SIZE,
+                  "Architecture,AARCH64\nBitwidth,%d\nPhase,DXE\nExecutionLevel,%a\n",
+                  CalculateMaximumSupportAddressBits (),
+                  ElString
+                  );
+
+  WriteBufferToFile (L"PlatformInfo", TempString, StringIndex);
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/AArch64/DxePagingAuditTests.c
@@ -16,7 +16,7 @@
 #define ROOT_TABLE_LEN(T0SZ)   (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
 #define IS_VALID  0x1
 #define IS_READ_WRITE(page)  (((page & TT_AP_RW_RW) != 0) || ((page & TT_AP_MASK) == 0))
-#define IS_EXECUTABLE(page)  ((page & TT_UXN_MASK) == 0 || (page & TT_PXN_MASK) == 0)
+#define IS_EXECUTABLE(page)  ((ArmReadCurrentEL () == AARCH64_EL2) ? ((page & TT_XN_MASK) == 0) : ((page & TT_UXN_MASK) == 0 || (page & TT_PXN_MASK) == 0))
 #define IS_ACCESSIBLE(page)  ((page & TT_AF) != 0)
 
 /**

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -67,6 +67,9 @@
   gEfiSimpleFileSystemProtocolGuid
   gCpuMpDebugProtocolGuid
 
+[Protocols.X64]
+  gEfiSmmBase2ProtocolGuid
+
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -74,5 +74,8 @@
   gEfiShellParametersProtocolGuid
   gCpuMpDebugProtocolGuid
 
+[Protocols.X64]
+  gEfiSmmBase2ProtocolGuid
+
 [FixedPcd]
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformSmrrUnsupported  ## SOMETIMES_CONSUMES

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -715,7 +715,6 @@ MemoryMapDumpHandler (
   EFI_MEMORY_DESCRIPTOR            *EfiMemoryMapEnd;
   EFI_MEMORY_DESCRIPTOR            *EfiMemNext;
   CHAR8                            TempString[MAX_STRING_SIZE];
-  UINT8                            MaxPhysicalAddressWidth;
   UINTN                            NumberOfDescriptors;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap = NULL;
   EFI_GCD_MEMORY_TYPE              MemorySpaceType;
@@ -726,18 +725,6 @@ MemoryMapDumpHandler (
   if (EFI_ERROR (PopulateHeapGuardDebugProtocol ())) {
     DEBUG ((DEBUG_ERROR, "%a - Error finding heap guard debug protocol\n", __FUNCTION__));
   }
-
-  //
-  // Add remaining misc data to the database.
-  //
-  MaxPhysicalAddressWidth = CalculateMaximumSupportAddressBits ();
-  AsciiSPrint (
-    &TempString[0],
-    MAX_STRING_SIZE,
-    "Bitwidth,0x%02x\n",
-    MaxPhysicalAddressWidth
-    );
-  AppendToMemoryInfoDatabase (&TempString[0]);
 
   //
   // Get the EFI memory map.
@@ -1445,6 +1432,7 @@ DumpPagingInfo (
   MemoryAttributesTableDump ();
   SpecialMemoryDump ();
   FlushAndClearMemoryInfoDatabase (L"MemoryInfoDatabase");
+  DumpPlatforminfo ();
 
 Cleanup:
   if (Pte1GEntries != NULL) {

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -138,17 +138,6 @@ MemoryAttributesTableDump (
   );
 
 /**
-  Calculate the maximum physical address bits supported.
-
-  @return the maximum support physical address bits supported.
-**/
-UINT8
-EFIAPI
-CalculateMaximumSupportAddressBits (
-  VOID
-  );
-
-/**
   This helper function walks the page tables to retrieve:
   - a count of each entry
   - a count of each directory entry
@@ -199,6 +188,16 @@ EFI_STATUS
 EFIAPI
 FlushAndClearMemoryInfoDatabase (
   IN CONST CHAR16  *FileName
+  );
+
+/**
+  Dumps platorm info required to correctly parse the pages (architecture,
+  execution level, etc.)
+**/
+VOID
+EFIAPI
+DumpPlatforminfo (
+  VOID
   );
 
 #endif // _PAGING_AUDIT_COMMON_H_

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -51,6 +51,9 @@
   gMemoryProtectionDebugProtocolGuid
   gCpuMpDebugProtocolGuid
 
+[Protocols.X64]
+  gEfiSmmBase2ProtocolGuid
+
 [Guids]
   gEdkiiPiSmmCommunicationRegionTableGuid       ## SOMETIMES_CONSUMES ## GUID
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/BinaryParsing.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/BinaryParsing.py
@@ -8,6 +8,7 @@ import struct
 from ctypes import *
 from collections import namedtuple
 from MemoryRangeObjects import *
+import Globals
 import logging
 import csv
 
@@ -38,14 +39,32 @@ def ParseInfoFile(fileName):
     logging.debug("%d entries found in file %s" % (len(MemoryRanges), fileName))
     return MemoryRanges
 
+def ParsePlatforminfofile(fileName):
+    logging.debug("-- Processing file '%s'..." % fileName)
+    byte_list = ParseFileToBytes(fileName)
+    byte_content = bytes(byte_list)
+    data = byte_content.decode('ascii')
+    database_reader = csv.reader(data.splitlines())
+    for row in database_reader:
+        if row[0] == "Architecture":
+            Globals.ParsingArchitecture = row[1]
+        elif row[0] == "ExecutionLevel":
+            Globals.ExecutionLevel = row[1]
+        elif row[0] == "Bitwidth":
+            Globals.Bitwidth = int(row[1])
+        elif row[0] == "Phase":
+            Globals.Phase = row[1]
+        else:
+            logging.error("Unknown key found in PlatformInfo.dat: %s" % row[0])
 
-def Parse4kPages(fileName, addressbits, architecture):
+def Parse4kPages(fileName):
     num = 0
     pages = []
+    addressbits = (1 << Globals.Bitwidth) - 1
     logging.debug("-- Processing file '%s'..." % fileName)
     ByteArray = ParseFileToBytes(fileName)
     byteZeroIndex = 0
-    if (architecture == "X64"):
+    if (Globals.ParsingArchitecture == "X64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):
                 byteZeroIndex += 8
@@ -59,7 +78,7 @@ def Parse4kPages(fileName, addressbits, architecture):
             byteZeroIndex += 8
             num += 1
             pages.append(MemoryRange("PTEntry", "4k", Present, ReadWrite, Nx, 1, User, (PageTableBaseAddress)))
-    elif (architecture == "AARCH64"):
+    elif (Globals.ParsingArchitecture == "AARCH64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             # check if this page is zero
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):
@@ -81,13 +100,14 @@ def Parse4kPages(fileName, addressbits, architecture):
     return pages
 
 
-def Parse2mPages(fileName, addressbits, architecture):
+def Parse2mPages(fileName):
     num = 0
     pages = []
+    addressbits = (1 << Globals.Bitwidth) - 1
     logging.debug("-- Processing file '%s'..." % fileName)
     ByteArray = ParseFileToBytes(fileName)
     byteZeroIndex = 0
-    if (architecture == "X64"):
+    if (Globals.ParsingArchitecture == "X64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):
                 byteZeroIndex += 8
@@ -102,7 +122,7 @@ def Parse2mPages(fileName, addressbits, architecture):
             byteZeroIndex += 8
             num += 1
             pages.append(MemoryRange("PTEntry", "2m", Present, ReadWrite, Nx, MustBe1, User, (PageTableBaseAddress)))
-    elif (architecture == "AARCH64"):
+    elif (Globals.ParsingArchitecture == "AARCH64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             # check if this page is zero
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):
@@ -124,13 +144,14 @@ def Parse2mPages(fileName, addressbits, architecture):
     return pages
 
 
-def Parse1gPages(fileName, addressbits, architecture):
+def Parse1gPages(fileName):
     num = 0
     pages = []
+    addressbits = (1 << Globals.Bitwidth) - 1
     logging.debug("-- Processing file '%s'..." % fileName)
     ByteArray = ParseFileToBytes(fileName)
     byteZeroIndex = 0
-    if (architecture == "X64"):
+    if (Globals.ParsingArchitecture == "X64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):
                 byteZeroIndex += 8
@@ -145,7 +166,7 @@ def Parse1gPages(fileName, addressbits, architecture):
             byteZeroIndex += 8
             pages.append(MemoryRange("PTEntry", "1g", Present, ReadWrite, Nx, MustBe1, User, PageTableBaseAddress))
             num += 1
-    elif (architecture == "AARCH64"):
+    elif (Globals.ParsingArchitecture == "AARCH64"):
         while (byteZeroIndex + 7) < len(ByteArray):
             # check if this page is zero
             if 0 == (ByteArray[byteZeroIndex + 0] + ByteArray[byteZeroIndex + 1] + ByteArray[byteZeroIndex + 2] + ByteArray[byteZeroIndex + 3] + ByteArray[byteZeroIndex + 4] + ByteArray[byteZeroIndex + 5] + ByteArray[byteZeroIndex + 6] + ByteArray[byteZeroIndex + 7]):

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -497,7 +497,7 @@
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX"])
+                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
                     SetMultiselectTo("AccessFlagFilter", ["Yes"])
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("MemorySpaceTypeFilter",
@@ -520,7 +520,7 @@
                 }, //end of Filter function
                 "ConfigureFilter":function() {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX"])
+                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
                     SetMultiselectTo("SectionFilter", ["DATA"])
                     return true;
                 } //end of configuring filter inputs

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/Globals.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/Globals.py
@@ -1,0 +1,10 @@
+# Global variables for the paging report generator scripts
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+ParsingArchitecture = ""
+ExecutionLevel = ""
+Phase = ""
+Bitwidth = 0

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
@@ -354,12 +354,16 @@ class MemoryRange(object):
 
             # Check the execution setting
             ExecuteString = "Disabled"
-            if (self.Ux and self.Px):
-                ExecuteString = "UX/PX"
-            elif (self.Ux):
-                ExecuteString = "UX"
-            elif (self.Px):
-                ExecuteString = "PX"
+            if (Globals.ExecutionLevel == "EL2" or Globals.ExecutionLevel == "EL3"):
+                if (self.Ux):
+                    ExecuteString = "Enabled"
+            else:
+                if (self.Ux and self.Px):
+                    ExecuteString = "UX/PX"
+                elif (self.Ux):
+                    ExecuteString = "UX"
+                elif (self.Px):
+                    ExecuteString = "PX"
 
             return {
                 "Page Size" : self.getPageSizeStr(),


### PR DESCRIPTION
1. Create the PlatformInfo.dat file which contains the required platform information to parse the page/translation tables (bitwidth, execution level, phase, architecture).
2. Check the execution level when parsing AARCH64 translation tables in the paging report generator scripts.

These patches will fix the paging audit test failure on SBSA, and will reduce the number of command line options which need to be passed into the page parsing scripts.