### PR TITLE
Add PCD to allow device exclusions for UsbHidDxe

### DIFF
--- a/HidPkg/HidPkg.dec
+++ b/HidPkg/HidPkg.dec
@@ -35,6 +35,13 @@
   gHidKeyboardLayoutPackageGuid      = {0x57adcfa9, 0xc08a, 0x40b9, {0x86, 0x87, 0x65, 0xe2, 0xec, 0xe0, 0xe5, 0xe1}}
   gHidKeyboardLayoutKeyGuid          = {0xdcafaba8, 0xcde5, 0x40a1, {0x9a, 0xd3, 0x48, 0x76, 0x44, 0x71, 0x7e, 0x47}}
 
+[PcdsFixedAtBuild, PcdsPatchableInModule]
+  ## List of {InterfaceClass, InterfaceSubClass, InterfaceProtocol} tuples that should be excluded from being managed by
+  # the UsbHidDxe driver. The list is terminated by a record of all zeros.
+  # For example, to exclude USB keyboards, this would be set to {0x3, 0x1, 0x1, 0x0, 0x0, 0x0}
+  # @Prompt Exclude devices from UsbHidDxe management.
+  gHidPkgTokenSpaceGuid.PcdExcludedHidDevices|{0x0, 0x0, 0x0}|VOID*|0x00010100
+
 [PcdsFeatureFlag]
   ## Indicates if HID KeyBoard Driver disables the default keyboard layout.
   #  The default keyboard layout serves as the backup when no keyboard layout can be retrieved

--- a/HidPkg/HidPkg.dec
+++ b/HidPkg/HidPkg.dec
@@ -38,7 +38,12 @@
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## List of {InterfaceClass, InterfaceSubClass, InterfaceProtocol} tuples that should be excluded from being managed by
   # the UsbHidDxe driver. The list is terminated by a record of all zeros.
-  # For example, to exclude USB keyboards, this would be set to {0x3, 0x1, 0x1, 0x0, 0x0, 0x0}
+  # Only interface class 3 (HID) is supported; other interface classes are ignored regardless of this list.
+  # SubClass and Protocol are defined by the USB HID 1.11 spec, section 4.2 and 4.3 respectively.
+  # - SubClass may be 0 - No Subclass, or 1 - Boot Interface Subclass.
+  # - If SubClass is 0, Protocol must be 0.
+  # - If SubClass is 1, Protocol must be 1 - Keyboard, or 2 - Mouse.
+  # For example, to exclude USB Boot Interface Keyboards, this would be set to {0x3, 0x1, 0x1, 0x0, 0x0, 0x0}
   # @Prompt Exclude devices from UsbHidDxe management.
   gHidPkgTokenSpaceGuid.PcdExcludedHidDevices|{0x0, 0x0, 0x0}|VOID*|0x00010100
 

--- a/HidPkg/UsbHidDxe/UsbHidDxe.inf
+++ b/HidPkg/UsbHidDxe/UsbHidDxe.inf
@@ -35,8 +35,9 @@
   UefiUsbLib
 
 [Protocols]
-  gHidIoProtocolGuid
-  gEfiUsbIoProtocolGuid
+  gHidIoProtocolGuid    ## PRODUCES
+  gEfiUsbIoProtocolGuid ## CONSUMES
 
 [Pcd]
-  gEfiMdePkgTokenSpaceGuid.PcdUsbTransferTimeoutValue  ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdUsbTransferTimeoutValue
+  gHidPkgTokenSpaceGuid.PcdExcludedHidDevices


### PR DESCRIPTION
## Description

Adds a PCD for configuring device exclusions for UsbHidDxe. Prior to this change, the UsbHidDxe driver included logic to exclude keyboard devices from being handled by HID, due to other parts of the stack not being fully implemented yet. This removes that code and replaces it with a PCD list that the platform integrator can use to disable particular devices as desired for the platform.

- [x] Impacts functionality?
  - Changes how UsbHidDxe exclusions are handled.
- [ ] Impacts security?
- [x] Breaking change?
  Previously keyboard exclusion was hard-coded; to replicate this behavior platforms will need to add a PCD specification in the DSC files to exclude keyboards. See Integration Instructions below for more details.
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified with functional testing of several different exclusions in Qemu Q35. 

## Integration Instructions

To replicate existing behavior, platforms will need to add PCD specification to the DSC like the following to exclude USB keyboards:

```
[PcdsFixedAtBuild]
  gHidPkgTokenSpaceGuid.PcdExcludedHidDevices|{0x3, 0x1, 0x1, 0x0, 0x0, 0x0}

