### PR TITLE
Add Rust Module [Rebase & FF]

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -32,8 +32,10 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         self.ActualTargets = []
         self.ActualArchitectures = []
         self.ActualToolChainTag = ""
-        self.UseBuiltInBaseTools = None
         self.ActualScopes = None
+        # In tree BaseTools are required for Rust build support so enable
+        # it by default.
+        self.UseBuiltInBaseTools = False
 
     # ####################################################################################### #
     #                             Extra CmdLine configuration                                 #
@@ -42,7 +44,6 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     def AddCommandLineOptions(self, parserObj):
         group = parserObj.add_mutually_exclusive_group()
         group.add_argument("-force_piptools", "--fpt", dest="force_piptools", action="store_true", default=False, help="Force the system to use pip tools")
-        group.add_argument("-no_piptools", "--npt", dest="no_piptools", action="store_true", default=False, help="Force the system to not use pip tools")
 
         try:
             codeql_helpers.add_command_line_option(parserObj)
@@ -51,10 +52,9 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
 
     def RetrieveCommandLineOptions(self, args):
         super().RetrieveCommandLineOptions(args)
+
         if args.force_piptools:
             self.UseBuiltInBaseTools = True
-        if args.no_piptools:
-            self.UseBuiltInBaseTools = False
 
         try:
             self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
@@ -149,27 +149,17 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
         if self.ActualScopes is None:
-            scopes = ("cibuild", "edk2-build", "host-based-test")
+            scopes = ("cibuild", "edk2-build", "host-based-test", "rust-ci")
 
             self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue("TOOL_CHAIN_TAG", "")
 
             is_linux = GetHostInfo().os.upper() == "LINUX"
 
-            if self.UseBuiltInBaseTools is None:
-                is_linux = GetHostInfo().os.upper() == "LINUX"
-                # try and import the pip module for basetools
-                try:
-                    import edk2basetools
-                    self.UseBuiltInBaseTools = True
-                except ImportError:
-                    self.UseBuiltInBaseTools = False
-                    pass
-
             if self.UseBuiltInBaseTools == True:
                 scopes += ('pipbuild-unix',) if is_linux else ('pipbuild-win',)
                 logging.warning("Using Pip Tools based BaseTools")
             else:
-                logging.warning("Falling back to using in-tree BaseTools")
+                logging.info("Using in-tree BaseTools")
 
             if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
                 if "AARCH64" in self.ActualArchitectures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 
 # Add packages that generate binaries here
 members = [
-    "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe",
 ]
 
 # Add packages that generate libraries here
 [workspace.dependencies]
 RustAdvancedLoggerDxe = {path = "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe"}
+RustBootServicesAllocatorDxe = {path = "MsCorePkg/Crates/RustBootServicesAllocatorDxe"}
 
 r-efi = "4.0.0"
 spin = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 # Add packages that generate binaries here
 members = [
+  "MsCorePkg/HelloWorldRustDxe",
 ]
 
 # Add packages that generate libraries here

--- a/MsCorePkg/Crates/RustBootServicesAllocatorDxe/Cargo.toml
+++ b/MsCorePkg/Crates/RustBootServicesAllocatorDxe/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "RustBootServicesAllocatorDxe"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_boot_services_allocator_dxe"
+path = "src/lib.rs"
+
+[dependencies]
+r-efi = {workspace=true}
+spin = {workspace=true}

