### PR TITLE
Resolve deadlock in RustBootServicesAllocatorDxe

### DIFF
--- a/MsCorePkg/Crates/RustBootServicesAllocatorDxe/Cargo.toml
+++ b/MsCorePkg/Crates/RustBootServicesAllocatorDxe/Cargo.toml
@@ -9,4 +9,6 @@ path = "src/lib.rs"
 
 [dependencies]
 r-efi = {workspace=true}
+
+[dev-dependencies]
 spin = {workspace=true}


### PR DESCRIPTION
## Description

Fix an issue where rust boot services allocator implementation could deadlock if memory allocations were attempted at different TPLs. Deadlock occurs in following scenario:
1. Task running at low TPL initiates an allocation request.
2. While that allocation is in progress and the lock is held, an interrupt occurs, and a new task executes at a higher TPL
3. new task attempts an allocation. 

Deadlock occurs because the higher TPL task cannot acquire the lock because it is held by the lower TPL task, and the lower TPL task cannot make forward progress because it has been interrupted by the higher TPL task.

To resolve this, this PR updates the allocation implementation to remove the spinlock. An AtomicPtr is used to give well-ordered access to the bootservices pointer used as the basis for the allocation implementation. Other aspects of the implementation (i.e. creation of the allocation tracker) are already thread-safe or are the responsibility of the boot services implementation. 

PR also contains some minor style cleanup. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
  - RustBootServicesAllocatorDxe unit tests updated to accommodate new implementation.
- [ ] Includes documentation?

## How This Was Tested

Verified boot on QEMU.

## Integration Instructions

N/A