### PR TITLE
Add Unaccepted Memory Type to Memory Protection Test App

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.c
@@ -117,6 +117,8 @@ GetDxeMemoryTypeSettingFromBitfield (
       return HeapGuardMemoryType.Fields.EfiPalCode;
     case EfiPersistentMemory:
       return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
     default:
       return FALSE;
   }
@@ -169,6 +171,8 @@ GetMmMemoryTypeSettingFromBitfield (
       return HeapGuardMemoryType.Fields.EfiPalCode;
     case EfiPersistentMemory:
       return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
     default:
       return FALSE;
   }
@@ -704,7 +708,8 @@ UefiNxProtectionPreReq (
 
   // Skip memory types which cannot be allocated
   if ((MemoryProtectionContext.TargetMemoryType == EfiConventionalMemory) ||
-      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory))
+      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory)   ||
+      (MemoryProtectionContext.TargetMemoryType == EfiUnacceptedMemoryType))
   {
     UT_LOG_WARNING ("Skipping test of memory type %a -- memory type cannot be allocated", MEMORY_TYPES[MemoryProtectionContext.TargetMemoryType]);
     return UNIT_TEST_SKIPPED;
@@ -747,7 +752,8 @@ UefiPageGuardPreReq (
 
   // Skip memory types which cannot be allocated
   if ((MemoryProtectionContext.TargetMemoryType == EfiConventionalMemory) ||
-      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory))
+      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory)   ||
+      (MemoryProtectionContext.TargetMemoryType == EfiUnacceptedMemoryType))
   {
     UT_LOG_WARNING ("Skipping test of memory type %a -- memory type cannot be allocated", MEMORY_TYPES[MemoryProtectionContext.TargetMemoryType]);
     return UNIT_TEST_SKIPPED;
@@ -784,7 +790,8 @@ UefiPoolGuardPreReq (
 
   // Skip memory types which cannot be allocated
   if ((MemoryProtectionContext.TargetMemoryType == EfiConventionalMemory) ||
-      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory))
+      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory)   ||
+      (MemoryProtectionContext.TargetMemoryType == EfiUnacceptedMemoryType))
   {
     UT_LOG_WARNING ("Skipping test of memory type %a -- memory type cannot be allocated", MEMORY_TYPES[MemoryProtectionContext.TargetMemoryType]);
     return UNIT_TEST_SKIPPED;
@@ -865,7 +872,8 @@ SmmPageGuardPreReq (
 
   // Skip memory types which cannot be allocated
   if ((MemoryProtectionContext.TargetMemoryType == EfiConventionalMemory) ||
-      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory))
+      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory)   ||
+      (MemoryProtectionContext.TargetMemoryType == EfiUnacceptedMemoryType))
   {
     UT_LOG_WARNING ("Skipping test of memory type %a -- memory type cannot be allocated", MEMORY_TYPES[MemoryProtectionContext.TargetMemoryType]);
     return UNIT_TEST_SKIPPED;
@@ -902,7 +910,8 @@ SmmPoolGuardPreReq (
 
   // Skip memory types which cannot be allocated
   if ((MemoryProtectionContext.TargetMemoryType == EfiConventionalMemory) ||
-      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory))
+      (MemoryProtectionContext.TargetMemoryType == EfiPersistentMemory)   ||
+      (MemoryProtectionContext.TargetMemoryType == EfiUnacceptedMemoryType))
   {
     UT_LOG_WARNING ("Skipping test of memory type %a -- memory type cannot be allocated", MEMORY_TYPES[MemoryProtectionContext.TargetMemoryType]);
     return UNIT_TEST_SKIPPED;

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
@@ -19,6 +19,8 @@ CHAR8  *MEMORY_TYPES[] = {
   "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory",    "EfiUnacceptedMemoryType"
 };
 
+STATIC_ASSERT (EfiMaxMemoryType == ARRAY_SIZE (MEMORY_TYPES), "MEMORY_TYPES array size does not match EfiMaxMemoryType");
+
 ////
 // Reset:                   Test will be run by violating the memory protection policy with the expectation that the system
 //                          will reboot each time. The test will take roughly 45 minutes to run with a strict protection policy.

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
@@ -16,7 +16,7 @@ CHAR8  *MEMORY_TYPES[] = {
   "ReservedMemoryType",      "LoaderCode",          "LoaderData",          "BootServicesCode",
   "BootServicesData",        "RuntimeServicesCode", "RuntimeServicesData", "ConventionalMemory",
   "UnusableMemory",          "ACPIReclaimMemory",   "ACPIMemoryNVS",       "MemoryMappedIO",
-  "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory"
+  "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory",    "EfiUnacceptedMemoryType"
 };
 
 ////


### PR DESCRIPTION
## Description

EDK2 added EfiUnacceptedMemoryType to the memory type list. This update adds this memory type to the memory protection test app and skips it because it is not allocatable.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the test on Q35

## Integration Instructions

N/A