--- a/MsCorePkg/Crates/RustBootServicesAllocatorDxe/src/lib.rs
+++ b/MsCorePkg/Crates/RustBootServicesAllocatorDxe/src/lib.rs
@@ -1,0 +1,281 @@
+//! Rust Boot Services Allocator
+//!
+//! Implements a global allocator based on UEFI AllocatePool().
+//! Memory is allocated from the EFI_BOOT_SERVICES_DATA pool.
+//!
+//! ## Examples and Usage
+//!
+//! ```no_run
+//! use r_efi::efi::Status;
+//! pub extern "efiapi" fn efi_main(
+//!   _image_handle: *const core::ffi::c_void,
+//!   system_table: *const r_efi::system::SystemTable,
+//! ) -> u64 {
+//!   rust_boot_services_allocator_dxe::GLOBAL_ALLOCATOR.init(unsafe { (*system_table).boot_services});
+//!
+//!   let mut foo = vec!["asdf", "xyzpdq", "abcdefg", "theoden"];
+//!   foo.sort();
+//!
+//!   let bar = Box::new(foo);
+//!
+//!   Status::SUCCESS.as_usize() as u64
+//! }
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+#![no_std]
+#![feature(allocator_api)]
+
+use core::{
+  alloc::{GlobalAlloc, Layout},
+  ffi::c_void,
+};
+
+use r_efi::{
+  efi::{BootServices, Status},
+  system::BOOT_SERVICES_DATA,
+};
+
+/// Static GLOBAL_ALLOCATOR instance that is marked with the `#[global_allocator]` attribute.
+///
+/// See [`core::alloc::GlobalAlloc`] for more details on rust global allocators. This allocator must be initialized
+/// before use, see [`SpinLockedAllocator::init()`].
+#[cfg_attr(not(test), global_allocator)]
+pub static GLOBAL_ALLOCATOR: SpinLockedAllocator = SpinLockedAllocator::new();
+
+const ALLOC_TRACKER_SIG: u32 = 0x706F6F6C; //arbitrary sig
+
+// Used to track allocations that need larger alignment than the UEFI Pool alignment (8 bytes).
+struct AllocationTracker {
+  signature: u32,
+  orig_ptr: *mut c_void,
+}
+
+// Private unlocked allocator implementation. The public locked allocator delegates to this implementation.
+struct BootServicesAllocator {
+  boot_services: Option<*mut BootServices>,
+}
+
+impl BootServicesAllocator {
+  // Create a new instance. const fn to allow static initialization.
+  const fn new() -> Self {
+    BootServicesAllocator { boot_services: None }
+  }
+
+  // initialize the allocator by providing a pointer to the global boot services table.
+  fn init(&mut self, boot_services: *mut BootServices) {
+    self.boot_services = Some(boot_services);
+  }
+
+  // implement allocation using EFI boot services AllocatePool() call.
+  fn boot_services_alloc(&self, layout: Layout) -> *mut u8 {
+    //bail early if not initialized.
+    let Some(bs_ptr) = self.boot_services else { return core::ptr::null_mut() };
+
+    let bs = unsafe { bs_ptr.as_mut().expect("Boot Services pointer is null.") };
+
+    match layout.align() {
+      0..=8 => {
+        //allocate the pointer directly since UEFI pool allocations are 8-byte aligned already.
+        let mut ptr: *mut c_void = core::ptr::null_mut();
+        match (bs.allocate_pool)(BOOT_SERVICES_DATA, layout.size(), core::ptr::addr_of_mut!(ptr)) {
+          Status::SUCCESS => ptr as *mut u8,
+          _ => core::ptr::null_mut(),
+        }
+      }
+      _ => {
+        //allocate extra space to align the allocation as requested and include a tracking structure to allow
+        //recovery of the original pointer for de-allocation. Tracking structure follows the allocation.
+        let (expanded_layout, tracking_offset) = match layout.extend(Layout::new::<AllocationTracker>()) {
+          Ok(x) => x,
+          Err(_) => return core::ptr::null_mut(),
+        };
+        let expanded_size = expanded_layout.size() + expanded_layout.align();
+
+        let mut orig_ptr: *mut c_void = core::ptr::null_mut();
+        let final_ptr = match (bs.allocate_pool)(BOOT_SERVICES_DATA, expanded_size, core::ptr::addr_of_mut!(orig_ptr)) {
+          Status::SUCCESS => orig_ptr as *mut u8,
+          _ => return core::ptr::null_mut(),
+        };
+
+        //align the pointer up to the required alignment.
+        let final_ptr = unsafe { final_ptr.add(final_ptr.align_offset(expanded_layout.align())) };
+
+        //get a reference to the allocation tracking structure after the allocation and populate it.
+        let tracker = unsafe {
+          final_ptr.add(tracking_offset).cast::<AllocationTracker>().as_mut().expect("tracking pointer is invalid")
+        };
+
+        tracker.signature = ALLOC_TRACKER_SIG;
+        tracker.orig_ptr = orig_ptr;
+
+        final_ptr
+      }
+    }
+  }
+
+  // implement dealloc (free) using EFI boot services FreePool() call.
+  fn boot_services_dealloc(&self, ptr: *mut u8, layout: Layout) {
+    //bail early if not initialized.
+    let Some(bs_ptr) = self.boot_services else { return };
+
+    let bs = unsafe { bs_ptr.as_mut().expect("Boot Services pointer is null.") };
+
+    match layout.align() {
+      0..=8 => {
+        //pointer was allocated directly, so free it directly.
+        let _ = (bs.free_pool)(ptr as *mut c_void);
+      }
+      _ => {
+        //pointer was potentially adjusted for alignment. Recover tracking structure to retrieve the original
+        //pointer to free.
+        let (_, tracking_offset) = match layout.extend(Layout::new::<AllocationTracker>()) {
+          Ok(x) => x,
+          Err(_) => return,
+        };
+        let tracker = unsafe {
+          ptr.add(tracking_offset).cast::<AllocationTracker>().as_mut().expect("tracking pointer is invalid")
+        };
+        debug_assert_eq!(tracker.signature, ALLOC_TRACKER_SIG);
+        let _ = (bs.free_pool)(tracker.orig_ptr);
+      }
+    }
+  }
+}
+
+/// A spin-locked allocator implementation.
+///
+/// Provides a locked allocator instance (using [`spin::Mutex`]) that is suitable for use as a
+/// [`core::alloc::GlobalAlloc`].
+pub struct SpinLockedAllocator {
+  inner: spin::Mutex<BootServicesAllocator>,
+}
+
+impl SpinLockedAllocator {
+  // Create a new instance. const fn to allow static initialization.
+  const fn new() -> Self {
+    SpinLockedAllocator { inner: spin::Mutex::new(BootServicesAllocator::new()) }
+  }
+
+  /// Initialize the allocator.
+  ///
+  /// This routine initializes the allocator by providing a pointer to the global EFI Boot Services table that will
+  /// supply pointers to the AllocatePool() and FreePool() primitives that implement memory allocation.
+  pub fn init(&self, boot_services: *mut BootServices) {
+    self.inner.lock().init(boot_services);
+  }
+}
+
+unsafe impl GlobalAlloc for SpinLockedAllocator {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    self.inner.lock().boot_services_alloc(layout)
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    self.inner.lock().boot_services_dealloc(ptr, layout)
+  }
+}
+
+unsafe impl Sync for SpinLockedAllocator {}
+unsafe impl Send for SpinLockedAllocator {}
+
+#[cfg(test)]
+mod tests {
+  extern crate std;
+
+  use core::{
+    alloc::{GlobalAlloc, Layout},
+    ffi::c_void,
+    mem::MaybeUninit,
+  };
+  use std::alloc::System;
+
+  use r_efi::{
+    efi::Status,
+    system::{BootServices, BOOT_SERVICES_DATA},
+  };
+  use std::collections::BTreeMap;
+
+  use crate::{AllocationTracker, SpinLockedAllocator, ALLOC_TRACKER_SIG};
+
+  static ALLOCATION_TRACKER: spin::Mutex<BTreeMap<usize, Layout>> = spin::Mutex::new(BTreeMap::new());
+
+  extern "efiapi" fn mock_allocate_pool(
+    pool_type: r_efi::system::MemoryType,
+    size: usize,
+    buffer: *mut *mut c_void,
+  ) -> Status {
+    assert_eq!(pool_type, BOOT_SERVICES_DATA);
+
+    unsafe {
+      let layout = Layout::from_size_align(size, 8).unwrap();
+      let ptr = System.alloc(layout) as *mut c_void;
+      buffer.write(ptr);
+      let existing_key = ALLOCATION_TRACKER.lock().insert(ptr as usize, layout);
+      assert!(existing_key.is_none());
+    }
+
+    Status::SUCCESS
+  }
+
+  extern "efiapi" fn mock_free_pool(buffer: *mut c_void) -> Status {
+    let layout = ALLOCATION_TRACKER.lock().remove(&(buffer as usize)).expect("freeing an un-allocated pointer");
+    unsafe {
+      System.dealloc(buffer as *mut u8, layout);
+    }
+
+    Status::SUCCESS
+  }
+
+  fn mock_boot_services() -> BootServices {
+    let boot_services = MaybeUninit::zeroed();
+    let mut boot_services: BootServices = unsafe { boot_services.assume_init() };
+    boot_services.allocate_pool = mock_allocate_pool;
+    boot_services.free_pool = mock_free_pool;
+    boot_services
+  }
+
+  #[test]
+  fn basic_alloc_and_dealloc() {
+    static ALLOCATOR: SpinLockedAllocator = SpinLockedAllocator::new();
+    ALLOCATOR.init(&mut mock_boot_services());
+
+    let layout = Layout::from_size_align(0x40, 0x8).unwrap();
+    let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
+    assert!(!ptr.is_null());
+    assert!(ALLOCATION_TRACKER.lock().contains_key(&(ptr as usize)));
+
+    unsafe { ALLOCATOR.dealloc(ptr, layout) };
+    assert!(!ALLOCATION_TRACKER.lock().contains_key(&(ptr as usize)));
+  }
+
+  #[test]
+  fn big_alignment_should_allocate_tracking_structure() {
+    static ALLOCATOR: SpinLockedAllocator = SpinLockedAllocator::new();
+    ALLOCATOR.init(&mut mock_boot_services());
+
+    let layout = Layout::from_size_align(0x40, 0x1000).unwrap();
+    let ptr = unsafe { ALLOCATOR.alloc_zeroed(layout) };
+    assert!(!ptr.is_null());
+    assert_eq!(ptr.align_offset(0x1000), 0);
+
+    // reconstruct a reference to the tracker structure at the end of the allocation.
+    let (_, tracking_offset) = layout.extend(Layout::new::<AllocationTracker>()).unwrap();
+    let tracker =
+      unsafe { ptr.add(tracking_offset).cast::<AllocationTracker>().as_mut().expect("tracking pointer is invalid") };
+    assert_eq!(tracker.signature, ALLOC_TRACKER_SIG);
+
+    let orig_ptr_addr = tracker.orig_ptr as usize;
+
+    assert!(ALLOCATION_TRACKER.lock().contains_key(&(orig_ptr_addr)));
+
+    unsafe { ALLOCATOR.dealloc(ptr, layout) };
+
+    assert!(!ALLOCATION_TRACKER.lock().contains_key(&(orig_ptr_addr)));
+  }
+}

