### PR TITLE
AdvLoggerPkg: Add PanicLib instance

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dsc
+++ b/AdvLoggerPkg/AdvLoggerPkg.dsc
@@ -122,6 +122,7 @@
 
 [Components]
   AdvLoggerPkg/Library/BaseDebugLibAdvancedLogger/BaseDebugLibAdvancedLogger.inf
+  AdvLoggerPkg/Library/BasePanicLibAdvancedLogger/BasePanicLibAdvancedLogger.inf
 
 [Components.IA32]
   AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/AdvancedLoggerLib.inf

--- a/AdvLoggerPkg/Docs/ReadMe.md
+++ b/AdvLoggerPkg/Docs/ReadMe.md
@@ -43,6 +43,7 @@ The following libraries are used with AdvancedLogger:
 | AdvancedLoggerLib          | One per module type - used to provide access to the in memory log buffer |
 | AdvLoggerSmmAccessLib      | Used to intercept GetVariable in order to provide an OS utility the ability to read the log |
 | BaseDebugLibAdvancedLogger | Basic Dxe etc DebugLib |
+| BasePanicLibAdvancedLogger | Basic PanicLib that applies to all PI boot phases that AdvancedLoggerLib supports. |
 | DebugAgent                 | Used to intercept SEC initialization |
 | PeiDebugLibAdvancedLogger  | Basic Pei DebugLib |
 | AdvancedLoggerHdwPortLib   | Hook for a hardware port to capture debug messages as they are written to the log. |
@@ -267,5 +268,5 @@ result in hardware printing not functional.
 
 ## Copyright
 
-Copyright (C) Microsoft Corporation. All rights reserved.  
+Copyright (C) Microsoft Corporation. All rights reserved. \
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/AdvLoggerPkg/Library/BasePanicLibAdvancedLogger/BasePanicLibAdvancedLogger.c
+++ b/AdvLoggerPkg/Library/BasePanicLibAdvancedLogger/BasePanicLibAdvancedLogger.c
@@ -1,0 +1,64 @@
+/** @file
+  An instance of the Panic Library that outputs to advanced logger.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/PrintLib.h>
+#include <Library/AdvancedLoggerLib.h>
+#include <Library/PanicLib.h>
+
+//
+// Define the maximum panic message length that this library supports
+//
+#define MAX_PANIC_MESSAGE_LENGTH  0x100
+
+/**
+  Prints a panic message containing a filename, line number, and description.
+  This is always followed by a dead loop.
+
+  Print a message of the form "PANIC <FileName>(<LineNumber>): <Description>\n"
+  to the debug output device.  Immediately after that CpuDeadLoop() is called.
+
+  If FileName is NULL, then a <FileName> string of "(NULL) Filename" is printed.
+  If Description is NULL, then a <Description> string of "(NULL) Description" is printed.
+
+  @param  FileName     The pointer to the name of the source file that generated the panic condition.
+  @param  LineNumber   The line number in the source file that generated the panic condition
+  @param  Description  The pointer to the description of the panic condition.
+
+**/
+VOID
+EFIAPI
+PanicReport (
+  IN CONST CHAR8  *FileName,
+  IN UINTN        LineNumber,
+  IN CONST CHAR8  *Description
+  )
+{
+  CHAR8  Buffer[MAX_PANIC_MESSAGE_LENGTH];
+
+  if (FileName == NULL) {
+    FileName = "(NULL) Filename";
+  }
+
+  if (Description == NULL) {
+    Description = "(NULL) Description";
+  }
+
+  AsciiSPrint (Buffer, sizeof (Buffer), "PANIC [%a] %a(%d): %a\n", gEfiCallerBaseName, FileName, LineNumber, Description);
+
+  // Note: 0x80000000 is used instead of DEBUG_ERROR to avoid a dependency on DebugLib.h just for that value.
+  //       The high bit being set for error status codes is defined per the UEFI Specification (2.10 section below).
+  //       https://uefi.org/specs/UEFI/2.10/Apx_D_Status_Codes.html#status-codes
+  AdvancedLoggerWrite (0x80000000, Buffer, AsciiStrnLenS (Buffer, sizeof (Buffer)));
+
+  //
+  // Deadloop since the system is in an unrecoverable state.
+  //
+  CpuDeadLoop ();
+}

--- a/AdvLoggerPkg/Library/BasePanicLibAdvancedLogger/BasePanicLibAdvancedLogger.inf
+++ b/AdvLoggerPkg/Library/BasePanicLibAdvancedLogger/BasePanicLibAdvancedLogger.inf
@@ -1,0 +1,31 @@
+## @file
+#  An instance of the Panic Library that outputs to advanced logger.
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION       = 0x00010005
+  BASE_NAME         = BasePanicLibAdvancedLogger
+  FILE_GUID         = 536D781D-A6A6-4831-AAB8-1E391DA2DD06
+  MODULE_TYPE       = BASE
+  VERSION_STRING    = 1.0
+  LIBRARY_CLASS     = PanicLib
+
+#
+#  VALID_ARCHITECTURES  = ANY
+#
+
+[Packages]
+  MdePkg/MdePkg.dec
+  AdvLoggerPkg/AdvLoggerPkg.dec
+
+[LibraryClasses]
+  AdvancedLoggerLib
+  BaseLib
+  PrintLib
+
+[Sources]
+  BasePanicLibAdvancedLogger.c


### PR DESCRIPTION
## Description

Adds an instance of PanicLib that outputs through advanced logger
using AdvancedLoggerLib.

This allows platforms already using advanced logger to use this
library instance which can decrease the size impact as opposed to
linking to output stacks like serial that might be redundant when
advanced logger is active.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Physical IA32/X64 platform with advanced logger used in PEI

---

Example of a test `PANIC()` placed in `ResetSystemPei` through this library
instance:

```
PANIC [ResetSystemPei] d:\src\ws\MU_BASECORE\MdeModulePkg\Universal\ResetSystemPei\ResetSystem.c(110): Test panic
```

## Integration Instructions

Use this library instance if routing panic messages through advanced logger
is preferred.