### PR TITLE
[REBASE && FF] Update DxePagingAuditTestApp with Additional Shell and HTML Tests

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <Library/ArmLib.h>
+#include <Protocol/MemoryAttribute.h>
 #include "../PagingAuditCommon.h"
 
 extern MEMORY_PROTECTION_DEBUG_PROTOCOL  *mMemoryProtectionProtocol;
@@ -251,10 +252,11 @@ DumpPlatforminfo (
   VOID
   )
 {
-  CHAR8  TempString[MAX_STRING_SIZE];
-  UINTN  ExecutionLevel;
-  CHAR8  *ElString;
-  UINTN  StringIndex;
+  CHAR8                          TempString[MAX_STRING_SIZE];
+  UINTN                          ExecutionLevel;
+  CHAR8                          *ElString;
+  UINTN                          StringIndex;
+  EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol;
 
   ExecutionLevel = ArmReadCurrentEL ();
 
@@ -268,13 +270,18 @@ DumpPlatforminfo (
     ElString = "Unknown";
   }
 
+  if (EFI_ERROR (gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&MemoryAttributeProtocol))) {
+    MemoryAttributeProtocol = NULL;
+  }
+
   // Dump the execution level of UEFI
   StringIndex = AsciiSPrint (
                   &TempString[0],
                   MAX_STRING_SIZE,
-                  "Architecture,AARCH64\nBitwidth,%d\nPhase,DXE\nExecutionLevel,%a\n",
+                  "Architecture,AARCH64\nBitwidth,%d\nPhase,DXE\nExecutionLevel,%a\nMemoryAttributeProtocolPresent,%a\n",
                   CalculateMaximumSupportAddressBits (),
-                  ElString
+                  ElString,
+                  (MemoryAttributeProtocol == NULL) ?  "FALSE" : "TRUE"
                   );
 
   WriteBufferToFile (L"PlatformInfo", TempString, StringIndex);

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -76,7 +76,6 @@ GetFlatPageTableData (
   UINTN       NumPage1GNotPresent = 0;
   UINT64      RootEntryCount      = 0;
   UINT64      Address;
-  BOOLEAN     Valid;
 
   //  Count parameters should be provided.
   if ((Pte1GCount == NULL) || (Pte2MCount == NULL) || (Pte4KCount == NULL) || (PdeCount == NULL) || (GuardCount == NULL)) {
@@ -117,13 +116,12 @@ GetFlatPageTableData (
     for (Index1 = 0x0; Index1 < TT_ENTRY_COUNT; Index1++ ) {
       Index2 = 0;
       Index3 = 0;
-      Valid  = TRUE;
       if ((Pte1G[Index1] & 0x1) == 0) {
         NumPage1GNotPresent++;
-        Valid = FALSE;
+        continue;
       }
 
-      if (!IS_BLOCK (Pte1G[Index1], 1) && Valid) {
+      if (!IS_BLOCK (Pte1G[Index1], 1)) {
         Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
 
         MyPdeCount++;
@@ -133,13 +131,12 @@ GetFlatPageTableData (
 
         for (Index2 = 0x0; Index2 < TT_ENTRY_COUNT; Index2++ ) {
           Index3 = 0;
-          Valid  = TRUE;
           if ((Pte2M[Index2] & 0x1) == 0) {
             NumPage2MNotPresent++;
-            Valid = FALSE;
+            continue;
           }
 
-          if (!IS_BLOCK (Pte2M[Index2], 2) && Valid) {
+          if (!IS_BLOCK (Pte2M[Index2], 2)) {
             Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
             MyPdeCount++;
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -137,8 +137,6 @@ FreePageTableMap (
 /**
   Populate the global flat page table map.
 
-  @param[in] Context            Unit test context.
-
   @retval EFI_SUCCESS           The page table is parsed successfully.
   @retval EFI_OUT_OF_RESOURCES  Failed to allocate memory for the page table map.
   @retval EFI_INVALID_PARAMETER An error occurred while parsing the page table.
@@ -168,7 +166,7 @@ PopulatePageTableMap (
 
     if (mMap.Entries == NULL) {
       UT_LOG_ERROR ("Failed to allocate %d pages for page table map!\n", mMap.EntryPagesAllocated);
-      return UNIT_TEST_ERROR_PREREQUISITE_NOT_MET;
+      return EFI_OUT_OF_RESOURCES;
     }
 
     Status = CreateFlatPageTable (&mMap);
@@ -214,6 +212,9 @@ FreeNonProtectedImageList (
 
 /**
   Populates the mNonProtectedImageList global
+
+  @retval EFI_SUCCESS   The non-protected image list is populated successfully.
+  @retval other         An error occurred while populating the non-protected image list.
 **/
 STATIC
 EFI_STATUS

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -14,45 +14,124 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/SimpleFileSystem.h>
 #include <Protocol/MemoryProtectionSpecialRegionProtocol.h>
 #include <Protocol/MemoryProtectionDebug.h>
+#include <Protocol/MemoryAttribute.h>
 
 #include <Library/FileHandleLib.h>
 #include <Library/DxeServicesTableLib.h>
 #include <Library/FlatPageTableLib.h>
 #include <Library/UnitTestLib.h>
+#include <Library/HobLib.h>
+#include <Library/SafeIntLib.h>
 
 #define UNIT_TEST_APP_NAME     "Paging Audit Test"
-#define UNIT_TEST_APP_VERSION  "1"
-#define MAX_CHARS_TO_READ      3
+#define UNIT_TEST_APP_VERSION  "2"
+#define MAX_CHARS_TO_READ      4
 
 // TRUE if A interval subsumes B interval
 #define CHECK_SUBSUMPTION(AStart, AEnd, BStart, BEnd) \
   ((AStart <= BStart) && (AEnd >= BEnd))
 
-CHAR8                             *mMemoryInfoDatabaseBuffer   = NULL;
-UINTN                             mMemoryInfoDatabaseSize      = 0;
-UINTN                             mMemoryInfoDatabaseAllocSize = 0;
-MEMORY_PROTECTION_SPECIAL_REGION  *mSpecialRegions             = NULL;
-IMAGE_RANGE_DESCRIPTOR            *mNonProtectedImageList      = NULL;
-UINTN                             mSpecialRegionCount          = 0;
-EFI_GCD_MEMORY_SPACE_DESCRIPTOR   *mMemorySpaceMap             = NULL;
-UINTN                             mMemorySpaceMapCount         = 0;
-PAGE_MAP                          mMap                         = { 0 };
+// TRUE if A and B have overlapping intervals
+#define CHECK_OVERLAP(AStart, AEnd, BStart, BEnd)   \
+  ((AEnd > AStart) && (BEnd > BStart) &&            \
+  ((AStart <= BStart && AEnd > BStart) ||           \
+  (BStart <= AStart && BEnd > AStart)))
+
+// Aligns the input address down to the nearest page boundary
+#define ALIGN_ADDRESS(Address)  ((Address / EFI_PAGE_SIZE) * EFI_PAGE_SIZE)
+
+// Globals required to create the memory info database
+CHAR8  *mMemoryInfoDatabaseBuffer   = NULL;
+UINTN  mMemoryInfoDatabaseSize      = 0;
+UINTN  mMemoryInfoDatabaseAllocSize = 0;
+
+// Globals for memory protection special regions
+MEMORY_PROTECTION_SPECIAL_REGION  *mSpecialRegions    = NULL;
+UINTN                             mSpecialRegionCount = 0;
+
+// Global for the non-protected image list
+IMAGE_RANGE_DESCRIPTOR  *mNonProtectedImageList = NULL;
+
+// Globals for the memory space map
+EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *mMemorySpaceMap     = NULL;
+UINTN                            mMemorySpaceMapCount = 0;
+
+// Globals for the EFI memory map
+UINTN                  mEfiMemoryMapSize           = 0;
+EFI_MEMORY_DESCRIPTOR  *mEfiMemoryMap              = NULL;
+UINTN                  mEfiMemoryMapDescriptorSize = 0;
+
+// Global for the flat page table
+PAGE_MAP  mMap = { 0 };
+
+// -------------------------------------------------
+//    GLOBALS SUPPORT FUNCTIONS
+// -------------------------------------------------
+
+/**
+  Return if the PE image section is aligned. This function must
+  only be called using a loaded image's code type or EfiReservedMemoryType.
+  Calling with a different type will ASSERT.
+
+  @param[in]  SectionAlignment    PE/COFF section alignment
+  @param[in]  MemoryType          PE/COFF image memory type
+
+  @retval TRUE  The PE image section is aligned.
+  @retval FALSE The PE image section is not aligned.
+**/
+BOOLEAN
+IsLoadedImageSectionAligned (
+  IN UINT32           SectionAlignment,
+  IN EFI_MEMORY_TYPE  MemoryType
+  )
+{
+  UINT32  PageAlignment;
+
+  switch (MemoryType) {
+    case EfiRuntimeServicesCode:
+    case EfiACPIMemoryNVS:
+      PageAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
+      break;
+    case EfiRuntimeServicesData:
+    case EfiACPIReclaimMemory:
+      ASSERT (FALSE);
+      PageAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
+      break;
+    case EfiBootServicesCode:
+    case EfiLoaderCode:
+    case EfiReservedMemoryType:
+      PageAlignment = EFI_PAGE_SIZE;
+      break;
+    default:
+      ASSERT (FALSE);
+      PageAlignment = EFI_PAGE_SIZE;
+      break;
+  }
+
+  if ((SectionAlignment & (PageAlignment - 1)) != 0) {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}
 
 /**
   Frees the entries in the mMap global.
-
-  @param[in] Context  Unit test context.
 **/
 STATIC
 VOID
-EFIAPI
 FreePageTableMap (
-  IN UNIT_TEST_CONTEXT  Context
+  VOID
   )
 {
   if (mMap.Entries != NULL) {
     FreePages (mMap.Entries, mMap.EntryPagesAllocated);
+    mMap.Entries = NULL;
   }
+
+  mMap.ArchSignature       = 0;
+  mMap.EntryCount          = 0;
+  mMap.EntryPagesAllocated = 0;
 }
 
 /**
@@ -65,19 +144,23 @@ FreePageTableMap (
   @retval EFI_INVALID_PARAMETER An error occurred while parsing the page table.
 **/
 STATIC
-UNIT_TEST_STATUS
-EFIAPI
+EFI_STATUS
 PopulatePageTableMap (
-  IN UNIT_TEST_CONTEXT  Context
+  VOID
   )
 {
   EFI_STATUS  Status;
 
+  if (mMap.Entries != NULL) {
+    return EFI_SUCCESS;
+  }
+
   Status = CreateFlatPageTable (&mMap);
 
-  while (Status == RETURN_BUFFER_TOO_SMALL) {
+  while (Status == EFI_BUFFER_TOO_SMALL) {
     if ((mMap.Entries != NULL) && (mMap.EntryPagesAllocated > 0)) {
       FreePages (mMap.Entries, mMap.EntryPagesAllocated);
+      mMap.Entries = NULL;
     }
 
     mMap.EntryPagesAllocated = EFI_SIZE_TO_PAGES (mMap.EntryCount * sizeof (PAGE_MAP_ENTRY));
@@ -92,17 +175,49 @@ PopulatePageTableMap (
   }
 
   if ((Status != EFI_SUCCESS) && (mMap.Entries != NULL)) {
-    FreePageTableMap (Context);
+    FreePageTableMap ();
   }
 
-  return Status == EFI_SUCCESS ? UNIT_TEST_PASSED : UNIT_TEST_ERROR_PREREQUISITE_NOT_MET;
+  return Status;
 }
 
 /**
-  Populates the non protected image list global
+  Frees the mNonProtectedImageList global
 **/
+STATIC
 VOID
-GetNonProtectedImageList (
+FreeNonProtectedImageList (
+  VOID
+  )
+{
+  LIST_ENTRY              *ImageRecordLink;
+  IMAGE_RANGE_DESCRIPTOR  *CurrentImageRangeDescriptor;
+
+  if (mNonProtectedImageList != NULL) {
+    ImageRecordLink = &mNonProtectedImageList->Link;
+    while (!IsListEmpty (ImageRecordLink)) {
+      CurrentImageRangeDescriptor = CR (
+                                      ImageRecordLink->ForwardLink,
+                                      IMAGE_RANGE_DESCRIPTOR,
+                                      Link,
+                                      IMAGE_RANGE_DESCRIPTOR_SIGNATURE
+                                      );
+
+      RemoveEntryList (&CurrentImageRangeDescriptor->Link);
+      FreePool (CurrentImageRangeDescriptor);
+    }
+
+    FreePool (mNonProtectedImageList);
+    mNonProtectedImageList = NULL;
+  }
+}
+
+/**
+  Populates the mNonProtectedImageList global
+**/
+STATIC
+EFI_STATUS
+PopulateNonProtectedImageList (
   VOID
   )
 {
@@ -112,7 +227,7 @@ GetNonProtectedImageList (
   MemoryProtectionProtocol = NULL;
 
   if (mNonProtectedImageList != NULL) {
-    return;
+    return EFI_SUCCESS;
   }
 
   Status = gBS->LocateProtocol (
@@ -132,13 +247,36 @@ GetNonProtectedImageList (
     DEBUG ((DEBUG_ERROR, "%a:%d - Unable to fetch non-protected image list\n", __FUNCTION__, __LINE__));
     mNonProtectedImageList = NULL;
   }
+
+  return Status;
+}
+
+/**
+  Frees the mSpecialRegions global
+**/
+STATIC
+VOID
+FreeSpecialRegions (
+  VOID
+  )
+{
+  if (mSpecialRegions != NULL) {
+    FreePool (mSpecialRegions);
+    mSpecialRegions = NULL;
+  }
+
+  mSpecialRegionCount = 0;
 }
 
 /**
   Populates the special region array global
+
+  @retval EFI_SUCCESS   The special region array is populated successfully.
+  @retval other         An error occurred while populating the special region array.
 **/
-VOID
-GetSpecialRegions (
+STATIC
+EFI_STATUS
+PopulateSpecialRegions (
   VOID
   )
 {
@@ -148,7 +286,7 @@ GetSpecialRegions (
   SpecialRegionProtocol = NULL;
 
   if (mSpecialRegions != NULL) {
-    return;
+    return EFI_SUCCESS;
   }
 
   Status = gBS->LocateProtocol (
@@ -166,9 +304,253 @@ GetSpecialRegions (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a:%d - Unable to fetch special region list\n", __FUNCTION__, __LINE__));
-    mNonProtectedImageList = NULL;
+    mSpecialRegions = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Frees the mMemorySpaceMap global
+**/
+STATIC
+VOID
+FreeMemorySpaceMap (
+  VOID
+  )
+{
+  if (mMemorySpaceMap != NULL) {
+    FreePool (mMemorySpaceMap);
+    mMemorySpaceMap = NULL;
+  }
+
+  mMemorySpaceMapCount = 0;
+}
+
+/**
+  Populates the memory space map global
+
+  @retval EFI_SUCCESS   The memory space map is populated successfully.
+  @retval other         An error occurred while populating the memory space map.
+**/
+STATIC
+EFI_STATUS
+PopulateMemorySpaceMap (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mMemorySpaceMap != NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Status = gDS->GetMemorySpaceMap (&mMemorySpaceMapCount, &mMemorySpaceMap);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a:%d - Unable to fetch memory space map\n", __FUNCTION__, __LINE__));
+    mMemorySpaceMap = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Frees the memory space map global
+**/
+STATIC
+VOID
+FreeEfiMemoryMap (
+  VOID
+  )
+{
+  if (mEfiMemoryMap != NULL) {
+    FreePool (mEfiMemoryMap);
+    mEfiMemoryMap = NULL;
+  }
+
+  mEfiMemoryMapSize           = 0;
+  mEfiMemoryMapDescriptorSize = 0;
+}
+
+/**
+  Populates the memory space map global
+
+  @retval EFI_SUCCESS   The memory space map is populated successfully.
+  @retval other         An error occurred while populating the memory space map.
+**/
+STATIC
+EFI_STATUS
+PopulateEfiMemoryMap (
+  VOID
+  )
+{
+  UINTN       EfiMapKey;
+  UINT32      EfiDescriptorVersion;
+  EFI_STATUS  Status;
+
+  // Get the EFI memory map.
+  mEfiMemoryMapSize           = 0;
+  mEfiMemoryMap               = NULL;
+  mEfiMemoryMapDescriptorSize = 0;
+
+  Status = gBS->GetMemoryMap (
+                  &mEfiMemoryMapSize,
+                  mEfiMemoryMap,
+                  &EfiMapKey,
+                  &mEfiMemoryMapDescriptorSize,
+                  &EfiDescriptorVersion
+                  );
+
+  // Loop to allocate space for the memory map and then copy it in.
+  do {
+    mEfiMemoryMap = (EFI_MEMORY_DESCRIPTOR *)AllocateZeroPool (mEfiMemoryMapSize);
+    if (mEfiMemoryMap == NULL) {
+      ASSERT (mEfiMemoryMap != NULL);
+      DEBUG ((DEBUG_ERROR, "%a - Unable to allocate memory for the EFI memory map.\n", __FUNCTION__));
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Status = gBS->GetMemoryMap (
+                    &mEfiMemoryMapSize,
+                    mEfiMemoryMap,
+                    &EfiMapKey,
+                    &mEfiMemoryMapDescriptorSize,
+                    &EfiDescriptorVersion
+                    );
+    if (EFI_ERROR (Status)) {
+      FreePool (mEfiMemoryMap);
+    }
+  } while (Status == EFI_BUFFER_TOO_SMALL);
+
+  return Status;
+}
+
+/**
+  Checks the input flat page/translation table for the input region and converts the associated
+  table entries to EFI access attributes.
+
+  @param[in]  Map                 Pointer to the PAGE_MAP struct to be parsed
+  @param[in]  Address             Start address of the region
+  @param[in]  Length              Length of the region
+  @param[out] Attributes          EFI Attributes of the region
+
+  @retval EFI_SUCCESS             The output Attributes is valid
+  @retval EFI_INVALID_PARAMETER   The flat translation table has not been built or
+                                  Attributes was NULL or Length was 0
+  @retval EFI_NOT_FOUND           The input region could not be found.
+**/
+EFI_STATUS
+EFIAPI
+GetRegionCommonAccessAttributes (
+  IN PAGE_MAP  *Map,
+  IN UINT64    Address,
+  IN UINT64    Length,
+  OUT UINT64   *Attributes
+  )
+{
+  UINTN    Index;
+  UINT64   EntryStartAddress;
+  UINT64   EntryEndAddress;
+  UINT64   InputEndAddress;
+  BOOLEAN  FoundRange;
+
+  if ((Map->Entries == NULL) || (Map->EntryCount == 0) || (Attributes == NULL) || (Length == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FoundRange      = FALSE;
+  Index           = 0;
+  InputEndAddress = 0;
+
+  if (EFI_ERROR (SafeUint64Add (Address, Length - 1, &InputEndAddress))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  do {
+    EntryStartAddress = Map->Entries[Index].LinearAddress;
+    if (EFI_ERROR (
+          SafeUint64Add (
+            Map->Entries[Index].LinearAddress,
+            Map->Entries[Index].Length - 1,
+            &EntryEndAddress
+            )
+          ))
+    {
+      return EFI_ABORTED;
+    }
+
+    if (CHECK_OVERLAP (Address, InputEndAddress, EntryStartAddress, EntryEndAddress)) {
+      if (!FoundRange) {
+        *Attributes = EFI_MEMORY_ACCESS_MASK;
+        FoundRange  = TRUE;
+      }
+
+      if (IsPageExecutable (Map->Entries[Index].PageEntry)) {
+        *Attributes &= ~EFI_MEMORY_XP;
+      }
+
+      if (IsPageWritable (Map->Entries[Index].PageEntry)) {
+        *Attributes &= ~EFI_MEMORY_RO;
+      }
+
+      if (IsPageReadable (Map->Entries[Index].PageEntry)) {
+        *Attributes &= ~EFI_MEMORY_RP;
+      }
+
+      Address = EntryEndAddress + 1;
+    }
+
+    if (EntryEndAddress >= InputEndAddress) {
+      break;
+    }
+  } while (++Index < Map->EntryCount);
+
+  return FoundRange ? EFI_SUCCESS : EFI_NOT_FOUND;
+}
+
+// ----------------------
+//    CLEANUP FUNCTION
+// ----------------------
+
+/**
+  Cleanup function for the unit test.
+
+  @param[in] Context        Unit test context
+
+  @retval UNIT_TEST_PASSED  Always passes
+**/
+STATIC
+VOID
+EFIAPI
+GeneralTestCleanup (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  if (mMap.Entries != NULL) {
+    FreePageTableMap ();
+  }
+
+  if (mSpecialRegions != NULL) {
+    FreeSpecialRegions ();
+  }
+
+  if (mNonProtectedImageList != NULL) {
+    FreeNonProtectedImageList ();
+  }
+
+  if (mMemorySpaceMap != NULL) {
+    FreeMemorySpaceMap ();
+  }
+
+  if (mEfiMemoryMap != NULL) {
+    FreeEfiMemoryMap ();
   }
 }
+
+// ---------------------------------
+//    UNIT TEST SUPPORT FUNCTIONS
+// ---------------------------------
 
 /**
   Checks if a region is allowed to be read/write/execute based on the special region array
@@ -247,52 +629,6 @@ CanRegionBeRWX (
 }
 
 /**
-  Check the page table for Read/Write/Execute regions.
-
-  @param[in] Context            Unit test context
-
-  @retval UNIT_TEST_PASSED      The unit test passed
-  @retval other                 The unit test failed
-
-**/
-UNIT_TEST_STATUS
-EFIAPI
-NoReadWriteExecute (
-  IN UNIT_TEST_CONTEXT  Context
-  )
-{
-  UINTN    Index;
-  BOOLEAN  FoundRWXAddress;
-
-  UT_ASSERT_NOT_NULL (mMap.Entries);
-  UT_ASSERT_NOT_EQUAL (mMap.EntryCount, 0);
-
-  Index           = 0;
-  FoundRWXAddress = FALSE;
-
-  for ( ; Index < mMap.EntryCount; Index++) {
-    if (IsPageExecutable (mMap.Entries[Index].PageEntry) &&
-        IsPageReadable (mMap.Entries[Index].PageEntry) &&
-        IsPageWritable (mMap.Entries[Index].PageEntry))
-    {
-      if (!CanRegionBeRWX (mMap.Entries[Index].LinearAddress, mMap.Entries[Index].Length)) {
-        UT_LOG_ERROR (
-          "Memory Range 0x%llx-0x%llx is Read/Write/Execute\n",
-          mMap.Entries[Index].LinearAddress,
-          mMap.Entries[Index].LinearAddress + mMap.Entries[Index].Length
-          );
-        FoundRWXAddress = TRUE;
-      }
-    }
-  }
-
-  UT_ASSERT_FALSE (FoundRWXAddress);
-
-  return UNIT_TEST_PASSED;
-}
-
-/**
-
  Locates and opens the SFS volume containing the application and, if successful, returns an
  FS handle to the opened volume.
 
@@ -422,8 +758,760 @@ CleanUp:
   return Status;
 }
 
+// -------------------------
+//    UNIT TEST FUNCTIONS
+// -------------------------
+
 /**
-  DxePagingAuditTestAppEntryPoint
+  Checks if the page/translation table has any read/write/execute
+  regions.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+
+**/
+UNIT_TEST_STATUS
+EFIAPI
+NoReadWriteExecute (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINTN    Index;
+  BOOLEAN  TestFailure;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  PopulateSpecialRegions ();
+  PopulateNonProtectedImageList ();
+  UT_ASSERT_NOT_EFI_ERROR (PopulateMemorySpaceMap ());
+  UT_ASSERT_NOT_NULL (mMemorySpaceMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  Index       = 0;
+  TestFailure = FALSE;
+
+  for ( ; Index < mMap.EntryCount; Index++) {
+    if (IsPageExecutable (mMap.Entries[Index].PageEntry) &&
+        IsPageReadable (mMap.Entries[Index].PageEntry) &&
+        IsPageWritable (mMap.Entries[Index].PageEntry))
+    {
+      if (!CanRegionBeRWX (mMap.Entries[Index].LinearAddress, mMap.Entries[Index].Length)) {
+        UT_LOG_ERROR (
+          "Memory Range 0x%llx-0x%llx is Read/Write/Execute\n",
+          mMap.Entries[Index].LinearAddress,
+          mMap.Entries[Index].LinearAddress + mMap.Entries[Index].Length
+          );
+        TestFailure = TRUE;
+      }
+    }
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that EfiConventionalMemory is EFI_MEMORY_RP or
+  is not mapped.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+UNIT_TEST_STATUS
+EFIAPI
+UnallocatedMemoryIsRP (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  BOOLEAN                TestFailure;
+  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
+  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
+  UINTN                  Attributes;
+  EFI_STATUS             Status;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulateEfiMemoryMap ());
+  UT_ASSERT_NOT_NULL (mEfiMemoryMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  TestFailure = FALSE;
+
+  EfiMemoryMapEntry = mEfiMemoryMap;
+  EfiMemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)mEfiMemoryMap + mEfiMemoryMapSize);
+
+  while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
+    if (EfiMemoryMapEntry->Type == EfiConventionalMemory) {
+      Attributes = 0;
+      Status     = GetRegionCommonAccessAttributes (
+                     &mMap,
+                     EfiMemoryMapEntry->PhysicalStart,
+                     EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE,
+                     &Attributes
+                     );
+      if (Status != EFI_NOT_FOUND) {
+        if (EFI_ERROR (Status)) {
+          UT_LOG_ERROR (
+            "Failed to get attributes for range 0x%llx - 0x%llx\n",
+            EfiMemoryMapEntry->PhysicalStart,
+            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
+            );
+          TestFailure = TRUE;
+        } else if ((Attributes & EFI_MEMORY_RP) == 0) {
+          UT_LOG_ERROR (
+            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_RP\n",
+            EfiMemoryMapEntry->PhysicalStart,
+            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
+            );
+          TestFailure = TRUE;
+        }
+      }
+    }
+
+    EfiMemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (EfiMemoryMapEntry, mEfiMemoryMapDescriptorSize);
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks if the EFI Memory Attribute Protocol is Present.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+UNIT_TEST_STATUS
+EFIAPI
+IsMemoryAttributeProtocolPresent (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                     Status;
+  EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttribute;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  Status = gBS->LocateProtocol (
+                  &gEfiMemoryAttributeProtocolGuid,
+                  NULL,
+                  (VOID **)&MemoryAttribute
+                  );
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Allocates Pages and Pools of each memory type and
+  checks that the returned buffers have restrictive
+  access attributes.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+UNIT_TEST_STATUS
+EFIAPI
+AllocatedPagesAndPoolsAreProtected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64      Attributes;
+  UINTN       Index;
+  EFI_STATUS  Status;
+  BOOLEAN     TestFailure;
+  UINTN       *PageAllocations[EfiMaxMemoryType];
+  UINTN       *PoolAllocations[EfiMaxMemoryType];
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  TestFailure = FALSE;
+  ZeroMem (PageAllocations, sizeof (PageAllocations));
+  ZeroMem (PoolAllocations, sizeof (PoolAllocations));
+
+  for (Index = 0; Index < EfiMaxMemoryType; Index++) {
+    if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory)) {
+      PageAllocations[Index] = AllocatePages (1);
+      if (PageAllocations[Index] == NULL) {
+        UT_LOG_ERROR ("Failed to allocate one page for memory type %d\n", Index);
+        TestFailure = TRUE;
+      }
+
+      PoolAllocations[Index] = AllocatePool (8);
+      if (PoolAllocations[Index] == NULL) {
+        UT_LOG_ERROR ("Failed to allocate an 8 byte pool for memory type %d\n", Index);
+        TestFailure = TRUE;
+      }
+    }
+  }
+
+  Status = PopulatePageTableMap ();
+
+  if (!EFI_ERROR (Status) && (mMap.Entries != NULL)) {
+    for (Index = 0; Index < EfiMaxMemoryType; Index++) {
+      if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory)) {
+        Attributes = 0;
+        Status     = GetRegionCommonAccessAttributes (
+                       &mMap,
+                       (UINT64)PageAllocations[Index],
+                       EFI_PAGE_SIZE,
+                       &Attributes
+                       );
+        if (Status != EFI_NOT_FOUND) {
+          if (EFI_ERROR (Status)) {
+            UT_LOG_ERROR (
+              "Failed to get attributes for range 0x%llx - 0x%llx\n",
+              PageAllocations[Index],
+              PageAllocations[Index] + EFI_PAGE_SIZE
+              );
+            TestFailure = TRUE;
+          }
+
+          if (Attributes == 0) {
+            UT_LOG_ERROR (
+              "Page range 0x%llx - 0x%llx has no restrictive access attributes\n",
+              PageAllocations[Index],
+              PageAllocations[Index] + EFI_PAGE_SIZE
+              );
+            TestFailure = TRUE;
+          }
+        }
+
+        Attributes = 0;
+        Status     = GetRegionCommonAccessAttributes (
+                       &mMap,
+                       ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]),
+                       EFI_PAGE_SIZE,
+                       &Attributes
+                       );
+        if ((Status != EFI_NOT_FOUND)) {
+          if (EFI_ERROR (Status)) {
+            UT_LOG_ERROR (
+              "Failed to get attributes for range 0x%llx - 0x%llx\n",
+              ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]),
+              ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]) + EFI_PAGE_SIZE
+              );
+            TestFailure = TRUE;
+          } else if (Attributes == 0) {
+            UT_LOG_ERROR (
+              "Pool range 0x%llx - 0x%llx has no restrictive access attributes\n",
+              PoolAllocations[Index],
+              PoolAllocations[Index] + sizeof (UINT64)
+              );
+            TestFailure = TRUE;
+          }
+        }
+      }
+    }
+  } else {
+    UT_LOG_ERROR ("Failed to populate page table map\n");
+    TestFailure = TRUE;
+  }
+
+  for (Index = 0; Index < EfiMaxMemoryType; Index++) {
+    if (PageAllocations[Index] != NULL) {
+      FreePages (PageAllocations[Index], 1);
+    }
+
+    if (PoolAllocations[Index] != NULL) {
+      FreePool (PoolAllocations[Index]);
+    }
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that the NULL page is not mapped or is
+  EFI_MEMORY_RP.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+NullCheck (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64      Attributes;
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  Attributes = 0;
+  Status     = GetRegionCommonAccessAttributes (&mMap, 0, EFI_PAGE_SIZE, &Attributes);
+
+  if ((Status != EFI_NOT_FOUND)) {
+    if (EFI_ERROR (Status)) {
+      UT_ASSERT_NOT_EFI_ERROR (Status);
+    } else {
+      UT_ASSERT_NOT_EQUAL (Attributes & EFI_MEMORY_RP, 0);
+    }
+  }
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that MMIO regions in the EFI memory map are
+  EFI_MEMORY_XP.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+MmioIsXp (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
+  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
+  UINT64                 Attributes;
+  BOOLEAN                TestFailure;
+  EFI_STATUS             Status;
+  UINTN                  Index;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulateEfiMemoryMap ());
+  UT_ASSERT_NOT_NULL (mEfiMemoryMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulateMemorySpaceMap ());
+  UT_ASSERT_NOT_NULL (mMemorySpaceMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  TestFailure = FALSE;
+
+  EfiMemoryMapEntry = mEfiMemoryMap;
+  EfiMemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)mEfiMemoryMap + mEfiMemoryMapSize);
+
+  while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
+    if (EfiMemoryMapEntry->Type == EfiMemoryMappedIO) {
+      Attributes = 0;
+      Status     = GetRegionCommonAccessAttributes (
+                     &mMap,
+                     EfiMemoryMapEntry->PhysicalStart,
+                     EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE,
+                     &Attributes
+                     );
+
+      if (Status != EFI_NOT_FOUND) {
+        if (EFI_ERROR (Status)) {
+          UT_LOG_ERROR (
+            "Failed to get attributes for range 0x%llx - 0x%llx\n",
+            EfiMemoryMapEntry->PhysicalStart,
+            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
+            );
+          TestFailure = TRUE;
+        } else if ((Attributes & EFI_MEMORY_XP) == 0) {
+          UT_LOG_ERROR (
+            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
+            EfiMemoryMapEntry->PhysicalStart,
+            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
+            );
+          TestFailure = TRUE;
+        }
+      }
+    }
+
+    EfiMemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (EfiMemoryMapEntry, mEfiMemoryMapDescriptorSize);
+  }
+
+  for (Index = 0; Index < mMemorySpaceMapCount; Index++) {
+    if (mMemorySpaceMap[Index].GcdMemoryType == EfiGcdMemoryTypeMemoryMappedIo) {
+      Attributes = 0;
+      Status     = GetRegionCommonAccessAttributes (
+                     &mMap,
+                     mMemorySpaceMap[Index].BaseAddress,
+                     mMemorySpaceMap[Index].Length,
+                     &Attributes
+                     );
+
+      if (Status != EFI_NOT_FOUND) {
+        if (EFI_ERROR (Status)) {
+          UT_LOG_ERROR (
+            "Failed to get attributes for range 0x%llx - 0x%llx\n",
+            mMemorySpaceMap[Index].BaseAddress,
+            mMemorySpaceMap[Index].BaseAddress + mMemorySpaceMap[Index].Length
+            );
+          TestFailure = TRUE;
+        } else if ((Attributes & EFI_MEMORY_XP) == 0) {
+          UT_LOG_ERROR (
+            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
+            mMemorySpaceMap[Index].BaseAddress,
+            mMemorySpaceMap[Index].BaseAddress + mMemorySpaceMap[Index].Length
+            );
+          TestFailure = TRUE;
+        }
+      }
+    }
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that loaded image sections containing code
+  are EFI_MEMORY_RO and sections containing data
+  are EFI_MEMORY_XP.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ImageCodeSectionsRoDataSectionsXp (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                           Status;
+  UINTN                                NoHandles;
+  EFI_HANDLE                           *HandleBuffer;
+  UINTN                                Index;
+  UINTN                                Index2;
+  EFI_LOADED_IMAGE_PROTOCOL            *LoadedImage;
+  EFI_IMAGE_DOS_HEADER                 *DosHdr;
+  UINT32                               PeCoffHeaderOffset;
+  EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION  Hdr;
+  UINT32                               SectionAlignment;
+  EFI_IMAGE_SECTION_HEADER             *Section;
+  UINT64                               Attributes;
+  BOOLEAN                              TestFailure;
+  UINT64                               SectionStart;
+  UINT64                               SectionEnd;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  TestFailure = FALSE;
+
+  Status = gBS->LocateHandleBuffer (
+                  ByProtocol,
+                  &gEfiLoadedImageProtocolGuid,
+                  NULL,
+                  &NoHandles,
+                  &HandleBuffer
+                  );
+  if (EFI_ERROR (Status) && (NoHandles == 0)) {
+    UT_LOG_ERROR ("Unable to query EFI Loaded Image Protocol\n");
+    UT_ASSERT_NOT_EFI_ERROR (Status);
+    UT_ASSERT_NOT_EQUAL (NoHandles, 0);
+  }
+
+  for (Index = 0; Index < NoHandles; Index++) {
+    Status = gBS->HandleProtocol (
+                    HandleBuffer[Index],
+                    &gEfiLoadedImageProtocolGuid,
+                    (VOID **)&LoadedImage
+                    );
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    // Check PE/COFF image
+    DosHdr             = (EFI_IMAGE_DOS_HEADER *)(UINTN)LoadedImage->ImageBase;
+    PeCoffHeaderOffset = 0;
+    if (DosHdr->e_magic == EFI_IMAGE_DOS_SIGNATURE) {
+      PeCoffHeaderOffset = DosHdr->e_lfanew;
+    }
+
+    Hdr.Pe32 = (EFI_IMAGE_NT_HEADERS32 *)((UINT8 *)(UINTN)LoadedImage->ImageBase + PeCoffHeaderOffset);
+
+    // Get SectionAlignment
+    if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+      SectionAlignment = Hdr.Pe32->OptionalHeader.SectionAlignment;
+    } else {
+      SectionAlignment = Hdr.Pe32Plus->OptionalHeader.SectionAlignment;
+    }
+
+    if (!IsLoadedImageSectionAligned (SectionAlignment, LoadedImage->ImageCodeType)) {
+      UT_LOG_ERROR (
+        "Image 0x%llx - 0x%llx is not aligned\n",
+        (UINTN)LoadedImage->ImageBase,
+        (UINTN)LoadedImage->ImageBase + LoadedImage->ImageSize
+        );
+      TestFailure = TRUE;
+      continue;
+    }
+
+    Section = (EFI_IMAGE_SECTION_HEADER *)(
+                                           (UINT8 *)(UINTN)LoadedImage->ImageBase +
+                                           PeCoffHeaderOffset +
+                                           sizeof (UINT32) +
+                                           sizeof (EFI_IMAGE_FILE_HEADER) +
+                                           Hdr.Pe32->FileHeader.SizeOfOptionalHeader
+                                           );
+
+    for (Index2 = 0; Index2 < Hdr.Pe32->FileHeader.NumberOfSections; Index2++) {
+      Attributes   = 0;
+      SectionStart = (UINT64)LoadedImage->ImageBase + Section[Index2].VirtualAddress;
+      SectionEnd   = SectionStart + ALIGN_VALUE (Section[Index2].SizeOfRawData, SectionAlignment);
+
+      // Check if the section contains code and data
+      if (((Section[Index2].Characteristics & EFI_IMAGE_SCN_CNT_CODE) != 0) &&
+          ((Section[Index2].Characteristics &
+            (EFI_IMAGE_SCN_CNT_INITIALIZED_DATA || EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) != 0))
+      {
+        UT_LOG_ERROR (
+          "Image Section 0x%llx-0x%llx contains code and data\n",
+          SectionStart,
+          SectionEnd
+          );
+        TestFailure = TRUE;
+      }
+
+      Status = GetRegionCommonAccessAttributes (
+                 &mMap,
+                 SectionStart,
+                 SectionEnd - SectionStart,
+                 &Attributes
+                 );
+
+      if (EFI_ERROR (Status)) {
+        TestFailure = TRUE;
+        UT_LOG_ERROR (
+          "Failed to get attributes for memory range 0x%llx-0x%llx\n",
+          SectionStart,
+          SectionEnd
+          );
+      } else if ((Section[Index2].Characteristics &
+                  (EFI_IMAGE_SCN_MEM_WRITE | EFI_IMAGE_SCN_MEM_EXECUTE)) == EFI_IMAGE_SCN_MEM_EXECUTE)
+      {
+        if ((Attributes & EFI_MEMORY_RO) == 0) {
+          UT_LOG_ERROR (
+            "Image Section 0x%llx-0x%llx is not EFI_MEMORY_RO\n",
+            SectionStart,
+            SectionEnd
+            );
+          TestFailure = TRUE;
+        }
+      } else {
+        if ((Attributes & EFI_MEMORY_XP) == 0) {
+          UT_LOG_ERROR (
+            "Image Section 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
+            SectionStart,
+            SectionEnd
+            );
+          TestFailure = TRUE;
+        }
+      }
+    }
+  }
+
+  FreePool (HandleBuffer);
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that the stack is EFI_MEMORY_XP and has
+  an EFI_MEMORY_RP page to catch overflow.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+BspStackIsXpAndHasGuardPage (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryHob;
+  BOOLEAN                    TestFailure;
+  EFI_PHYSICAL_ADDRESS       StackBase;
+  UINT64                     StackLength;
+  UINT64                     Attributes;
+  EFI_STATUS                 Status;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  Hob.Raw     = GetHobList ();
+  TestFailure = FALSE;
+
+  while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
+    MemoryHob = Hob.MemoryAllocation;
+    if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
+      StackBase   = (EFI_PHYSICAL_ADDRESS)((MemoryHob->AllocDescriptor.MemoryBaseAddress / EFI_PAGE_SIZE) * EFI_PAGE_SIZE);
+      StackLength = (EFI_PHYSICAL_ADDRESS)(EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (MemoryHob->AllocDescriptor.MemoryLength)));
+
+      UT_LOG_INFO ("BSP stack located at 0x%llx - 0x%llx", StackBase, StackBase + StackLength);
+
+      Attributes = 0;
+      Status     = GetRegionCommonAccessAttributes (
+                     &mMap,
+                     StackBase,
+                     EFI_PAGE_SIZE,
+                     &Attributes
+                     );
+      if ((Status != EFI_NOT_FOUND)) {
+        if (EFI_ERROR (Status)) {
+          UT_LOG_ERROR (
+            "Failed to get attributes for memory range 0x%llx-0x%llx\n",
+            StackBase,
+            StackBase + EFI_PAGE_SIZE
+            );
+          TestFailure = TRUE;
+        } else if (((Attributes & EFI_MEMORY_RP) == 0)) {
+          UT_LOG_ERROR (
+            "Stack 0x%llx-0x%llx does not have an EFI_MEMORY_RP page to catch overflow\n",
+            StackBase,
+            StackBase + EFI_PAGE_SIZE
+            );
+          TestFailure = TRUE;
+        }
+      }
+
+      Attributes = 0;
+      Status     = GetRegionCommonAccessAttributes (
+                     &mMap,
+                     StackBase + EFI_PAGE_SIZE,
+                     StackLength - EFI_PAGE_SIZE,
+                     &Attributes
+                     );
+
+      if (EFI_ERROR (Status)) {
+        UT_LOG_ERROR (
+          "Failed to get attributes for memory range 0x%llx-0x%llx\n",
+          StackBase + EFI_PAGE_SIZE,
+          StackBase + StackLength
+          );
+        TestFailure = TRUE;
+      } else if ((Attributes & EFI_MEMORY_XP) == 0) {
+        UT_LOG_ERROR (
+          "Stack 0x%llx-0x%llx is executable\n",
+          StackBase + EFI_PAGE_SIZE,
+          StackBase + StackLength
+          );
+        TestFailure = TRUE;
+      }
+
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Checks that memory ranges not in the EFI
+  memory map will cause a CPU fault if accessed.
+
+  @param[in] Context            Unit test context
+
+  @retval UNIT_TEST_PASSED      The unit test passed
+  @retval other                 The unit test failed
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+MemoryOutsideEfiMemoryMapIsInaccessible (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT64                 StartOfAddressSpace;
+  UINT64                 EndOfAddressSpace;
+  UINT64                 StartOfEfiMemoryMap;
+  UINT64                 EndOfEfiMemoryMap;
+  EFI_MEMORY_DESCRIPTOR  *FinalEfiMemoryMapDescriptor;
+  UINTN                  Index;
+  BOOLEAN                TestFailure;
+  UINT64                 StartOfMapEntry;
+  UINT64                 EndOfMapEntry;
+
+  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
+
+  UT_ASSERT_NOT_EFI_ERROR (PopulateEfiMemoryMap ());
+  UT_ASSERT_NOT_NULL (mEfiMemoryMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulateMemorySpaceMap ());
+  UT_ASSERT_NOT_NULL (mMemorySpaceMap);
+  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
+  UT_ASSERT_NOT_NULL (mMap.Entries);
+
+  StartOfAddressSpace = mMemorySpaceMap[0].BaseAddress;
+  EndOfAddressSpace   = mMemorySpaceMap[mMemorySpaceMapCount - 1].BaseAddress + mMemorySpaceMap[mMemorySpaceMapCount - 1].Length;
+  TestFailure         = FALSE;
+
+  StartOfEfiMemoryMap         = mEfiMemoryMap->PhysicalStart;
+  FinalEfiMemoryMapDescriptor = (EFI_MEMORY_DESCRIPTOR *)(((UINT8 *)mEfiMemoryMap + mEfiMemoryMapSize) - mEfiMemoryMapDescriptorSize);
+  EndOfEfiMemoryMap           = FinalEfiMemoryMapDescriptor->PhysicalStart + (FinalEfiMemoryMapDescriptor->NumberOfPages * EFI_PAGE_SIZE);
+
+  for (Index = 0; Index < mMap.EntryCount; Index++) {
+    StartOfMapEntry = mMap.Entries[Index].LinearAddress;
+    EndOfMapEntry   = mMap.Entries[Index].LinearAddress + mMap.Entries[Index].Length;
+    if (CHECK_OVERLAP (StartOfMapEntry, EndOfMapEntry, StartOfAddressSpace, StartOfEfiMemoryMap)) {
+      if (IsPageReadable (mMap.Entries[Index].PageEntry)) {
+        UT_LOG_ERROR (
+          "Memory Range 0x%llx-0x%llx is accessible\n",
+          StartOfMapEntry,
+          EndOfMapEntry
+          );
+        TestFailure = TRUE;
+      }
+    } else if (CHECK_OVERLAP (StartOfMapEntry, EndOfMapEntry, EndOfEfiMemoryMap, EndOfAddressSpace)) {
+      if (IsPageReadable (mMap.Entries[Index].PageEntry)) {
+        UT_LOG_ERROR (
+          "Memory Range 0x%llx-0x%llx is accessible\n",
+          StartOfMapEntry,
+          EndOfMapEntry
+          );
+        TestFailure = TRUE;
+      }
+    }
+  }
+
+  UT_ASSERT_FALSE (TestFailure);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Entry Point of the shell app.
 
   @param[in] ImageHandle  The firmware allocated handle for the EFI image.
   @param[in] SystemTable  A pointer to the EFI System Table.
@@ -447,7 +1535,6 @@ DxePagingAuditTestAppEntryPoint (
   EFI_FILE                       *Fs_Handle;
 
   DEBUG ((DEBUG_ERROR, "%a()\n", __FUNCTION__));
-
   DEBUG ((DEBUG_ERROR, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
 
   Status = gBS->HandleProtocol (
@@ -463,9 +1550,9 @@ DxePagingAuditTestAppEntryPoint (
 
   if (ShellParams->Argc > 1) {
     RunTests = FALSE;
-    if (StrnCmp (ShellParams->Argv[1], L"-r", 4) == 0) {
+    if (StrnCmp (ShellParams->Argv[1], L"-r", MAX_CHARS_TO_READ) == 0) {
       RunTests = TRUE;
-    } else if (StrnCmp (ShellParams->Argv[1], L"-d", 4) == 0) {
+    } else if (StrnCmp (ShellParams->Argv[1], L"-d", MAX_CHARS_TO_READ) == 0) {
       Status = OpenAppSFS (&Fs_Handle);
 
       if (!EFI_ERROR ((Status))) {
@@ -474,12 +1561,12 @@ DxePagingAuditTestAppEntryPoint (
         DumpPagingInfo (NULL);
       }
     } else {
-      if (StrnCmp (ShellParams->Argv[1], L"-h", 4) != 0) {
+      if (StrnCmp (ShellParams->Argv[1], L"-h", MAX_CHARS_TO_READ) != 0) {
         DEBUG ((DEBUG_INFO, "Invalid argument!\n"));
       }
 
       DEBUG ((DEBUG_INFO, "-h : Print available flags\n"));
-      DEBUG ((DEBUG_INFO, "-d : Dump the page table files to the EFI partition\n"));
+      DEBUG ((DEBUG_INFO, "-d : Dump the page table files\n"));
       DEBUG ((DEBUG_INFO, "-r : Run the application tests\n"));
       DEBUG ((DEBUG_INFO, "NOTE: Combined flags (i.e. -rd) is not supported\n"));
     }
@@ -505,26 +1592,30 @@ DxePagingAuditTestAppEntryPoint (
       goto EXIT;
     }
 
-    GetSpecialRegions ();
-    GetNonProtectedImageList ();
-    Status = gDS->GetMemorySpaceMap (&mMemorySpaceMapCount, &mMemorySpaceMap);
-
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a - Unable to fetch the GCD memory map. Test results may be inaccurate. Status: %r\n", __FUNCTION__, Status));
     }
 
-    AddTestCase (Misc, "No pages can be read,write,execute", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, PopulatePageTableMap, FreePageTableMap, NULL);
+    AddTestCase (Misc, "No pages are  readable, writable, and executable", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "Unallocated memory is EFI_MEMORY_RP", "Security.Misc.UnallocatedMemoryIsRP", UnallocatedMemoryIsRP, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "Memory Attribute Protocol is present", "Security.Misc.IsMemoryAttributeProtocolPresent", IsMemoryAttributeProtocolPresent, NULL, NULL, NULL);
+    AddTestCase (Misc, "Calls to allocate pages and pools return buffers with restrictive access attributes", "Security.Misc.AllocatedPagesAndPoolsAreProtected", AllocatedPagesAndPoolsAreProtected, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "NULL page is EFI_MEMORY_RP", "Security.Misc.NullCheck", NullCheck, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "MMIO Regions are EFI_MEMORY_XP", "Security.Misc.MmioIsXp", MmioIsXp, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "Image code sections are EFI_MEMORY_RO and and data sections are EFI_MEMORY_XP", "Security.Misc.ImageCodeSectionsRoDataSectionsXp", ImageCodeSectionsRoDataSectionsXp, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "BSP stack is EFI_MEMORY_XP and has EFI_MEMORY_RP guard page", "Security.Misc.BspStackIsXpAndHasGuardPage", BspStackIsXpAndHasGuardPage, NULL, GeneralTestCleanup, NULL);
+    AddTestCase (Misc, "Memory outside of the EFI Memory Map is inaccessible", "Security.Misc.MemoryOutsideEfiMemoryMapIsInaccessible", MemoryOutsideEfiMemoryMapIsInaccessible, NULL, GeneralTestCleanup, NULL);
 
     //
     // Execute the tests.
     //
     Status = RunAllTestSuites (Fw);
-EXIT:
+  }
 
-    if (Fw) {
-      FreeUnitTestFramework (Fw);
-    }
+EXIT:
+  if (Fw != NULL) {
+    FreeUnitTestFramework (Fw);
   }
 
   return EFI_SUCCESS;
-}   // DxePagingAuditTestAppEntryPoint()
+}

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -66,6 +66,7 @@
   gMemoryProtectionDebugProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
   gCpuMpDebugProtocolGuid
+  gEfiMemoryAttributeProtocolGuid
 
 [Protocols.X64]
   gEfiSmmBase2ProtocolGuid

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -51,6 +51,7 @@
   DxeMemoryProtectionHobLib
   FileHandleLib
   FlatPageTableLib
+  SafeIntLib
 
 [LibraryClasses.AARCH64]
   ArmLib
@@ -71,6 +72,8 @@
   gMemoryProtectionSpecialRegionProtocolGuid
   gEfiShellParametersProtocolGuid
   gCpuMpDebugProtocolGuid
+  gEfiMemoryAttributeProtocolGuid
+  gEfiLoadedImageProtocolGuid
 
 [Protocols.X64]
   gEfiSmmBase2ProtocolGuid

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
@@ -50,6 +50,7 @@
   gEfiSmmCommunicationProtocolGuid
   gMemoryProtectionDebugProtocolGuid
   gCpuMpDebugProtocolGuid
+  gEfiMemoryAttributeProtocolGuid
 
 [Protocols.X64]
   gEfiSmmBase2ProtocolGuid

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -13,6 +13,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Pi/PiHob.h>
 #include <Library/HobLib.h>
 #include <Protocol/SmmBase2.h>
+#include <Protocol/MemoryAttribute.h>
 
 #define AMD_64_SMM_ADDR  0xC0010112
 #define AMD_64_SMM_MASK  0xC0010113
@@ -747,11 +748,12 @@ DumpPlatforminfo (
   VOID
   )
 {
-  CHAR8                   TempString[MAX_STRING_SIZE];
-  UINTN                   StringIndex;
-  EFI_SMM_BASE2_PROTOCOL  *mSmmBase2;
-  BOOLEAN                 InSmm;
-  CHAR8                   *PhaseString;
+  CHAR8                          TempString[MAX_STRING_SIZE];
+  UINTN                          StringIndex;
+  EFI_SMM_BASE2_PROTOCOL         *mSmmBase2;
+  BOOLEAN                        InSmm;
+  CHAR8                          *PhaseString;
+  EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol;
 
   InSmm     = FALSE;
   mSmmBase2 = NULL;
@@ -769,12 +771,17 @@ DumpPlatforminfo (
     PhaseString = "DXE";
   }
 
+  if (EFI_ERROR (gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&MemoryAttributeProtocol))) {
+    MemoryAttributeProtocol = NULL;
+  }
+
   StringIndex = AsciiSPrint (
                   &TempString[0],
                   MAX_STRING_SIZE,
-                  "Architecture,X64\nPhase,%a\nBitwidth,%d\n",
+                  "Architecture,X64\nPhase,%a\nBitwidth,%d\nMemoryAttributeProtocolPresent,%a\n",
                   PhaseString,
-                  CalculateMaximumSupportAddressBits ()
+                  CalculateMaximumSupportAddressBits (),
+                  (MemoryAttributeProtocol == NULL) ?  "FALSE" : "TRUE"
                   );
 
   WriteBufferToFile (L"PlatformInfo", TempString, StringIndex);

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/BinaryParsing.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/BinaryParsing.py
@@ -54,6 +54,8 @@ def ParsePlatforminfofile(fileName):
             Globals.Bitwidth = int(row[1])
         elif row[0] == "Phase":
             Globals.Phase = row[1]
+        elif row[0] == "MemoryAttributeProtocolPresent":
+            Globals.MemoryAttributeProtocolPresent = row[1]
         else:
             logging.error("Unknown key found in PlatformInfo.dat: %s" % row[0])
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -1,14 +1,19 @@
 <!doctype html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible">
     <title>DXE Paging Analysis</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"> 
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css" integrity="sha384-DgpuBgmxMoEJnP/pccStiQeTHwqKcsuL22TmqYVw43N/k83XfGNmU+tKpz9+5Zpz" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha384-u4bCcN0S9upsb7D8S4IKXV9qmKh7bJrJbKa+jqcIPwQsk/dV+QHB/JyI/BXR3pNo" crossorigin="anonymous"> 
-   <style>
+    <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css"
+        integrity="sha384-DgpuBgmxMoEJnP/pccStiQeTHwqKcsuL22TmqYVw43N/k83XfGNmU+tKpz9+5Zpz" crossorigin="anonymous">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css"
+        integrity="sha384-u4bCcN0S9upsb7D8S4IKXV9qmKh7bJrJbKa+jqcIPwQsk/dV+QHB/JyI/BXR3pNo" crossorigin="anonymous">
+    <style>
         div.attribution {
             border: 1px solid #ddd;
             background-color: #bbb;
@@ -21,6 +26,7 @@
         }
     </style>
 </head>
+
 <body>
     <div class="container-fluid">
         <h1>DXE Paging Analysis</h1>
@@ -48,22 +54,30 @@
                         <header>Page Filter</header>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon1">Page Size</span>
-                            <select id="PageSizeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon1"></select>
+                            <select id="PageSizeFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon1"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon2">Access Flag Attribute</span>
-                            <select id="AccessFlagFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
+                            <select id="AccessFlagFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon2"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon2">Execute Attribute</span>
-                                <select id="ExecuteFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
+                            <span class="input-group-addon" id="basic-addon2">Execute Attribute</span>
+                            <select id="ExecuteFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon2"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon3">Read/Write Attribute</span>
-                                <select id="RWFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon3"></select>
+                            <span class="input-group-addon" id="basic-addon3">Read/Write Attribute</span>
+                            <select id="RWFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon3"></select>
                         </div>
                         <p></p>
                         <p>
@@ -74,27 +88,37 @@
                         <header>Memory Range Filter</header>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon4">UEFI Memory Type</span>
-                            <select id="MemoryTypeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
+                            <select id="MemoryTypeFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon4"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon4">GCD Memory Type</span>
-                            <select id="MemorySpaceTypeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
+                            <select id="MemorySpaceTypeFilter" class="form-control selectpicker"
+                                title="No Filter Active." data-style="btn-primary" data-actions-box="true"
+                                data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon6">Special Memory Regions</span>
-                            <select id="SpecialMemoryRegionsFilter" class="form-control selectpicker" data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary" multiple aria-describedby="basic-addon6"></select>
+                            <select id="SpecialMemoryRegionsFilter" class="form-control selectpicker"
+                                data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active."
+                                data-style="btn-primary" multiple aria-describedby="basic-addon6"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon5">Memory Contents</span>
-                            <select id="MemoryContentsFilter" class="form-control selectpicker" data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary" multiple aria-describedby="basic-addon5"></select>
+                            <select id="MemoryContentsFilter" class="form-control selectpicker" data-actions-box="true"
+                                data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary"
+                                multiple aria-describedby="basic-addon5"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon7">Section Type</span>
-                                <select id="SectionFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon7"></select>
+                            <span class="input-group-addon" id="basic-addon7">Section Type</span>
+                            <select id="SectionFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon7"></select>
                         </div>
                         <p></p>
                         <p>
@@ -104,6 +128,7 @@
                     <div class="col-xs-3">
                         <header>Actions</header>
                         Filters: <button id="ClearAllFilter" class="btn btn-danger">Clear All</button>
+                        <button id="toggleLogic">Toggle Logic (AND)</button>
                         <p></p>
                     </div>
                 </div>
@@ -152,11 +177,17 @@
                         <hr />
                         <div id="ToolLicenseContent">
                             <p>
-                                <span class="copyright">Copyright (C) Microsoft Corporation. All rights reserved.</span><br />
+                                <span class="copyright">Copyright (C) Microsoft Corporation. All rights
+                                    reserved.</span><br />
                                 <span class="license">
-                                    All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:<br>
-                                    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.<br>
-                                    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.<br><br>
+                                    All rights reserved. Redistribution and use in source and binary forms, with or
+                                    without modification, are permitted provided that the following conditions are
+                                    met:<br>
+                                    1. Redistributions of source code must retain the above copyright notice, this list
+                                    of conditions and the following disclaimer.<br>
+                                    2. Redistributions in binary form must reproduce the above copyright notice, this
+                                    list of conditions and the following disclaimer in the documentation and/or other
+                                    materials provided with the distribution.<br><br>
 
                                     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
                                     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -186,12 +217,24 @@
     </script>
 
     <!-- Javascript libraries -->
-    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script> 
-    <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js" integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo" crossorigin="anonymous"></script> 
-    <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script> 
-    <script src="https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js" integrity="sha384-7PXRkl4YJnEpP8uU4ev9652TTZSxrqC8uOpcV1ftVEC7LVyLZqqDUAaq+Y+lGgr9" crossorigin="anonymous"></script> 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha384-7RnKw5sMIle5aza0DbXRxSFziONgSQKq4/v0JGJnfrCIMWMyasw3n7w2IW4HK7Ss" crossorigin="anonymous"></script> 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-growl/1.0.0/jquery.bootstrap-growl.min.js" integrity="sha384-HitlARW+6c0IF2m5pcwV3x64ooKVvQsiTuCxKU9cRKVOVrYNopTqkeEoXclgAWqE" crossorigin="anonymous"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.2.1.min.js"
+        integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"
+        integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo"
+        crossorigin="anonymous"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js"
+        integrity="sha384-7PXRkl4YJnEpP8uU4ev9652TTZSxrqC8uOpcV1ftVEC7LVyLZqqDUAaq+Y+lGgr9"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js"
+        integrity="sha384-7RnKw5sMIle5aza0DbXRxSFziONgSQKq4/v0JGJnfrCIMWMyasw3n7w2IW4HK7Ss"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-growl/1.0.0/jquery.bootstrap-growl.min.js"
+        integrity="sha384-HitlARW+6c0IF2m5pcwV3x64ooKVvQsiTuCxKU9cRKVOVrYNopTqkeEoXclgAWqE"
+        crossorigin="anonymous"></script>
     <!-- Add javascript here -->
     <script>
         var DATA_TABLE_OFFSET = 500;
@@ -211,7 +254,7 @@
             //Write out errors or warnings in the data processing
             //
             EmbeddedJd.errors.forEach(function (element, index, array) {
-                $("table#ParsingErrors tbody").append("<tr><td>" + element +"</td></tr>");
+                $("table#ParsingErrors tbody").append("<tr><td>" + element + "</td></tr>");
             });  //end forEach
             var errorTable = $('table#ParsingErrors').dataTable({
                 "paginate": false,
@@ -227,7 +270,7 @@
                 $.fn.dataTable.tables({ visible: true, api: true }).columns.adjust();
             });
 
-         
+
             //
             // Create Attribution List for all external libraries used
             //
@@ -241,7 +284,7 @@
                 $("<div class='attribution'><h4>" + element.Title + "</h4><p>Version: <span class='version'>" + element.Version + "</span><br /><span class='copyright'>" +
                     element.Copyright + "</span><br />License: <a class='license' href='" + element.LicenseLink + "'>" + element.LicenseType + "</a></p></div>").appendTo("div#AttributionListWrapper");
             });
-           
+
             // filter
             $('button#ClearPageFilter').click(function () {
                 $("div#PageAttributeFilterWrapper select.selectpicker").selectpicker('deselectAll');
@@ -257,12 +300,12 @@
 
             $('button#ClearAllFilter').click(function () {
                 $('button#ClearMemoryFilter').click();
-                $('button#ClearPageFilter').click();    
+                $('button#ClearPageFilter').click();
             });
 
 
-             //table for modules
-             var mTable = $('table#MemoryRanges').dataTable({
+            //table for modules
+            var mTable = $('table#MemoryRanges').dataTable({
                 "aaData": EmbeddedJd.MemoryRanges,
                 "paginate": false,
                 "autoWidth": false,
@@ -324,152 +367,152 @@
                 ], //end of column def
                 initComplete: function () {
                     //Setup the filters
-                    this.api().column(2).every( function() {
+                    this.api().column(2).every(function () {
                         var column = this;
-                        var select = $("#PageSizeFilter").on( 'change', function () { 
+                        var select = $("#PageSizeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 2 - Page Size
 
-                    this.api().column(6).every( function() {
+                    this.api().column(6).every(function () {
                         var column = this;
-                        var select = $("#ExecuteFilter").on( 'change', function () {     
+                        var select = $("#ExecuteFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 6 - execute Attribute
 
-                    this.api().column(4).every( function() {
+                    this.api().column(4).every(function () {
                         var column = this;
-                        var select = $("#AccessFlagFilter").on( 'change', function () {     
+                        var select = $("#AccessFlagFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 4 - Present Attribute
 
-                    this.api().column(5).every( function() {
+                    this.api().column(5).every(function () {
                         var column = this;
-                        var select = $("#RWFilter").on( 'change', function () {     
+                        var select = $("#RWFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 5 - RW attribute
-                    
-                    this.api().column(9).every( function() {
+
+                    this.api().column(9).every(function () {
                         var column = this;
-                        var select = $("#SectionFilter").on( 'change', function () {
+                        var select = $("#SectionFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
                             column.search(SearchRegex, true, false).draw();
                         }); // on change
 
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 10 - Section Type for code/data sections
 
-                    this.api().column(7).every( function() {
+                    this.api().column(7).every(function () {
                         var column = this;
-                        var select = $("#MemoryTypeFilter").on( 'change', function () { 
+                        var select = $("#MemoryTypeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 8 - Memory Type
 
-                    this.api().column(8).every( function() {
+                    this.api().column(8).every(function () {
                         var column = this;
-                        var select = $("#MemorySpaceTypeFilter").on( 'change', function () { 
+                        var select = $("#MemorySpaceTypeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 9 - GCD Memory Type
 
-                    this.api().column(10).every( function() {
+                    this.api().column(10).every(function () {
                         var column = this;
-                        var select = $("#SpecialMemoryRegionsFilter").on( 'change', function () {     
+                        var select = $("#SpecialMemoryRegionsFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
-                        //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
-                    }); //column 11 - special Memory Type
-                    
 
-                    this.api().column(11).every( function() {
+                        //populate with options
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
+                    }); //column 11 - special Memory Type
+
+
+                    this.api().column(11).every(function () {
                         var column = this;
-                        var select = $("#MemoryContentsFilter").on( 'change', function () {     
+                        var select = $("#MemoryContentsFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            if(d === null) {
+                        column.data().unique().sort().each(function (d, j) {
+                            if (d === null) {
                                 d = "Nothing Found";  //this must align with the default content
                             }
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 12 - Memory Contents
-                } //end init complete func
+                } //end init complete func
             }) //end of modules table 
 
             /** Memory Range JSON looks like: 
@@ -489,37 +532,42 @@
             }
             **/
             var SavedFilters = [];
-            SavedFilters.push({"Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute", 
-                "Filter": function(mrObject) {
-                    if( (mrObject["Execute"] !== "Disabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Access Flag"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
+            SavedFilters.push({
+                "Name": "RW+X",
+                "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Filter": function (mrObject) {
+                    if ((mrObject["Execute"] !== "Disabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Access Flag"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
                     SetMultiselectTo("AccessFlagFilter", ["Yes"])
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("MemorySpaceTypeFilter",
                         ["EfiGcdMemoryTypeReserved",
-                        "EfiGcdMemoryTypeSystemMemory",
-                        "EfiGcdMemoryTypeMemoryMappedIo",
-                        "EfiGcdMemoryTypePersistent",
-                        "EfiGcdMemoryTypePersistentMemory",
-                        "EfiGcdMemoryTypeMoreReliable",
-                        "EfiGcdMemoryTypeMaximum"])
+                            "EfiGcdMemoryTypeSystemMemory",
+                            "EfiGcdMemoryTypeMemoryMappedIo",
+                            "EfiGcdMemoryTypePersistent",
+                            "EfiGcdMemoryTypePersistentMemory",
+                            "EfiGcdMemoryTypeMoreReliable",
+                            "EfiGcdMemoryTypeMaximum"])
                     return true;
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({"Name": "Data Sections are No-Execute", "Description": "Image data sections should be no-execute", "Filter": function(mrObject) {
-                    if((mrObject["Execute"] !== "Disabled") && (mrObject["Section Type"] === "DATA")) {
+            SavedFilters.push({
+                "Name": "Data Sections are No-Execute",
+                "Description": "Image data sections should be no-execute",
+                "Filter": function (mrObject) {
+                    if ((mrObject["Execute"] !== "Disabled") && (mrObject["Section Type"] === "DATA")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
                     SetMultiselectTo("SectionFilter", ["DATA"])
@@ -527,13 +575,16 @@
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({"Name": "Code Sections are Read-Only", "Description": "Image code sections should be read-only", "Filter": function(mrObject) {
-                    if((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
+            SavedFilters.push({
+                "Name": "Code Sections are Read-Only",
+                "Description": "Image code sections should be read-only",
+                "Filter": function (mrObject) {
+                    if ((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("SectionFilter", ["CODE"])
@@ -542,23 +593,23 @@
             });
 
             //Fill in the test results tab
-            SavedFilters.forEach(function(TestObject) {
+            SavedFilters.forEach(function (TestObject) {
                 var FailedCount = EmbeddedJd.MemoryRanges.filter(TestObject.Filter);
-                if(FailedCount == 0) {
+                if (FailedCount == 0) {
                     var b = $("<div class='TestStatus bg-success'><h4>" + TestObject.Name + "</h4><p>Description:" + TestObject.Description + "<br />Status: Success</p></div>");
                     b.appendTo("div#TestStatusListWrapper");
- 
+
                 } else {
                     var b = $("<div class='TestStatus bg-danger'><h4>" + TestObject.Name + "</h4><p>Description:" + TestObject.Description + "<br />Status: Failed (" + FailedCount.length + ")</p></div>");
                     //Create a button that configures the filter for this test result
                     var a = $('<button type="button" class="btn btn-danger">Set This As Filter For List</button>');
-                    a.click(function() {
-                        if(TestObject.ConfigureFilter()) {
+                    a.click(function () {
+                        if (TestObject.ConfigureFilter()) {
                             AddAlert(TestObject.Name + " Filter applied Successfully", "success");
                         } else {
                             AddAlert(TestObject.Name + " Filter failed", "danger");
-                        } 
-                        $('a[href="#tabs-3"]').tab('show'); 
+                        }
+                        $('a[href="#tabs-3"]').tab('show');
                     });
                     a.appendTo(b);
                     $('<p></p>').appendTo(b);
@@ -569,11 +620,11 @@
             $('div#tabs-3 select.selectpicker').selectpicker("refresh").change();
 
             //Show warning if there are parsing errors
-            if(EmbeddedJd.errors.length > 0) {
+            if (EmbeddedJd.errors.length > 0) {
                 $.bootstrapGrowl("Data Parsing Errors identified.  Please look at Parsing Errors tab as Results and Memory Data might not be accurate.", {
                     ele: 'body', // which element to append to
                     type: 'danger', // (null, 'info', 'danger', 'success')
-                    offset: {from: 'top', amount: 20}, // 'top', or 'bottom'
+                    offset: { from: 'top', amount: 20 }, // 'top', or 'bottom'
                     align: 'right', // ('left', 'right', or 'center')
                     width: 'auto', // (integer, or 'auto')
                     delay: 3600000, // Time while the message will be displayed.  1 hour
@@ -585,7 +636,7 @@
         //
         //To handle scroll tables adjust the height based on the window height.
         //
-        $(window).resize(function() {
+        $(window).resize(function () {
             var newHd = $(window).height() - DATA_TABLE_OFFSET;
             var newParsingHeight = $(window).height() - PARSING_TOOL_TABLE_OFFSET;
             $("#MemoryRanges_wrapper .dataTables_scrollBody").height(newHd);
@@ -593,18 +644,18 @@
             $.fn.dataTable.tables({ visible: true, api: true }).columns.adjust();
         });
 
-        function CreateRegexForSearchMultiselect(mylist){
+        function CreateRegexForSearchMultiselect(mylist) {
             var re = '';
             // console.log(mylist);
-            mylist.forEach(function(v,i,a) {
-                if(i > 0) {
+            mylist.forEach(function (v, i, a) {
+                if (i > 0) {
                     re += "|";
                 } else {
                     re += "("
                 }
                 re += '^' + $.fn.dataTable.util.escapeRegex(v) + '?';
             });
-            if(re !== '') {
+            if (re !== '') {
                 re += ")"
             }
             // console.log(re);
@@ -617,12 +668,11 @@
         @param selectName: id of the select element to set
         @param listOfValuesNotSelected: array of values to not select
         **/
-        function SetMultiselectToAllExcept(selectName, listOfValuesNotSelected )
-        {
+        function SetMultiselectToAllExcept(selectName, listOfValuesNotSelected) {
             var all = [];
             //get all options except reserved
-            $.each($("select#" + selectName +" option"), function(i,v) {
-                if(!listOfValuesNotSelected.includes($(v).val())){
+            $.each($("select#" + selectName + " option"), function (i, v) {
+                if (!listOfValuesNotSelected.includes($(v).val())) {
                     all.push($(v).val());
                 }
             });
@@ -637,45 +687,44 @@
             @param listOfValuesSelected: array of values to select
             @ret boolean status of setting all requested values
         **/
-        function SetMultiselectTo(selectName, listOfValuesSelected)
-        {
+        function SetMultiselectTo(selectName, listOfValuesSelected) {
             //var allOptions = $("select#" + selectName +" > option").map(function() { return $(this).val(); }).get(); //create array
-            $.each($("select#" + selectName +" option"), function(i,v) {
+            $.each($("select#" + selectName + " option"), function (i, v) {
                 var index = listOfValuesSelected.indexOf($(v).text());
-                if(index > -1){
+                if (index > -1) {
                     $(v).prop('selected', true);
                     listOfValuesSelected.splice(index, 1);  //remove from array so we can check at the end
                 }
-                else
-                {
+                else {
                     $(v).prop('selected', false);
                 }
             });
             $("select#" + selectName).change();
             $("select#" + selectName).selectpicker('refresh');
-            listOfValuesSelected.forEach(function(v, i, a) {
+            listOfValuesSelected.forEach(function (v, i, a) {
                 AddAlert("Can't set " + selectName + " value to " + v, "warning");
             });
-            return (listOfValuesSelected.length === 0); 
+            return (listOfValuesSelected.length === 0);
         }
 
         /**
         Add dismissable alert for user
         **/
-        function AddAlert(msg, level="danger"){
+        function AddAlert(msg, level = "danger") {
             $.bootstrapGrowl(msg, {
                 ele: 'body', // which element to append to
                 type: level, // (null, 'info', 'danger', 'success')
-                offset: {from: 'top', amount: 20}, // 'top', or 'bottom'
+                offset: { from: 'top', amount: 20 }, // 'top', or 'bottom'
                 align: 'right', // ('left', 'right', or 'center')
                 width: 'auto', // (integer, or 'auto')
                 delay: 10000, // Time while the message will be displayed.
                 allow_dismiss: true, // If true then will display a cross to close the popup.
                 stackup_spacing: 10 // spacing between consecutively stacked growls.
             });
-                
+
         }
 
     </script>
 </body>
+
 </html>

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -524,17 +524,33 @@
              **/
             var SavedFilters = [];
             SavedFilters.push({
-                "Name": "RW+X",
-                "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Name": "NULL Page Check",
+                "Description": "NULL page should be EFI_MEMORY_RP",
                 "Filter": function (mrObject) {
-                    if ((mrObject["Execute"] !== "Disabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Access Flag"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
-                        return true;
-                    }
-                    return false;
+                    var isTargetType = mrObject["System Memory"] === "NULL Page";
+                    var hasInvalidAttributes = mrObject["Access Flag"] !== "No";
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
+                    SetMultiselectTo("SpecialMemoryRegionsFilter", ["NULL Page"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "RW+X",
+                "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Filter": function (mrObject) {
+                    isTargetType = (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent");
+                    hasInvalidAttributes = (mrObject["Execute"] === "Enabled") &&
+                        (mrObject["Read/Write"] === "Enabled") &&
+                        (mrObject["Access Flag"] === "Yes");
+                    return isTargetType && hasInvalidAttributes;
+                },
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("ExecuteFilter", ["Enabled"])
                     SetMultiselectTo("AccessFlagFilter", ["Yes"])
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("MemorySpaceTypeFilter",
@@ -553,14 +569,13 @@
                 "Name": "Data Sections are No-Execute",
                 "Description": "Image data sections should be no-execute",
                 "Filter": function (mrObject) {
-                    if ((mrObject["Execute"] !== "Disabled") && (mrObject["Section Type"] === "DATA")) {
-                        return true;
-                    }
-                    return false;
+                    isTargetType = (mrObject["Section Type"] === "DATA");
+                    hasInvalidAttributes = (mrObject["Execute"] === "Enabled");
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("ExecuteFilter", ["UX", "PX", "UX/PX", "Enabled"])
+                    SetMultiselectTo("ExecuteFilter", ["Disabled"])
                     SetMultiselectTo("SectionFilter", ["DATA"])
                     return true;
                 } //end of configuring filter inputs
@@ -570,15 +585,66 @@
                 "Name": "Code Sections are Read-Only",
                 "Description": "Image code sections should be read-only",
                 "Filter": function (mrObject) {
-                    if ((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
-                        return true;
-                    }
-                    return false;
+                    isTargetType = (mrObject["Section Type"] === "CODE");
+                    hasInvalidAttributes = (mrObject["Read/Write"] === "Enabled");
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("SectionFilter", ["CODE"])
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "MMIO Execute Check",
+                "Description": "MMIO ranges should be non executable",
+                "Filter": function (mrObject) {
+                    var isTargetType = (mrObject["GCD Memory Type"] === "EfiGcdMemoryTypeMemoryMappedIo") ||
+                        (mrObject["Memory Type"] === "EfiMemoryMappedIO");
+                    var hasInvalidAttributes = (mrObject["Execute"] !== "Disabled") &&
+                        (mrObject["Access Flag"] !== "No");
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemorySpaceTypeFilter", ["EfiGcdMemoryTypeMemoryMappedIo"]);
+                    SetMultiselectTo("MemoryTypeFilter", ["EfiMemoryMappedIO"]);
+                    SetMultiselectTo("ExecuteFilter", ["Enabled"]);
+                    SetMultiselectTo("AccessFlagFilter", ["Yes"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "Free Memory Check",
+                "Description": "Free EFI memory should not be readable",
+                "Filter": function (mrObject) {
+                    var isTargetType = mrObject["Memory Type"] === "EfiConventionalMemory";
+                    var hasInvalidAttributes = mrObject["Access Flag"] !== "No";
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemoryTypeFilter", ["EfiConventionalMemory"]);
+                    SetMultiselectTo("AccessFlagFilter", ["Yes"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "Check Memory Not in EFI Memory Map is Inaccessible",
+                "Description": "Memory not in the EFI memory map should cause a fault if accessed",
+                "Filter": function (mrObject) {
+                    var isTargetType = mrObject["Memory Type"] === "None";
+                    var hasInvalidAttributes = mrObject["Access Flag"] !== "No";
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemoryTypeFilter", ["None"]);
+                    SetMultiselectTo("AccessFlagFilter", ["Yes"]);
                     return true;
                 } //end of configuring filter inputs
             });
@@ -607,6 +673,16 @@
                     b.appendTo("div#TestStatusListWrapper");
                 }
             });
+
+            var testName = "Memory Attribute Protocol is Installed";
+            var testDescription = "Checks if the platform produces the memory attribute protocol";
+            if (IsMemoryAttributeProtocolPresent === "TRUE") {
+                var b = $("<div class='TestStatus bg-success'><h4>" + testName + "</h4><p>Description:" + testDescription + "<br />Status: Success</p></div>");
+                b.appendTo("div#TestStatusListWrapper");
+            } else {
+                var b = $("<div class='TestStatus bg-danger'><h4>" + testName + "</h4><p>Description:" + testDescription + "<br />Status: Failed</p></div>");
+                b.appendTo("div#TestStatusListWrapper");
+            }
 
             $('div#tabs-3 select.selectpicker').selectpicker("refresh").change();
 
@@ -672,7 +748,6 @@
             @ret boolean status of setting all requested values
         **/
         function SetMultiselectTo(selectName, listOfValuesSelected) {
-            //var allOptions = $("select#" + selectName +" > option").map(function() { return $(this).val(); }).get(); //create array
             $.each($("select#" + selectName + " option"), function (i, v) {
                 var index = listOfValuesSelected.indexOf($(v).text());
                 if (index > -1) {
@@ -685,9 +760,6 @@
             });
             $("select#" + selectName).change();
             $("select#" + selectName).selectpicker('refresh');
-            listOfValuesSelected.forEach(function (v, i, a) {
-                AddAlert("Can't set " + selectName + " value to " + v, "warning");
-            });
             return (listOfValuesSelected.length === 0);
         }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -127,8 +127,8 @@
                     </div>
                     <div class="col-xs-3">
                         <header>Actions</header>
-                        Filters: <button id="ClearAllFilter" class="btn btn-danger">Clear All</button>
-                        <button id="toggleLogic">Toggle Logic (AND)</button>
+                        <button id="ClearAllFilter" class="btn btn-danger">Clear All</button>
+                        <button id="toggleLogic" class="btn btn-danger">Filter Logic: AND</button>
                         <p></p>
                     </div>
                 </div>
@@ -303,6 +303,18 @@
                 $('button#ClearPageFilter').click();
             });
 
+            var currentLogic = "AND";
+
+            $(document).on("click", "#toggleLogic", function () {
+                if (currentLogic === "AND") {
+                    currentLogic = "OR";
+                    $(this).text("Filter Logic: OR");
+                } else {
+                    currentLogic = "AND";
+                    $(this).text("Filter Logic: AND");
+                }
+                applyFilter(currentLogic);
+            });
 
             //table for modules
             var mTable = $('table#MemoryRanges').dataTable({
@@ -367,171 +379,149 @@
                     }
                 ], //end of column def
                 initComplete: function () {
-                    //Setup the filters
-                    this.api().column(2).every(function () {
+                    var tableApi = this.api();
+
+                    tableApi.columns().every(function () {
                         var column = this;
-                        var select = $("#PageSizeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
+                        var select;
 
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 2 - Page Size
-
-                    this.api().column(6).every(function () {
-                        var column = this;
-                        var select = $("#ExecuteFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 6 - execute Attribute
-
-                    this.api().column(4).every(function () {
-                        var column = this;
-                        var select = $("#AccessFlagFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 4 - Present Attribute
-
-                    this.api().column(5).every(function () {
-                        var column = this;
-                        var select = $("#RWFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 5 - RW attribute
-
-                    this.api().column(9).every(function () {
-                        var column = this;
-                        var select = $("#SectionFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column.search(SearchRegex, true, false).draw();
-                        }); // on change
+                        switch (column.index()) {
+                            case 2:
+                                select = $("#PageSizeFilter");
+                                break;
+                            case 4:
+                                select = $("#AccessFlagFilter");
+                                break;
+                            case 5:
+                                select = $("#RWFilter");
+                                break;
+                            case 6:
+                                select = $("#ExecuteFilter");
+                                break;
+                            case 7:
+                                select = $("#MemoryTypeFilter");
+                                break;
+                            case 8:
+                                select = $("#MemorySpaceTypeFilter");
+                                break;
+                            case 9:
+                                select = $("#SectionFilter");
+                                break;
+                            case 10:
+                                select = $("#SpecialMemoryRegionsFilter");
+                                break;
+                            case 11:
+                                select = $("#MemoryContentsFilter");
+                                break;
+                            default:
+                                console.log("Unhandled column index in init:", column.index());
+                                return;
+                        }
 
                         column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 10 - Section Type for code/data sections
-
-                    this.api().column(7).every(function () {
-                        var column = this;
-                        var select = $("#MemoryTypeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 8 - Memory Type
-
-                    this.api().column(8).every(function () {
-                        var column = this;
-                        var select = $("#MemorySpaceTypeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 9 - GCD Memory Type
-
-                    this.api().column(10).every(function () {
-                        var column = this;
-                        var select = $("#SpecialMemoryRegionsFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 11 - special Memory Type
-
-
-                    this.api().column(11).every(function () {
-                        var column = this;
-                        var select = $("#MemoryContentsFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            if (d === null) {
-                                d = "Nothing Found";  //this must align with the default content
+                            if (d !== null) {
+                                select.append('<option value="' + d + '">' + d + '</option>');
                             }
-                            select.append('<option value="' + d + '">' + d + '</option>')
                         });
-                    }); //column 12 - Memory Contents
-                } //end init complete func
-            }) //end of modules table 
+                    });
 
-            /** Memory Range JSON looks like: 
-            {"Page Size": "4k", 
-            "Present": "Yes",
-            "Read/Write": "Enabled", 
-            "Execute": "UX/PX",
-            "Start": "0x0000058000", 
-            "End": "0x0000058FFF", 
-            "Number of Entries": 1, 
-            "Memory Type": "EfiReservedMemoryType", 
-            "GCD Memory Type": "EfiGcdMemoryTypeReserved"
-            "Attributes": "EFI_MEMORY_RO, EFI_MEMORY_RUNTIME"
-            "System Memory": "None"
-            "Memory Contents": null,
-            "Partial Page": False
+                    $(".selectpicker").on("change", function () {
+                        applyFilter(currentLogic);
+                    });
+                }
+            })
+
+            var columnKeyMapping = {
+                "Page Size": "PageSize",
+                "Execute": "Execute",
+                "Access Flag": "AccessFlag",
+                "Read/Write": "RW",
+                "UEFI Memory Type": "MemoryType",
+                "GCD Memory Type": "MemorySpaceType",
+                "Special Memory Usage": "SpecialMemoryRegions",
+                "UEFI Memory Contents": "MemoryContents",
+                "Section Type": "SectionType"
+            };
+
+            function applyFilter(logic) {
+                $.fn.dataTable.ext.search = [];
+
+                var selectedValues = {
+                    PageSize: $("#PageSizeFilter").val(),
+                    Execute: $("#ExecuteFilter").val(),
+                    AccessFlag: $("#AccessFlagFilter").val(),
+                    RW: $("#RWFilter").val(),
+                    MemoryType: $("#MemoryTypeFilter").val(),
+                    MemorySpaceType: $("#MemorySpaceTypeFilter").val(),
+                    SpecialMemoryRegions: $("#SpecialMemoryRegionsFilter").val(),
+                    MemoryContents: $("#MemoryContentsFilter").val(),
+                    SectionType: $("#SectionFilter").val()
+                }
+
+                // Bail if no filters are selected
+                var noFiltersSelected = Object.values(selectedValues).every(arr => arr.length === 0);
+                if (noFiltersSelected) {
+                    mTable.api().search('').columns().search('').draw();
+                    return;
+                }
+
+                var searchRegexes = {
+                    PageSize: CreateRegexForSearchMultiselect(selectedValues.PageSize),
+                    Execute: CreateRegexForSearchMultiselect(selectedValues.Execute),
+                    AccessFlag: CreateRegexForSearchMultiselect(selectedValues.AccessFlag),
+                    RW: CreateRegexForSearchMultiselect(selectedValues.RW),
+                    MemoryType: CreateRegexForSearchMultiselect(selectedValues.MemoryType),
+                    MemorySpaceType: CreateRegexForSearchMultiselect(selectedValues.MemorySpaceType),
+                    SpecialMemoryRegions: CreateRegexForSearchMultiselect(selectedValues.SpecialMemoryRegions),
+                    MemoryContents: CreateRegexForSearchMultiselect(selectedValues.MemoryContents),
+                    SectionType: CreateRegexForSearchMultiselect(selectedValues.SectionType)
+                };
+
+                if (logic === "AND") {
+                    mTable.api().columns().every(function () {
+                        var columnTitle = this.header().textContent.trim();
+                        var searchKey = columnKeyMapping[columnTitle];
+                        if (searchRegexes[searchKey]) {
+                            this.search(searchRegexes[searchKey], true, false);
+                        } else {
+                            this.search('');
+                        }
+                    });
+                } else if (logic === "OR") {
+                    mTable.api().columns().search('');
+                    $.fn.dataTable.ext.search.push(function (settings, searchData, index, rowData, counter) {
+                        for (var key in columnKeyMapping) {
+                            var columnTitle = key;
+                            var searchKey = columnKeyMapping[columnTitle];
+                            var regexStr = searchRegexes[searchKey];
+                            var regex = new RegExp(regexStr);
+                            if (regexStr && regex.test(searchData[settings.aoColumns.findIndex(col => col.sTitle === columnTitle)])) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    });
+
+                }
+                mTable.api().draw();
             }
-            **/
+
+            /** Memory Range JSON looks like:
+            {"Page Size": "4k",
+            "Access Flag": "No",
+            "Read/Write": "Enabled",
+            "Execute": "Enabled",
+            "Start": "0x0000000000",
+            "End": "0x0000000FFF",
+            "Number of Entries": 1,
+            "Memory Type": "None",
+            "GCD Memory Type": "EfiGcdMemoryTypeNonExistent",
+            "Section Type": "Not Tracked",
+            "System Memory": "NULL Page",
+            "Memory Contents": null,
+            "Partial Page": false
+            }
+             **/
             var SavedFilters = [];
             SavedFilters.push({
                 "Name": "RW+X",
@@ -647,19 +637,12 @@
 
         function CreateRegexForSearchMultiselect(mylist) {
             var re = '';
-            // console.log(mylist);
             mylist.forEach(function (v, i, a) {
                 if (i > 0) {
                     re += "|";
-                } else {
-                    re += "("
                 }
-                re += '^' + $.fn.dataTable.util.escapeRegex(v) + '?';
+                re += '^' + $.fn.dataTable.util.escapeRegex(v) + '$';
             });
-            if (re !== '') {
-                re += ")"
-            }
-            // console.log(re);
             return re;
         }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -181,7 +181,8 @@
     </div>
 
     <script>
-        var EmbeddedJd = %TO_BE_FILLED_IN_BY_PYTHON_SCRIPT%;
+        var EmbeddedJd = % TO_BE_FILLED_IN_BY_PYTHON_SCRIPT %;
+        var IsMemoryAttributeProtocolPresent = % IS_MEMORY_ATTRIBUTE_PROTOCOL_PRESENT %;
     </script>
 
     <!-- Javascript libraries -->

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -310,6 +310,7 @@
                 "paginate": false,
                 "autoWidth": false,
                 "scrollY": ($(window).height() - DATA_TABLE_OFFSET) + "px",
+                "scrollX": true,
                 "sorting": [[0, "asc"]],
                 "columnDefs": [
                     {

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -187,7 +187,8 @@
     </div>
 
     <script>
-        var EmbeddedJd = %TO_BE_FILLED_IN_BY_PYTHON_SCRIPT%;
+        var EmbeddedJd = % TO_BE_FILLED_IN_BY_PYTHON_SCRIPT %;
+        var IsMemoryAttributeProtocolPresent = % IS_MEMORY_ATTRIBUTE_PROTOCOL_PRESENT %;
     </script>
 
     <!-- Javascript libraries -->

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -317,6 +317,7 @@
                 "paginate": false,
                 "autoWidth": false,
                 "scrollY": ($(window).height() - DATA_TABLE_OFFSET) + "px",
+                "scrollX": true,
                 "sorting": [[0, "asc"]],
                 "columnDefs": [
                     {

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -134,7 +134,8 @@
                     </div>
                     <div class="col-xs-3">
                         <header>Actions</header>
-                        Filters: <button id="ClearAllFilter" class="btn btn-danger">Clear All</button>
+                        <button id="ClearAllFilter" class="btn btn-danger">Clear All</button>
+                        <button id="toggleLogic" class="btn btn-danger">Filter Logic: AND</button>
                         <p></p>
                     </div>
                 </div>
@@ -310,6 +311,18 @@
                 $('button#ClearPageFilter').click();
             });
 
+            var currentLogic = "AND";
+
+            $(document).on("click", "#toggleLogic", function () {
+                if (currentLogic === "AND") {
+                    currentLogic = "OR";
+                    $(this).text("Filter Logic: OR");
+                } else {
+                    currentLogic = "AND";
+                    $(this).text("Filter Logic: AND");
+                }
+                applyFilter(currentLogic);
+            });
 
             //table for modules
             var mTable = $('table#MemoryRanges').dataTable({
@@ -378,166 +391,140 @@
                     }
                 ], //end of column def
                 initComplete: function () {
-                    //Setup the filters
-                    this.api().column(2).every(function () {
+                    var tableApi = this.api();
+
+                    tableApi.columns().every(function () {
                         var column = this;
-                        var select = $("#PageSizeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
+                        var select;
 
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 2 - Page Size
-
-                    this.api().column(6).every(function () {
-                        var column = this;
-                        var select = $("#ExecuteFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 6 - execute Attribute
-
-                    this.api().column(4).every(function () {
-                        var column = this;
-                        var select = $("#PresentFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 4 - Present Attribute
-
-                    this.api().column(5).every(function () {
-                        var column = this;
-                        var select = $("#RWFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 5 - RW attribute
-
-                    this.api().column(7).every(function () {
-                        var column = this;
-                        var select = $("#PrivilegeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column.search(SearchRegex, true, false).draw();
-                        }); // on change
+                        switch (column.index()) {
+                            case 2:
+                                select = $("#PageSizeFilter");
+                                break;
+                            case 4:
+                                select = $("#PresentFilter");
+                                break;
+                            case 6:
+                                select = $("#ExecuteFilter");
+                                break;
+                            case 5:
+                                select = $("#RWFilter");
+                                break;
+                            case 7:
+                                select = $("#PrivilegeFilter");
+                                break;
+                            case 8:
+                                select = $("#MemoryTypeFilter");
+                                break;
+                            case 9:
+                                select = $("#MemorySpaceTypeFilter");
+                                break;
+                            case 10:
+                                select = $("#SectionFilter");
+                                break;
+                            case 11:
+                                select = $("#SpecialMemoryRegionsFilter");
+                                break;
+                            case 12:
+                                select = $("#MemoryContentsFilter");
+                                break;
+                            default:
+                                console.log("Unhandled column index in init:", column.index());
+                                return;
+                        }
 
                         column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 7 - Privilege (User / Supervisor)
-
-                    this.api().column(10).every(function () {
-                        var column = this;
-                        var select = $("#SectionFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column.search(SearchRegex, true, false).draw();
-                        }); // on change
-
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 10 - Section Type for code/data sections
-
-                    this.api().column(8).every(function () {
-                        var column = this;
-                        var select = $("#MemoryTypeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 8 - Memory Type
-
-                    this.api().column(9).every(function () {
-                        var column = this;
-                        var select = $("#MemorySpaceTypeFilter").on('change', function () {
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 9 - GCD Memory Type
-
-                    this.api().column(11).every(function () {
-                        var column = this;
-                        var select = $("#SpecialMemoryRegionsFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            select.append('<option value="' + d + '">' + d + '</option>')
-                        });
-                    }); //column 11 - special Memory Type
-
-
-                    this.api().column(12).every(function () {
-                        var column = this;
-                        var select = $("#MemoryContentsFilter").on('change', function () {
-                            //var SelectedValues = $(this).val() || [];
-                            var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                            column
-                                //.search( val ? '^'+val+'$' : '', true, false )
-                                .search(SearchRegex, true, false)
-                                .draw();
-                        }); // on change
-
-                        //populate with options
-                        column.data().unique().sort().each(function (d, j) {
-                            if (d === null) {
-                                d = "Nothing Found";  //this must align with the default content
+                            if (d !== null) {
+                                select.append('<option value="' + d + '">' + d + '</option>');
                             }
-                            select.append('<option value="' + d + '">' + d + '</option>')
                         });
-                    }); //column 12 - Memory Contents
-                } //end init complete func
-            }) //end of modules table 
+                    });
+
+                    $(".selectpicker").on("change", function () {
+                        applyFilter(currentLogic);
+                    });
+                }
+            })
+
+            var columnKeyMapping = {
+                "Page Size": "PageSize",
+                "Present": "Present",
+                "Read/Write": "RW",
+                "Execute": "Execute",
+                "Privilege": "Privilege",
+                "UEFI Memory Type": "MemoryType",
+                "GCD Memory Type": "MemorySpaceType",
+                "Section Type": "SectionType",
+                "Special Memory Usage": "SpecialMemoryRegions",
+                "UEFI Memory Contents": "MemoryContents"
+            };
+
+            function applyFilter(logic) {
+                $.fn.dataTable.ext.search = [];
+
+                var selectedValues = {
+                    PageSize: $("#PageSizeFilter").val(),
+                    Execute: $("#ExecuteFilter").val(),
+                    Present: $("#PresentFilter").val(),
+                    RW: $("#RWFilter").val(),
+                    Privilege: $("#PrivilegeFilter").val(),
+                    MemoryType: $("#MemoryTypeFilter").val(),
+                    MemorySpaceType: $("#MemorySpaceTypeFilter").val(),
+                    SpecialMemoryRegions: $("#SpecialMemoryRegionsFilter").val(),
+                    MemoryContents: $("#MemoryContentsFilter").val(),
+                    SectionType: $("#SectionFilter").val()
+                }
+
+                // Check if filters are selected
+                var noFiltersSelected = Object.values(selectedValues).every(arr => arr.length === 0);
+                if (noFiltersSelected) {
+                    mTable.api().search('').columns().search('').draw();
+                    return;
+                }
+
+                var searchRegexes = {
+                    PageSize: CreateRegexForSearchMultiselect(selectedValues.PageSize),
+                    Execute: CreateRegexForSearchMultiselect(selectedValues.Execute),
+                    Present: CreateRegexForSearchMultiselect(selectedValues.Present),
+                    RW: CreateRegexForSearchMultiselect(selectedValues.RW),
+                    Privilege: CreateRegexForSearchMultiselect(selectedValues.Privilege),
+                    MemoryType: CreateRegexForSearchMultiselect(selectedValues.MemoryType),
+                    MemorySpaceType: CreateRegexForSearchMultiselect(selectedValues.MemorySpaceType),
+                    SpecialMemoryRegions: CreateRegexForSearchMultiselect(selectedValues.SpecialMemoryRegions),
+                    MemoryContents: CreateRegexForSearchMultiselect(selectedValues.MemoryContents),
+                    SectionType: CreateRegexForSearchMultiselect(selectedValues.SectionType)
+                };
+
+                if (logic === "AND") {
+                    mTable.api().columns().every(function () {
+                        var columnTitle = this.header().textContent.trim();
+                        var searchKey = columnKeyMapping[columnTitle];
+                        if (searchRegexes[searchKey]) {
+                            this.search(searchRegexes[searchKey], true, false);
+                        } else {
+                            this.search('');
+                        }
+                    });
+                } else if (logic === "OR") {
+                    mTable.api().columns().search('');
+
+                    // Push our custom search function
+                    $.fn.dataTable.ext.search.push(function (settings, searchData, index, rowData, counter) {
+                        for (var key in columnKeyMapping) {
+                            var columnTitle = key;
+                            var searchKey = columnKeyMapping[columnTitle];
+                            var regexStr = searchRegexes[searchKey];
+                            var regex = new RegExp(regexStr);
+                            if (regexStr && regex.test(searchData[settings.aoColumns.findIndex(col => col.sTitle === columnTitle)])) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    });
+
+                }
+                mTable.api().draw();
+            }
 
             /** Memory Range JSON looks like: 
             {"Page Size": "4k", 
@@ -666,19 +653,12 @@
 
         function CreateRegexForSearchMultiselect(mylist) {
             var re = '';
-            // console.log(mylist);
             mylist.forEach(function (v, i, a) {
                 if (i > 0) {
                     re += "|";
-                } else {
-                    re += "("
                 }
-                re += '^' + $.fn.dataTable.util.escapeRegex(v) + '?';
+                re += '^' + $.fn.dataTable.util.escapeRegex(v) + '$';
             });
-            if (re !== '') {
-                re += ")"
-            }
-            // console.log(re);
             return re;
         }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -1,14 +1,19 @@
 <!doctype html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible">
     <title>DXE Paging Analysis</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"> 
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css" integrity="sha384-DgpuBgmxMoEJnP/pccStiQeTHwqKcsuL22TmqYVw43N/k83XfGNmU+tKpz9+5Zpz" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css" integrity="sha384-u4bCcN0S9upsb7D8S4IKXV9qmKh7bJrJbKa+jqcIPwQsk/dV+QHB/JyI/BXR3pNo" crossorigin="anonymous"> 
-   <style>
+    <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css"
+        integrity="sha384-DgpuBgmxMoEJnP/pccStiQeTHwqKcsuL22TmqYVw43N/k83XfGNmU+tKpz9+5Zpz" crossorigin="anonymous">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/css/bootstrap-select.min.css"
+        integrity="sha384-u4bCcN0S9upsb7D8S4IKXV9qmKh7bJrJbKa+jqcIPwQsk/dV+QHB/JyI/BXR3pNo" crossorigin="anonymous">
+    <style>
         div.attribution {
             border: 1px solid #ddd;
             background-color: #bbb;
@@ -21,6 +26,7 @@
         }
     </style>
 </head>
+
 <body>
     <div class="container-fluid">
         <h1>DXE Paging Analysis</h1>
@@ -48,27 +54,37 @@
                         <header>Page Filter</header>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon1">Page Size</span>
-                            <select id="PageSizeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon1"></select>
+                            <select id="PageSizeFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon1"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon2">Present Attribute</span>
-                            <select id="PresentFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
+                            <select id="PresentFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon2"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon2">Execute Attribute</span>
-                                <select id="ExecuteFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon2"></select>
+                            <span class="input-group-addon" id="basic-addon2">Execute Attribute</span>
+                            <select id="ExecuteFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon2"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon3">Read/Write Attribute</span>
-                                <select id="RWFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon3"></select>
+                            <span class="input-group-addon" id="basic-addon3">Read/Write Attribute</span>
+                            <select id="RWFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon3"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon8">Privilege Level</span>
-                                <select id="PrivilegeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon8"></select>
+                            <span class="input-group-addon" id="basic-addon8">Privilege Level</span>
+                            <select id="PrivilegeFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon8"></select>
                         </div>
                         <p></p>
                         <p>
@@ -79,27 +95,37 @@
                         <header>Memory Range Filter</header>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon4">UEFI Memory Type</span>
-                            <select id="MemoryTypeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
+                            <select id="MemoryTypeFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon4"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon4">GCD Memory Type</span>
-                            <select id="MemorySpaceTypeFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
+                            <select id="MemorySpaceTypeFilter" class="form-control selectpicker"
+                                title="No Filter Active." data-style="btn-primary" data-actions-box="true"
+                                data-selected-text-format="count > 2" multiple aria-describedby="basic-addon4"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon6">Special Memory Regions</span>
-                            <select id="SpecialMemoryRegionsFilter" class="form-control selectpicker" data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary" multiple aria-describedby="basic-addon6"></select>
+                            <select id="SpecialMemoryRegionsFilter" class="form-control selectpicker"
+                                data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active."
+                                data-style="btn-primary" multiple aria-describedby="basic-addon6"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
                             <span class="input-group-addon" id="basic-addon5">Memory Contents</span>
-                            <select id="MemoryContentsFilter" class="form-control selectpicker" data-actions-box="true" data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary" multiple aria-describedby="basic-addon5"></select>
+                            <select id="MemoryContentsFilter" class="form-control selectpicker" data-actions-box="true"
+                                data-selected-text-format="count > 2" title="No Filter Active." data-style="btn-primary"
+                                multiple aria-describedby="basic-addon5"></select>
                         </div>
                         <p></p>
                         <div class="input-group">
-                                <span class="input-group-addon" id="basic-addon7">Section Type</span>
-                                <select id="SectionFilter" class="form-control selectpicker" title="No Filter Active." data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2" multiple aria-describedby="basic-addon7"></select>
+                            <span class="input-group-addon" id="basic-addon7">Section Type</span>
+                            <select id="SectionFilter" class="form-control selectpicker" title="No Filter Active."
+                                data-style="btn-primary" data-actions-box="true" data-selected-text-format="count > 2"
+                                multiple aria-describedby="basic-addon7"></select>
                         </div>
                         <p></p>
                         <p>
@@ -158,11 +184,17 @@
                         <hr />
                         <div id="ToolLicenseContent">
                             <p>
-                                <span class="copyright">Copyright (C) Microsoft Corporation. All rights reserved.</span><br />
+                                <span class="copyright">Copyright (C) Microsoft Corporation. All rights
+                                    reserved.</span><br />
                                 <span class="license">
-                                    All rights reserved. Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:<br>
-                                    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.<br>
-                                    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.<br><br>
+                                    All rights reserved. Redistribution and use in source and binary forms, with or
+                                    without modification, are permitted provided that the following conditions are
+                                    met:<br>
+                                    1. Redistributions of source code must retain the above copyright notice, this list
+                                    of conditions and the following disclaimer.<br>
+                                    2. Redistributions in binary form must reproduce the above copyright notice, this
+                                    list of conditions and the following disclaimer in the documentation and/or other
+                                    materials provided with the distribution.<br><br>
 
                                     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
                                     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -192,12 +224,24 @@
     </script>
 
     <!-- Javascript libraries -->
-    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script> 
-    <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js" integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo" crossorigin="anonymous"></script> 
-    <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script> 
-    <script src="https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js" integrity="sha384-7PXRkl4YJnEpP8uU4ev9652TTZSxrqC8uOpcV1ftVEC7LVyLZqqDUAaq+Y+lGgr9" crossorigin="anonymous"></script> 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js" integrity="sha384-7RnKw5sMIle5aza0DbXRxSFziONgSQKq4/v0JGJnfrCIMWMyasw3n7w2IW4HK7Ss" crossorigin="anonymous"></script> 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-growl/1.0.0/jquery.bootstrap-growl.min.js" integrity="sha384-HitlARW+6c0IF2m5pcwV3x64ooKVvQsiTuCxKU9cRKVOVrYNopTqkeEoXclgAWqE" crossorigin="anonymous"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.2.1.min.js"
+        integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"
+        integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo"
+        crossorigin="anonymous"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js"
+        integrity="sha384-7PXRkl4YJnEpP8uU4ev9652TTZSxrqC8uOpcV1ftVEC7LVyLZqqDUAaq+Y+lGgr9"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js"
+        integrity="sha384-7RnKw5sMIle5aza0DbXRxSFziONgSQKq4/v0JGJnfrCIMWMyasw3n7w2IW4HK7Ss"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-growl/1.0.0/jquery.bootstrap-growl.min.js"
+        integrity="sha384-HitlARW+6c0IF2m5pcwV3x64ooKVvQsiTuCxKU9cRKVOVrYNopTqkeEoXclgAWqE"
+        crossorigin="anonymous"></script>
     <!-- Add javascript here -->
     <script>
         var DATA_TABLE_OFFSET = 500;
@@ -217,7 +261,7 @@
             //Write out errors or warnings in the data processing
             //
             EmbeddedJd.errors.forEach(function (element, index, array) {
-                $("table#ParsingErrors tbody").append("<tr><td>" + element +"</td></tr>");
+                $("table#ParsingErrors tbody").append("<tr><td>" + element + "</td></tr>");
             });  //end forEach
             var errorTable = $('table#ParsingErrors').dataTable({
                 "paginate": false,
@@ -233,7 +277,7 @@
                 $.fn.dataTable.tables({ visible: true, api: true }).columns.adjust();
             });
 
-         
+
             //
             // Create Attribution List for all external libraries used
             //
@@ -247,7 +291,7 @@
                 $("<div class='attribution'><h4>" + element.Title + "</h4><p>Version: <span class='version'>" + element.Version + "</span><br /><span class='copyright'>" +
                     element.Copyright + "</span><br />License: <a class='license' href='" + element.LicenseLink + "'>" + element.LicenseType + "</a></p></div>").appendTo("div#AttributionListWrapper");
             });
-           
+
             // filter
             $('button#ClearPageFilter').click(function () {
                 $("div#PageAttributeFilterWrapper select.selectpicker").selectpicker('deselectAll');
@@ -263,12 +307,12 @@
 
             $('button#ClearAllFilter').click(function () {
                 $('button#ClearMemoryFilter').click();
-                $('button#ClearPageFilter').click();    
+                $('button#ClearPageFilter').click();
             });
 
 
-             //table for modules
-             var mTable = $('table#MemoryRanges').dataTable({
+            //table for modules
+            var mTable = $('table#MemoryRanges').dataTable({
                 "aaData": EmbeddedJd.MemoryRanges,
                 "paginate": false,
                 "autoWidth": false,
@@ -334,164 +378,164 @@
                 ], //end of column def
                 initComplete: function () {
                     //Setup the filters
-                    this.api().column(2).every( function() {
+                    this.api().column(2).every(function () {
                         var column = this;
-                        var select = $("#PageSizeFilter").on( 'change', function () { 
+                        var select = $("#PageSizeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 2 - Page Size
 
-                    this.api().column(6).every( function() {
+                    this.api().column(6).every(function () {
                         var column = this;
-                        var select = $("#ExecuteFilter").on( 'change', function () {     
+                        var select = $("#ExecuteFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 6 - execute Attribute
 
-                    this.api().column(4).every( function() {
+                    this.api().column(4).every(function () {
                         var column = this;
-                        var select = $("#PresentFilter").on( 'change', function () {     
+                        var select = $("#PresentFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 4 - Present Attribute
 
-                    this.api().column(5).every( function() {
+                    this.api().column(5).every(function () {
                         var column = this;
-                        var select = $("#RWFilter").on( 'change', function () {     
+                        var select = $("#RWFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 5 - RW attribute
-                    
-                    this.api().column(7).every( function() {
+
+                    this.api().column(7).every(function () {
                         var column = this;
-                        var select = $("#PrivilegeFilter").on( 'change', function () {
+                        var select = $("#PrivilegeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
                             column.search(SearchRegex, true, false).draw();
                         }); // on change
 
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 7 - Privilege (User / Supervisor)
 
-                    this.api().column(10).every( function() {
+                    this.api().column(10).every(function () {
                         var column = this;
-                        var select = $("#SectionFilter").on( 'change', function () {
+                        var select = $("#SectionFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
                             column.search(SearchRegex, true, false).draw();
                         }); // on change
 
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 10 - Section Type for code/data sections
 
-                    this.api().column(8).every( function() {
+                    this.api().column(8).every(function () {
                         var column = this;
-                        var select = $("#MemoryTypeFilter").on( 'change', function () { 
+                        var select = $("#MemoryTypeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 8 - Memory Type
 
-                    this.api().column(9).every( function() {
+                    this.api().column(9).every(function () {
                         var column = this;
-                        var select = $("#MemorySpaceTypeFilter").on( 'change', function () { 
+                        var select = $("#MemorySpaceTypeFilter").on('change', function () {
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
+                            column
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 9 - GCD Memory Type
 
-                    this.api().column(11).every( function() {
+                    this.api().column(11).every(function () {
                         var column = this;
-                        var select = $("#SpecialMemoryRegionsFilter").on( 'change', function () {     
+                        var select = $("#SpecialMemoryRegionsFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
-                        //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
-                    }); //column 11 - special Memory Type
-                    
 
-                    this.api().column(12).every( function() {
+                        //populate with options
+                        column.data().unique().sort().each(function (d, j) {
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
+                    }); //column 11 - special Memory Type
+
+
+                    this.api().column(12).every(function () {
                         var column = this;
-                        var select = $("#MemoryContentsFilter").on( 'change', function () {     
+                        var select = $("#MemoryContentsFilter").on('change', function () {
                             //var SelectedValues = $(this).val() || [];
                             var SearchRegex = CreateRegexForSearchMultiselect($(this).val());
-                             column
-                                //.search( val ? '^'+val+'$' : '', true, false )
+                            column
+                                //.search( val ? '^'+val+'$' : '', true, false )
                                 .search(SearchRegex, true, false)
-                                .draw();
+                                .draw();
                         }); // on change
-                        
+
                         //populate with options
-                        column.data().unique().sort().each( function ( d, j ) {
-                            if(d === null) {
+                        column.data().unique().sort().each(function (d, j) {
+                            if (d === null) {
                                 d = "Nothing Found";  //this must align with the default content
                             }
-                            select.append( '<option value="'+d+'">'+d+'</option>' )
-                        });
+                            select.append('<option value="' + d + '">' + d + '</option>')
+                        });
                     }); //column 12 - Memory Contents
-                } //end init complete func
+                } //end init complete func
             }) //end of modules table 
 
             /** Memory Range JSON looks like: 
@@ -512,37 +556,39 @@
             }
             **/
             var SavedFilters = [];
-            SavedFilters.push({"Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute", 
-                "Filter": function(mrObject) {
-                    if( (mrObject["Execute"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Present"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
+            SavedFilters.push({
+                "Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Filter": function (mrObject) {
+                    if ((mrObject["Execute"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Present"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("ExecuteFilter", ["Enabled"])
                     SetMultiselectTo("PresentFilter", ["Yes"])
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("MemorySpaceTypeFilter",
                         ["EfiGcdMemoryTypeReserved",
-                        "EfiGcdMemoryTypeSystemMemory",
-                        "EfiGcdMemoryTypeMemoryMappedIo",
-                        "EfiGcdMemoryTypePersistent",
-                        "EfiGcdMemoryTypePersistentMemory",
-                        "EfiGcdMemoryTypeMoreReliable",
-                        "EfiGcdMemoryTypeMaximum"])
+                            "EfiGcdMemoryTypeSystemMemory",
+                            "EfiGcdMemoryTypeMemoryMappedIo",
+                            "EfiGcdMemoryTypePersistent",
+                            "EfiGcdMemoryTypePersistentMemory",
+                            "EfiGcdMemoryTypeMoreReliable",
+                            "EfiGcdMemoryTypeMaximum"])
                     return true;
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({"Name": "Data Sections are No-Execute", "Description": "Image data sections should be no-execute", "Filter": function(mrObject) {
-                    if((mrObject["Execute"] === "Enabled") && (mrObject["Section Type"] === "DATA")) {
+            SavedFilters.push({
+                "Name": "Data Sections are No-Execute", "Description": "Image data sections should be no-execute", "Filter": function (mrObject) {
+                    if ((mrObject["Execute"] === "Enabled") && (mrObject["Section Type"] === "DATA")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("ExecuteFilter", ["Disabled"])
                     SetMultiselectTo("SectionFilter", ["DATA"])
@@ -550,13 +596,14 @@
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({"Name": "Code Sections are Read-Only", "Description": "Image code sections should be read-only", "Filter": function(mrObject) {
-                    if((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
+            SavedFilters.push({
+                "Name": "Code Sections are Read-Only", "Description": "Image code sections should be read-only", "Filter": function (mrObject) {
+                    if ((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
                         return true;
                     }
                     return false;
                 }, //end of Filter function
-                "ConfigureFilter":function() {
+                "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("SectionFilter", ["CODE"])
@@ -565,23 +612,23 @@
             });
 
             //Fill in the test results tab
-            SavedFilters.forEach(function(TestObject) {
+            SavedFilters.forEach(function (TestObject) {
                 var FailedCount = EmbeddedJd.MemoryRanges.filter(TestObject.Filter);
-                if(FailedCount == 0) {
+                if (FailedCount == 0) {
                     var b = $("<div class='TestStatus bg-success'><h4>" + TestObject.Name + "</h4><p>Description:" + TestObject.Description + "<br />Status: Success</p></div>");
                     b.appendTo("div#TestStatusListWrapper");
- 
+
                 } else {
                     var b = $("<div class='TestStatus bg-danger'><h4>" + TestObject.Name + "</h4><p>Description:" + TestObject.Description + "<br />Status: Failed (" + FailedCount.length + ")</p></div>");
                     //Create a button that configures the filter for this test result
                     var a = $('<button type="button" class="btn btn-danger">Set This As Filter For List</button>');
-                    a.click(function() {
-                        if(TestObject.ConfigureFilter()) {
+                    a.click(function () {
+                        if (TestObject.ConfigureFilter()) {
                             AddAlert(TestObject.Name + " Filter applied Successfully", "success");
                         } else {
                             AddAlert(TestObject.Name + " Filter failed", "danger");
-                        } 
-                        $('a[href="#tabs-3"]').tab('show'); 
+                        }
+                        $('a[href="#tabs-3"]').tab('show');
                     });
                     a.appendTo(b);
                     $('<p></p>').appendTo(b);
@@ -592,11 +639,11 @@
             $('div#tabs-3 select.selectpicker').selectpicker("refresh").change();
 
             //Show warning if there are parsing errors
-            if(EmbeddedJd.errors.length > 0) {
+            if (EmbeddedJd.errors.length > 0) {
                 $.bootstrapGrowl("Data Parsing Errors identified.  Please look at Parsing Errors tab as Results and Memory Data might not be accurate.", {
                     ele: 'body', // which element to append to
                     type: 'danger', // (null, 'info', 'danger', 'success')
-                    offset: {from: 'top', amount: 20}, // 'top', or 'bottom'
+                    offset: { from: 'top', amount: 20 }, // 'top', or 'bottom'
                     align: 'right', // ('left', 'right', or 'center')
                     width: 'auto', // (integer, or 'auto')
                     delay: 3600000, // Time while the message will be displayed.  1 hour
@@ -608,7 +655,7 @@
         //
         //To handle scroll tables adjust the height based on the window height.
         //
-        $(window).resize(function() {
+        $(window).resize(function () {
             var newHd = $(window).height() - DATA_TABLE_OFFSET;
             var newParsingHeight = $(window).height() - PARSING_TOOL_TABLE_OFFSET;
             $("#MemoryRanges_wrapper .dataTables_scrollBody").height(newHd);
@@ -616,18 +663,18 @@
             $.fn.dataTable.tables({ visible: true, api: true }).columns.adjust();
         });
 
-        function CreateRegexForSearchMultiselect(mylist){
+        function CreateRegexForSearchMultiselect(mylist) {
             var re = '';
             // console.log(mylist);
-            mylist.forEach(function(v,i,a) {
-                if(i > 0) {
+            mylist.forEach(function (v, i, a) {
+                if (i > 0) {
                     re += "|";
                 } else {
                     re += "("
                 }
                 re += '^' + $.fn.dataTable.util.escapeRegex(v) + '?';
             });
-            if(re !== '') {
+            if (re !== '') {
                 re += ")"
             }
             // console.log(re);
@@ -640,12 +687,11 @@
         @param selectName: id of the select element to set
         @param listOfValuesNotSelected: array of values to not select
         **/
-        function SetMultiselectToAllExcept(selectName, listOfValuesNotSelected )
-        {
+        function SetMultiselectToAllExcept(selectName, listOfValuesNotSelected) {
             var all = [];
             //get all options except reserved
-            $.each($("select#" + selectName +" option"), function(i,v) {
-                if(!listOfValuesNotSelected.includes($(v).val())){
+            $.each($("select#" + selectName + " option"), function (i, v) {
+                if (!listOfValuesNotSelected.includes($(v).val())) {
                     all.push($(v).val());
                 }
             });
@@ -660,45 +706,44 @@
             @param listOfValuesSelected: array of values to select
             @ret boolean status of setting all requested values
         **/
-        function SetMultiselectTo(selectName, listOfValuesSelected)
-        {
+        function SetMultiselectTo(selectName, listOfValuesSelected) {
             //var allOptions = $("select#" + selectName +" > option").map(function() { return $(this).val(); }).get(); //create array
-            $.each($("select#" + selectName +" option"), function(i,v) {
+            $.each($("select#" + selectName + " option"), function (i, v) {
                 var index = listOfValuesSelected.indexOf($(v).text());
-                if(index > -1){
+                if (index > -1) {
                     $(v).prop('selected', true);
                     listOfValuesSelected.splice(index, 1);  //remove from array so we can check at the end
                 }
-                else
-                {
+                else {
                     $(v).prop('selected', false);
                 }
             });
             $("select#" + selectName).change();
             $("select#" + selectName).selectpicker('refresh');
-            listOfValuesSelected.forEach(function(v, i, a) {
+            listOfValuesSelected.forEach(function (v, i, a) {
                 AddAlert("Can't set " + selectName + " value to " + v, "warning");
             });
-            return (listOfValuesSelected.length === 0); 
+            return (listOfValuesSelected.length === 0);
         }
 
         /**
         Add dismissable alert for user
         **/
-        function AddAlert(msg, level="danger"){
+        function AddAlert(msg, level = "danger") {
             $.bootstrapGrowl(msg, {
                 ele: 'body', // which element to append to
                 type: level, // (null, 'info', 'danger', 'success')
-                offset: {from: 'top', amount: 20}, // 'top', or 'bottom'
+                offset: { from: 'top', amount: 20 }, // 'top', or 'bottom'
                 align: 'right', // ('left', 'right', or 'center')
                 width: 'auto', // (integer, or 'auto')
                 delay: 10000, // Time while the message will be displayed.
                 allow_dismiss: true, // If true then will display a cross to close the popup.
                 stackup_spacing: 10 // spacing between consecutively stacked growls.
             });
-                
+
         }
 
     </script>
 </body>
+
 </html>

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -545,13 +545,30 @@
             **/
             var SavedFilters = [];
             SavedFilters.push({
-                "Name": "RW+X", "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Name": "NULL Page Check",
+                "Description": "NULL page should be EFI_MEMORY_RP",
                 "Filter": function (mrObject) {
-                    if ((mrObject["Execute"] === "Enabled") && (mrObject["Read/Write"] === "Enabled") && (mrObject["Present"] === "Yes") && (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent")) {
-                        return true;
-                    }
-                    return false;
+                    var isTargetType = mrObject["System Memory"] === "NULL Page";
+                    var hasInvalidAttributes = mrObject["Present"] !== "No";
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("SpecialMemoryRegionsFilter", ["NULL Page"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "RW+X",
+                "Description": "No memory range should have page attributes that allow read, write, and execute",
+                "Filter": function (mrObject) {
+                    isTargetType = (mrObject["GCD Memory Type"] !== "EfiGcdMemoryTypeNonExistent");
+                    hasInvalidAttributes = (mrObject["Execute"] === "Enabled") &&
+                        (mrObject["Read/Write"] === "Enabled") &&
+                        (mrObject["Present"] === "Yes");
+                    return isTargetType && hasInvalidAttributes;
+                },
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("ExecuteFilter", ["Enabled"])
@@ -570,11 +587,12 @@
             });
 
             SavedFilters.push({
-                "Name": "Data Sections are No-Execute", "Description": "Image data sections should be no-execute", "Filter": function (mrObject) {
-                    if ((mrObject["Execute"] === "Enabled") && (mrObject["Section Type"] === "DATA")) {
-                        return true;
-                    }
-                    return false;
+                "Name": "Data Sections are No-Execute",
+                "Description": "Image data sections should be no-execute",
+                "Filter": function (mrObject) {
+                    isTargetType = (mrObject["Section Type"] === "DATA");
+                    hasInvalidAttributes = (mrObject["Execute"] === "Enabled");
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
@@ -585,16 +603,69 @@
             });
 
             SavedFilters.push({
-                "Name": "Code Sections are Read-Only", "Description": "Image code sections should be read-only", "Filter": function (mrObject) {
-                    if ((mrObject["Read/Write"] === "Enabled") && (mrObject["Section Type"] === "CODE")) {
-                        return true;
-                    }
-                    return false;
+                "Name": "Code Sections are Read-Only",
+                "Description": "Image code sections should be read-only",
+                "Filter": function (mrObject) {
+                    isTargetType = (mrObject["Section Type"] === "CODE");
+                    hasInvalidAttributes = (mrObject["Read/Write"] === "Enabled");
+                    return isTargetType && hasInvalidAttributes;
                 }, //end of Filter function
                 "ConfigureFilter": function () {
                     $("button#ClearAllFilter").click();  //clear the filters
                     SetMultiselectTo("RWFilter", ["Enabled"])
                     SetMultiselectTo("SectionFilter", ["CODE"])
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "MMIO Execute Check",
+                "Description": "MMIO ranges should be non executable",
+                "Filter": function (mrObject) {
+                    var isTargetType = (mrObject["GCD Memory Type"] === "EfiGcdMemoryTypeMemoryMappedIo") ||
+                        (mrObject["Memory Type"] === "EfiMemoryMappedIO");
+                    var hasInvalidAttributes = (mrObject["Execute"] !== "Disabled") &&
+                        (mrObject["Present"] !== "No");
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemorySpaceTypeFilter", ["EfiGcdMemoryTypeMemoryMappedIo"]);
+                    SetMultiselectTo("MemoryTypeFilter", ["EfiMemoryMappedIO"]);
+                    SetMultiselectTo("ExecuteFilter", ["Enabled"]);
+                    SetMultiselectTo("PresentFilter", ["Yes"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "Free Memory Check",
+                "Description": "Free EFI memory should not be readable",
+                "Filter": function (mrObject) {
+                    var isTargetType = mrObject["Memory Type"] === "EfiConventionalMemory";
+                    var hasInvalidAttributes = mrObject["Present"] !== "No";
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemoryTypeFilter", ["EfiConventionalMemory"]);
+                    SetMultiselectTo("PresentFilter", ["Yes"]);
+                    return true;
+                } //end of configuring filter inputs
+            });
+
+            SavedFilters.push({
+                "Name": "Check Memory Not in EFI Memory Map is Inaccessible",
+                "Description": "Memory not in the EFI memory map should cause a fault if accessed",
+                "Filter": function (mrObject) {
+                    var isTargetType = mrObject["Memory Type"] === "None";
+                    var hasInvalidAttributes = mrObject["Present"] !== "Yes";
+                    return isTargetType && hasInvalidAttributes;
+                }, //end of Filter function
+                "ConfigureFilter": function () {
+                    $("button#ClearAllFilter").click();  //clear the filters
+                    SetMultiselectTo("MemoryTypeFilter", ["None"]);
+                    SetMultiselectTo("PresentFilter", ["Yes"]);
                     return true;
                 } //end of configuring filter inputs
             });
@@ -623,6 +694,16 @@
                     b.appendTo("div#TestStatusListWrapper");
                 }
             });
+
+            var testName = "Memory Attribute Protocol is Installed";
+            var testDescription = "Checks if the platform produces the memory attribute protocol";
+            if (IsMemoryAttributeProtocolPresent === "TRUE") {
+                var b = $("<div class='TestStatus bg-success'><h4>" + testName + "</h4><p>Description:" + testDescription + "<br />Status: Success</p></div>");
+                b.appendTo("div#TestStatusListWrapper");
+            } else {
+                var b = $("<div class='TestStatus bg-danger'><h4>" + testName + "</h4><p>Description:" + testDescription + "<br />Status: Failed</p></div>");
+                b.appendTo("div#TestStatusListWrapper");
+            }
 
             $('div#tabs-3 select.selectpicker').selectpicker("refresh").change();
 
@@ -701,9 +782,6 @@
             });
             $("select#" + selectName).change();
             $("select#" + selectName).selectpicker('refresh');
-            listOfValuesSelected.forEach(function (v, i, a) {
-                AddAlert("Can't set " + selectName + " value to " + v, "warning");
-            });
             return (listOfValuesSelected.length === 0);
         }
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/Globals.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/Globals.py
@@ -8,3 +8,4 @@ ParsingArchitecture = ""
 ExecutionLevel = ""
 Phase = ""
 Bitwidth = 0
+MemoryAttributeProtocolPresent = ""

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/PagingReportGenerator.py
@@ -230,8 +230,13 @@ class ParsingTool(object):
             template = open(os.path.join(sp, "SmmPaging_template.html"), "r")
 
         for line in template.readlines():
-            if "%TO_BE_FILLED_IN_BY_PYTHON_SCRIPT%" in line:
-                line = line.replace("%TO_BE_FILLED_IN_BY_PYTHON_SCRIPT%", js)
+            if "% TO_BE_FILLED_IN_BY_PYTHON_SCRIPT %" in line:
+                line = line.replace("% TO_BE_FILLED_IN_BY_PYTHON_SCRIPT %", js)
+            if "% IS_MEMORY_ATTRIBUTE_PROTOCOL_PRESENT %" in line:
+                if Globals.MemoryAttributeProtocolPresent != "":
+                    line = line.replace("% IS_MEMORY_ATTRIBUTE_PROTOCOL_PRESENT %", "\"" + Globals.MemoryAttributeProtocolPresent + "\"")
+                else:
+                    line = line.replace("% IS_MEMORY_ATTRIBUTE_PROTOCOL_PRESENT %", "\"FALSE\"")
             f.write(line)
         template.close()
         f.close()

--- a/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
@@ -314,6 +314,7 @@ CreateFlatPageTable (
     );
 
   if (LocalEntryCount > Map->EntryCount) {
+    Map->EntryCount = LocalEntryCount;
     return EFI_BUFFER_TOO_SMALL;
   }
 

--- a/UefiTestingPkg/UefiTestingPkg.ci.yaml
+++ b/UefiTestingPkg/UefiTestingPkg.ci.yaml
@@ -92,7 +92,8 @@
             "MPIDRs",
             "PAGESs",
             "SMRRs",
-            "unsplit"
+            "unsplit",
+            "lfanew", # PE/COFF
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
     }


### PR DESCRIPTION
Adds 8 tests to the paging audit shell app. Which check the following:
1. Unallocated memory is EFI_MEMORY_RP
2. Memory Attribute Protocol is present
3. Calls to allocate pages and pools return buffers with restrictive access attributes
4. NULL page is EFI_MEMORY_RP
5. MMIO Regions are Non Executable
6. Image code sections are EFI_MEMORY_RO and and data sections are EFI_MEMORY_XP
7. BSP stack is EFI_MEMORY_XP and has EFI_MEMORY_RP guard page
8. Memory outside of the EFI Memory Map is inaccessible

Adds 5 tests to the HTML templates:
1. Test that the NULL page is EFI_MEMORY_RP
2. Check that MMIO memory is non-executable.
3. Check that EfiConventionalMemory is non-executable.
4. Check that memory not in the EFI memory map is not accessible.
5. Check that the memory attribute protocol is present on the platform.

This also refactors much of the HTML, adds some quality of life updates to the output
HTML paging audit, adds logical OR filtering capability, and adds the collection of
Memory Attribute Protocol presence on the tested platform.

Tested on Q35, SBSA, and on development devices at UEFI Plugfest.