--- a/MsCorePkg/HelloWorldRustDxe/.gitignore
+++ b/MsCorePkg/HelloWorldRustDxe/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/MsCorePkg/HelloWorldRustDxe/Cargo.toml
+++ b/MsCorePkg/HelloWorldRustDxe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "HelloWorldRustDxe"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "HelloWorldRustDxe"
+path = "src/main.rs"
+test = false
+
+[dependencies]
+r-efi = {workspace=true}
+RustAdvancedLoggerDxe = {workspace=true}
+RustBootServicesAllocatorDxe = {workspace=true}

--- a/MsCorePkg/HelloWorldRustDxe/HelloWorldRustDxe.inf
+++ b/MsCorePkg/HelloWorldRustDxe/HelloWorldRustDxe.inf
@@ -1,0 +1,20 @@
+### @file
+# Hello World DXE Rust driver.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = HelloWorldRustDxe
+  FILE_GUID       = A14E35E2-BB32-4446-8622-C1874B8284E4
+  MODULE_TYPE     = DXE_DRIVER
+  RUST_MODULE     = TRUE
+
+[Sources]
+  Cargo.toml
+
+[Depex]
+  TRUE

--- a/MsCorePkg/HelloWorldRustDxe/src/main.rs
+++ b/MsCorePkg/HelloWorldRustDxe/src/main.rs
@@ -1,0 +1,46 @@
+//! Hello World Rust DXE Driver
+//!
+//! Demonstrates how to build a DXE driver written in Rust.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+#![no_std]
+#![no_main]
+#![allow(non_snake_case)]
+
+extern crate alloc;
+
+use alloc::vec;
+use core::panic::PanicInfo;
+use r_efi::efi::Status;
+use rust_advanced_logger_dxe::{debugln, init_debug, DEBUG_INFO};
+
+#[no_mangle]
+pub extern "efiapi" fn efi_main(
+  _image_handle: *const core::ffi::c_void,
+  _system_table: *const r_efi::system::SystemTable,
+) -> u64 {
+  rust_boot_services_allocator_dxe::GLOBAL_ALLOCATOR.init(unsafe { (*_system_table).boot_services });
+  init_debug(unsafe { (*_system_table).boot_services });
+
+  debugln!(DEBUG_INFO, "Hello, World. This is Rust in UEFI.");
+
+  debugln!(DEBUG_INFO, "file: {:} line: {:} as hex: {:x}", file!(), line!(), line!());
+
+  let mut foo = vec!["asdf", "xyzpdq", "abcdefg", "thxyzb"];
+
+  debugln!(DEBUG_INFO, "Unsorted vec: {:?}", foo);
+  foo.sort();
+  debugln!(DEBUG_INFO, "Sorted vec: {:?}", foo);
+
+  Status::SUCCESS.as_usize() as u64
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+  loop {}
+}

