### PR TITLE
HidPkg/UsbHidDxe: Continue on failure to get descriptor

### DIFF
--- a/HidPkg/UsbHidDxe/UsbHidDxe.c
+++ b/HidPkg/UsbHidDxe/UsbHidDxe.c
@@ -723,7 +723,6 @@ ReadDescriptors (
 
   Status = UsbGetFullHidDescriptor (UsbHidDevice->UsbIo, UsbHidDevice->InterfaceDescriptor.InterfaceNumber, &UsbHidDevice->HidDescriptor);
   if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
     goto ErrorExit;
   }
 
@@ -895,7 +894,6 @@ UsbHidDriverBindingStart (
 
   Status = ReadDescriptors (UsbHidDevice);
   if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
     goto ErrorExit;
   }
 


### PR DESCRIPTION
## Description

In case a HID device fails to return a valid HID descriptor, this change
will return the error status from UsbHidDriverBindingStart() rather
than assert to match previous behavior from HID drivers that required
the boot protocol. The HID IO protocol will not be installed on these
devices.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified functionality is unchanged on physical platform with UsbHidDxe integrated.
- Verified boot previously encountering an assert on the QEMU virtual platform is
  not blocking boot.

## Integration Instructions

Update to a Mu Plus release with this change.