### PR TITLE
Fix various non-functional issues [Rebase & FF]

### DIFF
--- a/MsCorePkg/Include/Library/DeviceSpecificBusInfoLib.h
+++ b/MsCorePkg/Include/Library/DeviceSpecificBusInfoLib.h
@@ -12,6 +12,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#ifndef DEVICE_SPECIFIC_BUS_INFO_LIB_H_
+#define DEVICE_SPECIFIC_BUS_INFO_LIB_H_
+
 typedef enum {
   Ignore,     // Do not check link speed
   Gen1,       // 2.5 GT/s
@@ -72,3 +75,5 @@ ProcessPciDeviceResults (
   IN  UINTN                    ResultCount,
   IN  DEVICE_PCI_CHECK_RESULT  *Results
   );
+
+#endif

--- a/MsWheaPkg/HwhMenu/CreatorIDParser.h
+++ b/MsWheaPkg/HwhMenu/CreatorIDParser.h
@@ -8,6 +8,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#ifndef CREATOR_ID_PARSER_H_
+#define CREATOR_ID_PARSER_H_
+
 /**
  *  Parses the Creator ID which, for now, just prints the GUID
  *
@@ -19,3 +22,5 @@ VOID
 ParseCreatorID (
   IN CONST EFI_GUID  *CreatorID
   );
+
+#endif

--- a/MsWheaPkg/HwhMenu/PlatformIDParser.h
+++ b/MsWheaPkg/HwhMenu/PlatformIDParser.h
@@ -9,6 +9,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#ifndef PLATFORM_ID_PARSER_H_
+#define PLATFORM_ID_PARSER_H_
+
 /**
  *  Parses the Platform/Source ID
  *
@@ -20,3 +23,5 @@ VOID
 ParseSourceID (
   IN CONST EFI_GUID  *SourceID
   );
+
+#endif

--- a/MsWheaPkg/Include/Library/CheckHwErrRecHeaderLib.h
+++ b/MsWheaPkg/Include/Library/CheckHwErrRecHeaderLib.h
@@ -4,6 +4,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#ifndef CHECK_HW_ERR_REC_HEADER_LIB_H_
+#define CHECK_HW_ERR_REC_HEADER_LIB_H_
+
 /**
  *  Checks that all length and offset fields within the HWErrRec fall within the bounds of
  *  the buffer, all section data is accounted for in their respective section headers, and that
@@ -21,3 +24,5 @@ ValidateCperHeader (
   IN CONST EFI_COMMON_ERROR_RECORD_HEADER  *Err,
   IN CONST UINTN                           Size
   );
+
+#endif

--- a/MsWheaPkg/Library/MsWheaEarlyStorageLib/MsWheaEarlyStorageLib.c
+++ b/MsWheaPkg/Library/MsWheaEarlyStorageLib/MsWheaEarlyStorageLib.c
@@ -63,7 +63,7 @@ __MsWheaCMOSRawRead (
 
   for (i = 0; i < Size; i++) {
     mIndex = Offset + i;
-    if ((mIndex >= 0) && (mIndex <= 127)) {
+    if (mIndex <= 127) {
       IoWrite8 (PCAT_RTC_LO_ADDRESS_PORT, mIndex);
       mBuf[i] = IoRead8 (PCAT_RTC_LO_DATA_PORT);
     } else {
@@ -114,7 +114,7 @@ __MsWheaCMOSRawWrite (
 
   for (i = 0; i < Size; i++) {
     mIndex = Offset + i;
-    if ((mIndex >= 0) && (mIndex <= 127)) {
+    if (mIndex <= 127) {
       IoWrite8 (PCAT_RTC_LO_ADDRESS_PORT, mIndex);
       IoWrite8 (PCAT_RTC_LO_DATA_PORT, mBuf[i]);
     } else {
@@ -160,7 +160,7 @@ __MsWheaCMOSRawClear (
 
   for (i = 0; i < Size; i++) {
     mIndex = Offset + i;
-    if ((mIndex >= 0) && (mIndex <= 127)) {
+    if (mIndex <= 127) {
       IoWrite8 (PCAT_RTC_LO_ADDRESS_PORT, mIndex);
       IoWrite8 (PCAT_RTC_LO_DATA_PORT, PcdGet8 (PcdMsWheaEarlyStorageDefaultValue));
     } else {

--- a/MsWheaPkg/Library/MsWheaEarlyStorageLib/MsWheaEarlyStorageLib.c
+++ b/MsWheaPkg/Library/MsWheaEarlyStorageLib/MsWheaEarlyStorageLib.c
@@ -176,20 +176,6 @@ Cleanup:
 
 /**
 
-This routine clears all bytes in Data region
-
-**/
-STATIC
-VOID
-MsWheaCMOSStoreClearAll (
-  VOID
-  )
-{
-  __MsWheaCMOSRawClear (MsWheaEarlyStorageGetMaxSize (), MS_WHEA_EARLY_STORAGE_OFFSET);
-}
-
-/**
-
 This routine returns the maximum number of bytes that can be stored in the early storage area.
 
 @retval Count    The maximum number of bytes that can be stored in the MS WHEA store.


### PR DESCRIPTION
## Description

1. `Add header guards missing in some files`

   Some header files, such as those which define structures,
   cannot be included more than once within a translation unit, as doing
   so would cause a redefinition error. Such headers must be guarded to
   prevent ill-effects from multiple inclusion. Similarly, if header
   files include other header files, and this inclusion graph contains
   a cycle, then at least one file within the cycle must contain header
   guards in order to break the cycle. Because of cases like these, all
   headers should be guarded as a matter of good practice, even if they
   do not strictly need to be.

   Furthermore, most modern compilers contain optimizations which are
   triggered by header guards. If the header guard strictly conforms
   to the pattern that compilers expect, then inclusions of that
   header other than the first have absolutely no effect: the file
   isn't re-read from disk, nor is it re-tokenised or re-preprocessed.
   This can result in a noticeable, albeit minor, improvement to
   compilation time.

2. `MsWheaPkg/MsWheaEarlyStorageLib: Remove unused static function`

   Removes `MsWheaCMOSStoreClearAll()` which is scoped to the file and
   not used. Improves code readability and maintenance.

3. `MsWheaPkg/MsWheaEarlyStorageLib: Remove unsigned comparisons to zero`

   Removes an unnecessary condition since unsigned values are always
   greater than or equal to 0.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build and CI.

## Integration Instructions

N/A