--- a/MsCorePkg/MsCorePkg.ci.yaml
+++ b/MsCorePkg/MsCorePkg.ci.yaml
@@ -112,5 +112,12 @@
             "UEFI's"
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    "RustHostUnitTestPlugin": {
+        "Coverage": .75,
+        "CoverageOverrides": {
+            "RustBootServicesAllocatorDxe": 0.03
+        }
     }
 }

--- a/MsCorePkg/MsCorePkg.ci.yaml
+++ b/MsCorePkg/MsCorePkg.ci.yaml
@@ -117,6 +117,7 @@
     "RustHostUnitTestPlugin": {
         "Coverage": .75,
         "CoverageOverrides": {
+            "HelloWorldRustDxe": 0.0,
             "RustBootServicesAllocatorDxe": 0.03
         }
     }

--- a/MsCorePkg/MsCorePkg.dsc
+++ b/MsCorePkg/MsCorePkg.dsc
@@ -178,6 +178,7 @@
   MsCorePkg/Library/BaseIsCapsuleSupportedLibNull/BaseIsCapsuleSupportedLibNull.inf
   MsCorePkg/Library/SecureBootKeyStoreLibNull/SecureBootKeyStoreLibNull.inf
   MsCorePkg/Library/MuSecureBootKeySelectorLib/MuSecureBootKeySelectorLib.inf
