### PR TITLE
Update MathLib.c to fix DisplayEngineDxe not compiling on ARM

### DIFF
--- a/MsCorePkg/Library/MathLib/MathLib.c
+++ b/MsCorePkg/Library/MathLib/MathLib.c
@@ -218,7 +218,7 @@ sqrt_d (
   IN CONST double  input
   )
 {
-  UINT64  firstGuess = (UINT64)input;
+  UINT32  firstGuess = (UINT32)input;
   double  x          = 0;
   double  prevX      = -1;
 


### PR DESCRIPTION
## Description

This change was made for fixing DisplayEngineDxe giving a linking error on 32-bit ARM architecture because of sqrt_d in MathLib. It fixes issue #350 

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

<_Please describe the test(s) that were run to verify the changes._>

## Integration Instructions

N/A