### PR TITLE
RustAdvancedLoggerDxe: Remove spinlocks, add `function!()`, add `std` feature. 

### DIFF
--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/Cargo.toml
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/Cargo.toml
@@ -10,4 +10,6 @@ path = "src/lib.rs"
 
 [dependencies]
 r-efi = {workspace=true}
-spin = {workspace=true}
+
+[features]
+std = []

--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
@@ -195,6 +195,19 @@ macro_rules! debugln {
     ($level:expr, $fmt:expr, $($arg:tt)*) => ($crate::debug!($level, concat!($fmt, "\n"), $($arg)*));
 }
 
+/// Yields a &'static str that is the name of the containing function.
+#[macro_export]
+macro_rules! function {
+  () => {{
+    fn f() {}
+    fn type_name_of<T>(_: T) -> &'static str {
+      core::any::type_name::<T>()
+    }
+    let name = type_name_of(f);
+    name.strip_suffix("::f").unwrap()
+  }};
+}
+
 #[cfg(test)]
 mod tests {
   extern crate std;

--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
@@ -137,38 +137,78 @@ pub fn _log(level: usize, args: fmt::Arguments) {
   LOGGER.log(level, args)
 }
 
-/// Prints to the AdvancedLogger log at the specified level.
-///
-/// This macro uses the same syntax as rust std [`std::println!`] macro, with the addition of a level argument that
-/// indicates what debug level the output is to be written at.
-///
-/// See [`std::fmt`] for details on format strings.
-///
-/// ```no_run
-/// use rust_advanced_logger_dxe::{init_debug, debug, DEBUG_INFO};
-/// use r_efi::efi::Status;
-/// pub extern "efiapi" fn efi_main(
-///    _image_handle: *const core::ffi::c_void,
-///    _system_table: *const r_efi::system::SystemTable,
-///  ) -> u64 {
-///
-///    //Initialize debug logging - no output without this.
-///    init_debug(unsafe { (*_system_table).boot_services});
-///
-///    debug!(DEBUG_INFO, "Hello, World. This is {:} in {:}. ", "rust", "UEFI");
-///    debug!(DEBUG_INFO, "Better add our own newline.\n");
-///
-///    Status::SUCCESS.as_usize() as u64
-/// }
-/// ```
-#[macro_export]
-macro_rules! debug {
-    ($level:expr, $($arg:tt)*) => {
-        $crate::_log($level, format_args!($($arg)*))
-    }
+#[cfg(not(feature = "std"))]
+mod no_std_debug {
+  /// Prints to the AdvancedLogger log at the specified level.
+  ///
+  /// This macro uses the same syntax as rust std [`std::println!`] macro, with the addition of a level argument that
+  /// indicates what debug level the output is to be written at.
+  ///
+  /// See [`std::fmt`] for details on format strings.
+  ///
+  /// ```no_run
+  /// use rust_advanced_logger_dxe::{init_debug, debug, DEBUG_INFO};
+  /// use r_efi::efi::Status;
+  /// pub extern "efiapi" fn efi_main(
+  ///    _image_handle: *const core::ffi::c_void,
+  ///    _system_table: *const r_efi::system::SystemTable,
+  ///  ) -> u64 {
+  ///
+  ///    //Initialize debug logging - no output without this.
+  ///    init_debug(unsafe { (*_system_table).boot_services});
+  ///
+  ///    debug!(DEBUG_INFO, "Hello, World. This is {:} in {:}. ", "rust", "UEFI");
+  ///    debug!(DEBUG_INFO, "Better add our own newline.\n");
+  ///
+  ///    Status::SUCCESS.as_usize() as u64
+  /// }
+  /// ```
+  #[macro_export]
+  macro_rules! debug {
+      ($level:expr, $($arg:tt)*) => {
+          $crate::_log($level, format_args!($($arg)*))
+      }
+  }
 }
 
-/// Prints to the AdvancedLogger log at the specified level with a newline.
+#[cfg(feature = "std")]
+mod std_debug {
+  extern crate std;
+
+  /// Prints to the console log.
+  ///
+  /// This macro uses the same syntax as rust std [`std::println!`] macro, with the addition of a level argument that
+  /// indicates what debug level the output is to be written at.
+  ///
+  /// See [`std::fmt`] for details on format strings.
+  ///
+  /// ```no_run
+  /// use rust_advanced_logger_dxe::{init_debug, debug, DEBUG_INFO};
+  /// use r_efi::efi::Status;
+  /// pub extern "efiapi" fn efi_main(
+  ///    _image_handle: *const core::ffi::c_void,
+  ///    _system_table: *const r_efi::system::SystemTable,
+  ///  ) -> u64 {
+  ///
+  ///    //Initialize debug logging - no output without this.
+  ///    init_debug(unsafe { (*_system_table).boot_services});
+  ///
+  ///    debug!(DEBUG_INFO, "Hello, World. This is {:} in {:}. ", "rust", "UEFI");
+  ///    debug!(DEBUG_INFO, "Better add our own newline.\n");
+  ///
+  ///    Status::SUCCESS.as_usize() as u64
+  /// }
+  /// ```
+  #[macro_export]
+  macro_rules! debug {
+      ($level:expr, $($arg:tt)*) => {
+          let _ = $level;
+          print!($($arg)*)
+      }
+  }
+}
+
+/// Prints to the log with a newline.
 ///
 /// Equivalent to the [`debug!`] macro except that a newline is appended to the format string.
 ///


### PR DESCRIPTION
## Description

This PR implements 3 enhancements for the RustAdvancedLoggerDxe driver:
* Removes spinlocks altogether. State that used to be shared (in particular, the current log level while generating a multi-part log message) is now on the stack.
* Add `function!()` macro that returns the current function name as a static string. 
* Add `std` feture that maps `debug!()` and by extension `debugln!()` macros to std::println; 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
  - Existing unit tests updated to accommodate new design.
- [x] Includes documentation?
  - Existing docs updated to accommodate new design.

## How This Was Tested

Unit tests pass, new features validated in both unit test environment (`std` feature active and mapping to std::print) and qemu UEFI boot (`std` feature not active, using AdvLogger protocol).

## Integration Instructions
N/A - existing code should function as-is. New code that wants to take advantage of `std` can activate it for tests by specifying it as a feature for RustAdvLoggerDxe in dev-dependencies:

```
[dev-dependencies]
RustAdvancedLoggerDxe = {workspace=true, features=["std"]}
```