+  MsCorePkg/HelloWorldRustDxe/HelloWorldRustDxe.inf
 
 [Components.IA32]
   MsCorePkg/Core/GuidedSectionExtractPeim/GuidedSectionExtract.inf


### PR DESCRIPTION
## Description

Makes some adjustments to allow edk2 Rust-based modules to build
in the repo and adds a hello world Rust DXE module.

These are based on the Rust code from @joschock.

Summary of changes:

---

.pytool/CISettings.py: Set rust-ci scope and use in tree BaseTools

The Rust BaseTool changes are not in the edk2-basetools PIP module,
so this change updates CISettings.py to use the in tree tools by
default.

The `rust-ci` scope is added as an active scope so Rust related
plugins like `RustHostUnitTestPlugin` will run.

---

MsCorePkg: Add RustBootServicesAllocatorDxe

Adds a library crate that implements a global allocator based on
`AllocatePool()`. Memory is allocated from the
`EFI_BOOT_SERVICES_DATA` pool.

---

MsCorePkg: Add HelloWorldRustDxe

Adds a simple Rust based DXE driver to demonstrate how to structure
a DXE driver that only has Rust crate dependencies.

Within the firmware build framework, this is considered a "pure Rust"
DXE driver in that it only has a `Cargo.toml` file in the `[Sources]`
section of the INF with no EDK II library dependencies.

The module uses the `RustAdvancedLoggerDxe` crate (which is a wrapper
around the Advanced Logger protocol) to write debug messages and the
`RustBootServicesAllocatorDxe`.

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MsCorePkg CI build
- Boot and test HelloWorldRustDxe on QEMU Q35

## Integration Instructions

See [Rust Build](https://github.com/microsoft/mu_basecore/blob/release/202302/Docs/rust_build.md) for more details about building and using Rust modules.