### PR TITLE
MsGraphicsPkg/SimpleUIToolKit: Move array bounds check before access

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
@@ -946,7 +946,7 @@ Ctor (
 
   // Iterate through cell list and compute bounding rectangle, checkbox bounding rectangle (optional) and string bitmap rectangle.
   //
-  for (Index = 0; CellData[Index].CellText != NULL && Index < this->m_NumberOfCells; Index++) {
+  for (Index = 0; Index < this->m_NumberOfCells && CellData[Index].CellText != NULL; Index++) {
     this->m_pCells[Index].OriginalOrder    = Index;
     this->m_pCells[Index].pCellText        = AllocateCopyPool (StrSize (CellData[Index].CellText), CellData[Index].CellText);
     this->m_pCells[Index].CheckboxSelected = CellData[Index].CheckBoxSelected;


### PR DESCRIPTION
## Description

Checks the index is within expected bounds before accessing the array.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CodeQL and package compilation.

## Integration Instructions

N/A