### PR TITLE
Integrate UefiCpuLib breaking change

### DIFF
--- a/MsCorePkg/MsCorePkg.dsc
+++ b/MsCorePkg/MsCorePkg.dsc
@@ -58,7 +58,7 @@
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   LocalApicLib|UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
-  UefiCpuLib|UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.inf
+  CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
 
   DeviceBootManagerLib|MsCorePkg/Library/DeviceBootManagerLibNull/DeviceBootManagerLibNull.inf
   PlatformBootManagerLib|MsCorePkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf

--- a/TpmTestingPkg/TpmTestingPkg.dsc
+++ b/TpmTestingPkg/TpmTestingPkg.dsc
@@ -20,6 +20,7 @@
 [LibraryClasses]
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
+  CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   FvMeasurementExclusionLib|TpmTestingPkg/Library/BaseFvMeasurementExclusionLibNull/BaseFvMeasurementExclusionLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
@@ -36,7 +37,6 @@
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
-  UefiCpuLib|UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -34,7 +34,7 @@
   MdeModulePkg/MdeModulePkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
   UefiTestingPkg/UefiTestingPkg.dec
-  
+
 [Packages.AARCH64]
   ArmPkg/ArmPkg.dec
 
@@ -53,7 +53,7 @@
   ArmLib
 
 [LibraryClasses.X64]
-  UefiCpuLib
+  CpuLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -29,7 +29,7 @@
 [Sources.AARCH64]
   AArch64/PagingAuditProcessor.c
   Dxe/App/AArch64/DxePagingAuditTests.c
-  
+
 [Packages.AARCH64]
   ArmPkg/ArmPkg.dec
 
@@ -58,7 +58,7 @@
   ArmLib
 
 [LibraryClasses.X64]
-  UefiCpuLib
+  CpuLib
   CpuPageTableLib
 
 [Guids]

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditDriver.inf
@@ -41,14 +41,14 @@
   DebugLib
   SmmMemLib
   BaseMemoryLib
-  PeCoffGetEntryPointLib 
+  PeCoffGetEntryPointLib
   BaseLib
   BaseMemoryLib
   DebugLib
   HobLib
   UefiLib
   PcdLib
-  UefiCpuLib
+  CpuLib
   DxeServicesTableLib
 
 [Depex]

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -40,7 +40,7 @@
   UefiBootServicesTableLib
   UefiLib
   CpuExceptionHandlerLib
-  UefiCpuLib
+  CpuLib
   HobLib
   PeCoffGetEntryPointLib
   DxeServicesTableLib

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "../PagingAuditCommon.h"
 #include <Register/Msr.h>
-#include <Library/UefiCpuLib.h>
+#include <Library/CpuLib.h>
 #include <Pi/PiHob.h>
 #include <Library/HobLib.h>
 #include <Protocol/SmmBase2.h>

--- a/UefiTestingPkg/UefiTestingPkg.dsc
+++ b/UefiTestingPkg/UefiTestingPkg.dsc
@@ -49,7 +49,7 @@
   DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
-  UefiCpuLib|UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.inf
+  CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   CpuExceptionHandlerLib|MdeModulePkg/Library/CpuExceptionHandlerLibNull/CpuExceptionHandlerLibNull.inf
   HwResetSystemLib|MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf


### PR DESCRIPTION
## Description

Updates the repo for a change that merged UefiCpuLib with CpuLib.

UefiCpuLib will be removed entirely soon so all references are updated to CpuLib.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Repo CI build
- Platform integration build (in QemuQ35Pkg)

## Integration Instructions

N/A