### PR TITLE
Fixing the array size not matching for memory protection unit test

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/MemoryProtectionTestCommon.h
@@ -16,8 +16,10 @@ CHAR8  *MEMORY_TYPES[] = {
   "ReservedMemoryType",      "LoaderCode",          "LoaderData",          "BootServicesCode",
   "BootServicesData",        "RuntimeServicesCode", "RuntimeServicesData", "ConventionalMemory",
   "UnusableMemory",          "ACPIReclaimMemory",   "ACPIMemoryNVS",       "MemoryMappedIO",
-  "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory"
+  "MemoryMappedIOPortSpace", "PalCode",             "PersistentMemory",    "UnacceptedMemory"
 };
+
+STATIC_ASSERT (EfiMaxMemoryType == ARRAY_SIZE (MEMORY_TYPES), "MEMORY_TYPES array size does not match EfiMaxMemoryType");
 
 ////
 // Reset:                   Test will be run by violating the memory protection policy with the expectation that the system


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

There is a new memory type from basecore, which caused the unit test to crash randomly when adding test cases.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on proprietary virtual ARM systems.

## Integration Instructions

N/A
