### PR TITLE
[REBASE && FF] FlatPageTableLib and DxePagingAuditTestApp Updates

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -486,89 +486,6 @@ ValidateEfiMemoryMapSize (
 }
 
 /**
-  Checks the input flat page/translation table for the input region and converts the associated
-  table entries to EFI access attributes.
-
-  @param[in]  Map                 Pointer to the PAGE_MAP struct to be parsed
-  @param[in]  Address             Start address of the region
-  @param[in]  Length              Length of the region
-  @param[out] Attributes          EFI Attributes of the region
-
-  @retval EFI_SUCCESS             The output Attributes is valid
-  @retval EFI_INVALID_PARAMETER   The flat translation table has not been built or
-                                  Attributes was NULL or Length was 0
-  @retval EFI_NOT_FOUND           The input region could not be found.
-**/
-EFI_STATUS
-EFIAPI
-GetRegionCommonAccessAttributes (
-  IN PAGE_MAP  *Map,
-  IN UINT64    Address,
-  IN UINT64    Length,
-  OUT UINT64   *Attributes
-  )
-{
-  UINTN    Index;
-  UINT64   EntryStartAddress;
-  UINT64   EntryEndAddress;
-  UINT64   InputEndAddress;
-  BOOLEAN  FoundRange;
-
-  if ((Map->Entries == NULL) || (Map->EntryCount == 0) || (Attributes == NULL) || (Length == 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FoundRange      = FALSE;
-  Index           = 0;
-  InputEndAddress = 0;
-
-  if (EFI_ERROR (SafeUint64Add (Address, Length - 1, &InputEndAddress))) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  do {
-    EntryStartAddress = Map->Entries[Index].LinearAddress;
-    if (EFI_ERROR (
-          SafeUint64Add (
-            Map->Entries[Index].LinearAddress,
-            Map->Entries[Index].Length - 1,
-            &EntryEndAddress
-            )
-          ))
-    {
-      return EFI_ABORTED;
-    }
-
-    if (CHECK_OVERLAP (Address, InputEndAddress, EntryStartAddress, EntryEndAddress)) {
-      if (!FoundRange) {
-        *Attributes = EFI_MEMORY_ACCESS_MASK;
-        FoundRange  = TRUE;
-      }
-
-      if (IsPageExecutable (Map->Entries[Index].PageEntry)) {
-        *Attributes &= ~EFI_MEMORY_XP;
-      }
-
-      if (IsPageWritable (Map->Entries[Index].PageEntry)) {
-        *Attributes &= ~EFI_MEMORY_RO;
-      }
-
-      if (IsPageReadable (Map->Entries[Index].PageEntry)) {
-        *Attributes &= ~EFI_MEMORY_RP;
-      }
-
-      Address = EntryEndAddress + 1;
-    }
-
-    if (EntryEndAddress >= InputEndAddress) {
-      break;
-    }
-  } while (++Index < Map->EntryCount);
-
-  return FoundRange ? EFI_SUCCESS : EFI_NOT_FOUND;
-}
-
-/**
   Checks the input flat page/translation table for the input region and validates
   the attributes match the input attributes.
 
@@ -998,8 +915,6 @@ UnallocatedMemoryIsRP (
   BOOLEAN                TestFailure;
   EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
   EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
-  UINTN                  Attributes;
-  EFI_STATUS             Status;
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
 
@@ -1015,29 +930,17 @@ UnallocatedMemoryIsRP (
 
   while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
     if (EfiMemoryMapEntry->Type == EfiConventionalMemory) {
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     EfiMemoryMapEntry->PhysicalStart,
-                     EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-      if (Status != EFI_NOT_FOUND) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for range 0x%llx - 0x%llx\n",
-            EfiMemoryMapEntry->PhysicalStart,
-            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
-            );
-          TestFailure = TRUE;
-        } else if ((Attributes & EFI_MEMORY_RP) == 0) {
-          UT_LOG_ERROR (
-            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_RP\n",
-            EfiMemoryMapEntry->PhysicalStart,
-            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
-            );
-          TestFailure = TRUE;
-        }
+      if (!ValidateRegionAttributes (
+             &mMap,
+             EfiMemoryMapEntry->PhysicalStart,
+             (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE),
+             EFI_MEMORY_RP,
+             TRUE,
+             TRUE,
+             TRUE
+             ))
+      {
+        TestFailure = TRUE;
       }
     }
 
@@ -1095,12 +998,10 @@ AllocatedPagesAndPoolsAreProtected (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  UINT64      Attributes;
-  UINTN       Index;
-  EFI_STATUS  Status;
-  BOOLEAN     TestFailure;
-  UINTN       *PageAllocations[EfiMaxMemoryType];
-  UINTN       *PoolAllocations[EfiMaxMemoryType];
+  UINTN    Index;
+  BOOLEAN  TestFailure;
+  UINTN    *PageAllocations[EfiMaxMemoryType];
+  UINTN    *PoolAllocations[EfiMaxMemoryType];
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
 
@@ -1109,7 +1010,7 @@ AllocatedPagesAndPoolsAreProtected (
   ZeroMem (PoolAllocations, sizeof (PoolAllocations));
 
   for (Index = 0; Index < EfiMaxMemoryType; Index++) {
-    if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory)) {
+    if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory) && (Index != EfiUnacceptedMemoryType)) {
       PageAllocations[Index] = AllocatePages (1);
       if (PageAllocations[Index] == NULL) {
         UT_LOG_ERROR ("Failed to allocate one page for memory type %d\n", Index);
@@ -1128,57 +1029,31 @@ AllocatedPagesAndPoolsAreProtected (
   UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
 
   for (Index = 0; Index < EfiMaxMemoryType; Index++) {
-    if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory)) {
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     (UINT64)PageAllocations[Index],
-                     EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-      if (Status != EFI_NOT_FOUND) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for range 0x%llx - 0x%llx\n",
-            PageAllocations[Index],
-            PageAllocations[Index] + EFI_PAGE_SIZE
-            );
-          TestFailure = TRUE;
-        }
-
-        if (Attributes == 0) {
-          UT_LOG_ERROR (
-            "Page range 0x%llx - 0x%llx has no restrictive access attributes\n",
-            PageAllocations[Index],
-            PageAllocations[Index] + EFI_PAGE_SIZE
-            );
-          TestFailure = TRUE;
-        }
+    if ((Index != EfiConventionalMemory) && (Index != EfiPersistentMemory) && (Index != EfiUnacceptedMemoryType)) {
+      if (!ValidateRegionAttributes (
+             &mMap,
+             (UINT64)PageAllocations[Index],
+             EFI_PAGE_SIZE,
+             EFI_MEMORY_RP | EFI_MEMORY_RO | EFI_MEMORY_XP,
+             TRUE,
+             FALSE,
+             TRUE
+             ))
+      {
+        TestFailure = TRUE;
       }
 
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]),
-                     EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-      if ((Status != EFI_NOT_FOUND)) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for range 0x%llx - 0x%llx\n",
-            ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]),
-            ALIGN_ADDRESS ((UINTN)PoolAllocations[Index]) + EFI_PAGE_SIZE
-            );
-          TestFailure = TRUE;
-        } else if (Attributes == 0) {
-          UT_LOG_ERROR (
-            "Pool range 0x%llx - 0x%llx has no restrictive access attributes\n",
-            PoolAllocations[Index],
-            PoolAllocations[Index] + sizeof (UINT64)
-            );
-          TestFailure = TRUE;
-        }
+      if (!ValidateRegionAttributes (
+             &mMap,
+             (UINT64)PoolAllocations[Index],
+             8,
+             EFI_MEMORY_RP | EFI_MEMORY_RO | EFI_MEMORY_XP,
+             TRUE,
+             FALSE,
+             TRUE
+             ))
+      {
+        TestFailure = TRUE;
       }
     }
   }
@@ -1214,23 +1089,21 @@ NullCheck (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  UINT64      Attributes;
-  EFI_STATUS  Status;
-
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
   UT_ASSERT_NOT_EFI_ERROR (ValidatePageTableMapSize ());
   UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
 
-  Attributes = 0;
-  Status     = GetRegionCommonAccessAttributes (&mMap, 0, EFI_PAGE_SIZE, &Attributes);
-
-  if ((Status != EFI_NOT_FOUND)) {
-    if (EFI_ERROR (Status)) {
-      UT_ASSERT_NOT_EFI_ERROR (Status);
-    } else {
-      UT_ASSERT_NOT_EQUAL (Attributes & EFI_MEMORY_RP, 0);
-    }
-  }
+  UT_ASSERT_TRUE (
+    ValidateRegionAttributes (
+      &mMap,
+      0,
+      EFI_PAGE_SIZE,
+      EFI_MEMORY_RP,
+      TRUE,
+      TRUE,
+      TRUE
+      )
+    );
 
   return UNIT_TEST_PASSED;
 }
@@ -1253,9 +1126,7 @@ MmioIsXp (
 {
   EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
   EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
-  UINT64                 Attributes;
   BOOLEAN                TestFailure;
-  EFI_STATUS             Status;
   UINTN                  Index;
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
@@ -1273,30 +1144,17 @@ MmioIsXp (
 
   while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
     if (EfiMemoryMapEntry->Type == EfiMemoryMappedIO) {
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     EfiMemoryMapEntry->PhysicalStart,
-                     EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-
-      if (Status != EFI_NOT_FOUND) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for range 0x%llx - 0x%llx\n",
-            EfiMemoryMapEntry->PhysicalStart,
-            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
-            );
-          TestFailure = TRUE;
-        } else if ((Attributes & EFI_MEMORY_XP) == 0) {
-          UT_LOG_ERROR (
-            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
-            EfiMemoryMapEntry->PhysicalStart,
-            EfiMemoryMapEntry->PhysicalStart + (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE)
-            );
-          TestFailure = TRUE;
-        }
+      if (!ValidateRegionAttributes (
+             &mMap,
+             EfiMemoryMapEntry->PhysicalStart,
+             (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE),
+             EFI_MEMORY_XP | EFI_MEMORY_RP,
+             TRUE,
+             TRUE,
+             TRUE
+             ))
+      {
+        TestFailure = TRUE;
       }
     }
 
@@ -1305,30 +1163,17 @@ MmioIsXp (
 
   for (Index = 0; Index < mMemorySpaceMapCount; Index++) {
     if (mMemorySpaceMap[Index].GcdMemoryType == EfiGcdMemoryTypeMemoryMappedIo) {
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     mMemorySpaceMap[Index].BaseAddress,
-                     mMemorySpaceMap[Index].Length,
-                     &Attributes
-                     );
-
-      if (Status != EFI_NOT_FOUND) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for range 0x%llx - 0x%llx\n",
-            mMemorySpaceMap[Index].BaseAddress,
-            mMemorySpaceMap[Index].BaseAddress + mMemorySpaceMap[Index].Length
-            );
-          TestFailure = TRUE;
-        } else if ((Attributes & EFI_MEMORY_XP) == 0) {
-          UT_LOG_ERROR (
-            "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
-            mMemorySpaceMap[Index].BaseAddress,
-            mMemorySpaceMap[Index].BaseAddress + mMemorySpaceMap[Index].Length
-            );
-          TestFailure = TRUE;
-        }
+      if (!ValidateRegionAttributes (
+             &mMap,
+             mMemorySpaceMap[Index].BaseAddress,
+             mMemorySpaceMap[Index].Length,
+             EFI_MEMORY_XP | EFI_MEMORY_RP,
+             TRUE,
+             TRUE,
+             TRUE
+             ))
+      {
+        TestFailure = TRUE;
       }
     }
   }
@@ -1366,7 +1211,6 @@ ImageCodeSectionsRoDataSectionsXp (
   EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION  Hdr;
   UINT32                               SectionAlignment;
   EFI_IMAGE_SECTION_HEADER             *Section;
-  UINT64                               Attributes;
   BOOLEAN                              TestFailure;
   UINT64                               SectionStart;
   UINT64                               SectionEnd;
@@ -1449,7 +1293,6 @@ ImageCodeSectionsRoDataSectionsXp (
                                            );
 
     for (Index2 = 0; Index2 < Hdr.Pe32->FileHeader.NumberOfSections; Index2++) {
-      Attributes   = 0;
       SectionStart = (UINT64)LoadedImage->ImageBase + Section[Index2].VirtualAddress;
       SectionEnd   = SectionStart + ALIGN_VALUE (Section[Index2].SizeOfRawData, SectionAlignment);
 
@@ -1465,26 +1308,19 @@ ImageCodeSectionsRoDataSectionsXp (
           SectionEnd
           );
         TestFailure = TRUE;
-      }
-
-      Status = GetRegionCommonAccessAttributes (
-                 &mMap,
-                 SectionStart,
-                 SectionEnd - SectionStart,
-                 &Attributes
-                 );
-
-      if (EFI_ERROR (Status)) {
-        TestFailure = TRUE;
-        UT_LOG_ERROR (
-          "Failed to get attributes for memory range 0x%llx-0x%llx\n",
-          SectionStart,
-          SectionEnd
-          );
       } else if ((Section[Index2].Characteristics &
                   (EFI_IMAGE_SCN_MEM_WRITE | EFI_IMAGE_SCN_MEM_EXECUTE)) == EFI_IMAGE_SCN_MEM_EXECUTE)
       {
-        if ((Attributes & EFI_MEMORY_RO) == 0) {
+        if (!ValidateRegionAttributes (
+               &mMap,
+               SectionStart,
+               SectionEnd - SectionStart,
+               EFI_MEMORY_RO,
+               FALSE,
+               FALSE,
+               FALSE
+               ))
+        {
           UT_LOG_ERROR (
             "Image %a: Section 0x%llx-0x%llx is not EFI_MEMORY_RO\n",
             PdbFileName,
@@ -1494,7 +1330,16 @@ ImageCodeSectionsRoDataSectionsXp (
           TestFailure = TRUE;
         }
       } else {
-        if ((Attributes & EFI_MEMORY_XP) == 0) {
+        if (!ValidateRegionAttributes (
+               &mMap,
+               SectionStart,
+               SectionEnd - SectionStart,
+               EFI_MEMORY_XP,
+               FALSE,
+               FALSE,
+               FALSE
+               ))
+        {
           UT_LOG_ERROR (
             "Image %a: Section 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
             PdbFileName,
@@ -1535,8 +1380,6 @@ BspStackIsXpAndHasGuardPage (
   BOOLEAN                    TestFailure;
   EFI_PHYSICAL_ADDRESS       StackBase;
   UINT64                     StackLength;
-  UINT64                     Attributes;
-  EFI_STATUS                 Status;
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
 
@@ -1554,49 +1397,36 @@ BspStackIsXpAndHasGuardPage (
 
       UT_LOG_INFO ("BSP stack located at 0x%llx - 0x%llx\n", StackBase, StackBase + StackLength);
 
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     StackBase,
-                     EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-      if ((Status != EFI_NOT_FOUND)) {
-        if (EFI_ERROR (Status)) {
-          UT_LOG_ERROR (
-            "Failed to get attributes for memory range 0x%llx-0x%llx\n",
-            StackBase,
-            StackBase + EFI_PAGE_SIZE
-            );
-          TestFailure = TRUE;
-        } else if (((Attributes & EFI_MEMORY_RP) == 0)) {
-          UT_LOG_ERROR (
-            "Stack 0x%llx-0x%llx does not have an EFI_MEMORY_RP page to catch overflow\n",
-            StackBase,
-            StackBase + EFI_PAGE_SIZE
-            );
-          TestFailure = TRUE;
-        }
-      }
-
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     StackBase + EFI_PAGE_SIZE,
-                     StackLength - EFI_PAGE_SIZE,
-                     &Attributes
-                     );
-
-      if (EFI_ERROR (Status)) {
+      if (!ValidateRegionAttributes (
+             &mMap,
+             StackBase,
+             EFI_PAGE_SIZE,
+             EFI_MEMORY_RP,
+             TRUE,
+             TRUE,
+             FALSE
+             ))
+      {
         UT_LOG_ERROR (
-          "Failed to get attributes for memory range 0x%llx-0x%llx\n",
-          StackBase + EFI_PAGE_SIZE,
-          StackBase + StackLength
+          "Stack 0x%llx-0x%llx does not have an EFI_MEMORY_RP page to catch overflow\n",
+          StackBase,
+          StackBase + EFI_PAGE_SIZE
           );
         TestFailure = TRUE;
-      } else if ((Attributes & EFI_MEMORY_XP) == 0) {
+      }
+
+      if (!ValidateRegionAttributes (
+             &mMap,
+             StackBase + EFI_PAGE_SIZE,
+             StackLength - EFI_PAGE_SIZE,
+             EFI_MEMORY_XP,
+             TRUE,
+             FALSE,
+             FALSE
+             ))
+      {
         UT_LOG_ERROR (
-          "Stack 0x%llx-0x%llx is executable\n",
+          "Stack 0x%llx-0x%llx is not EFI_MEMORY_XP\n",
           StackBase + EFI_PAGE_SIZE,
           StackBase + StackLength
           );
@@ -1636,8 +1466,6 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   EFI_MEMORY_DESCRIPTOR  *CurrentEfiMemoryMapEntry;
   BOOLEAN                TestFailure;
   EFI_PHYSICAL_ADDRESS   LastMemoryMapEntryEnd;
-  UINT64                 Attributes;
-  EFI_STATUS             Status;
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
 
@@ -1656,20 +1484,16 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   CurrentEfiMemoryMapEntry = mEfiMemoryMap;
 
   if (CurrentEfiMemoryMapEntry->PhysicalStart > StartOfAddressSpace) {
-    Attributes = 0;
-    Status     = GetRegionCommonAccessAttributes (
-                   &mMap,
-                   StartOfAddressSpace,
-                   CurrentEfiMemoryMapEntry->PhysicalStart - StartOfAddressSpace,
-                   &Attributes
-                   );
-
-    if ((Status != EFI_NOT_FOUND) && ((Attributes & EFI_MEMORY_RP) == 0)) {
-      UT_LOG_ERROR (
-        "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_RP\n",
-        StartOfAddressSpace,
-        CurrentEfiMemoryMapEntry->PhysicalStart
-        );
+    if (!ValidateRegionAttributes (
+           &mMap,
+           StartOfAddressSpace,
+           CurrentEfiMemoryMapEntry->PhysicalStart - StartOfAddressSpace,
+           EFI_MEMORY_RP,
+           TRUE,
+           TRUE,
+           TRUE
+           ))
+    {
       TestFailure = TRUE;
     }
   }
@@ -1680,19 +1504,16 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
 
   while ((UINTN)CurrentEfiMemoryMapEntry < (UINTN)EndOfEfiMemoryMap) {
     if (CurrentEfiMemoryMapEntry->PhysicalStart > LastMemoryMapEntryEnd) {
-      Attributes = 0;
-      Status     = GetRegionCommonAccessAttributes (
-                     &mMap,
-                     LastMemoryMapEntryEnd,
-                     CurrentEfiMemoryMapEntry->PhysicalStart - LastMemoryMapEntryEnd,
-                     &Attributes
-                     );
-      if ((Status != EFI_NOT_FOUND) && ((Attributes & EFI_MEMORY_RP) == 0)) {
-        UT_LOG_ERROR (
-          "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_RP\n",
-          LastMemoryMapEntryEnd,
-          CurrentEfiMemoryMapEntry->PhysicalStart
-          );
+      if (!ValidateRegionAttributes (
+             &mMap,
+             LastMemoryMapEntryEnd,
+             CurrentEfiMemoryMapEntry->PhysicalStart - LastMemoryMapEntryEnd,
+             EFI_MEMORY_RP,
+             TRUE,
+             TRUE,
+             TRUE
+             ))
+      {
         TestFailure = TRUE;
       }
     }
@@ -1703,19 +1524,16 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   }
 
   if (LastMemoryMapEntryEnd < EndOfAddressSpace) {
-    Attributes = 0;
-    Status     = GetRegionCommonAccessAttributes (
-                   &mMap,
-                   LastMemoryMapEntryEnd,
-                   EndOfAddressSpace - LastMemoryMapEntryEnd,
-                   &Attributes
-                   );
-    if ((Status != EFI_NOT_FOUND) && ((Attributes & EFI_MEMORY_RP) == 0)) {
-      UT_LOG_ERROR (
-        "Memory Range 0x%llx-0x%llx is not EFI_MEMORY_RP\n",
-        LastMemoryMapEntryEnd,
-        EndOfAddressSpace
-        );
+    if (!ValidateRegionAttributes (
+           &mMap,
+           LastMemoryMapEntryEnd,
+           EndOfAddressSpace - LastMemoryMapEntryEnd,
+           EFI_MEMORY_RP,
+           TRUE,
+           TRUE,
+           TRUE
+           ))
+    {
       TestFailure = TRUE;
     }
   }

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -1215,9 +1215,7 @@ FlushAndClearMemoryInfoDatabase (
   )
 {
   // If we have database contents, flush them to the file.
-  if (mMemoryInfoDatabaseSize > 0) {
-    WriteBufferToFile (FileName, mMemoryInfoDatabaseBuffer, mMemoryInfoDatabaseSize);
-  }
+  WriteBufferToFile (FileName, mMemoryInfoDatabaseBuffer, mMemoryInfoDatabaseSize);
 
   // If we have a database, free it, and reset all counters.
   if (mMemoryInfoDatabaseBuffer != NULL) {

--- a/UefiTestingPkg/Include/Library/FlatPageTableLib.h
+++ b/UefiTestingPkg/Include/Library/FlatPageTableLib.h
@@ -115,27 +115,43 @@ DumpPageMap (
 
 /**
   Checks the input flat page/translation table for the input region and converts the associated
-  table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). If the
-  access attributes vary across the region, EFI_NO_MAPPING is returned.
+  table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). The caller
+  of this function is responsible for checking ActualCheckedLength if the return value is
+  EFI_NOT_FOUND or EFI_NO_MAPPING. EFI_NOT_FOUND indicates that the attributes vary across
+  the region. EFI_NO_MAPPING indicates that the section from RegionStart to RegionStart +
+  ActualCheckedLength is not mapped. If ActualCheckedLength == RegionLength,
+  when EFI_NO_MAPPING is returned, the entire input region is not mapped.
 
-  @param[in]  Map                 Pointer to the PAGE_MAP struct to be parsed
-  @param[in]  Length              Length in bytes of the region
-  @param[in]  Length              Length of the region
-  @param[out] Attributes          EFI Attributes of the region
+  @param[in]  Map                     Pointer to the PAGE_MAP struct to be parsed
+  @param[in]  RegionStart             Starting address of the region to check.
+  @param[in]  RegionLength            Length, in bytes, of the region to check.
+  @param[out] Attributes              EFI Attributes of the region.
+  @param[out] ActualCheckedLength     The length checked from RegionStart.
+                                      If the region has varying attributes or the start
+                                      of the region is not mapped, this will be the
+                                      length from RegionStart to which the return
+                                      value applies.
 
-  @retval EFI_SUCCESS             The output Attributes is valid
-  @retval EFI_INVALID_PARAMETER   The flat translation table has not been built or
-                                  Attributes was NULL or Length was 0
-  @retval EFI_NOT_FOUND           The input region could not be found
-  @retval EFI_NO_MAPPING          The access attributes are not consistent across the region.
+  @retval EFI_SUCCESS             The region attributes were successfully determined.
+  @retval EFI_INVALID_PARAMETER   An input argument is invalid.
+  @retval EFI_ABORTED             The input PAGE_MAP is invalid.
+  @retval EFI_NOT_FOUND           The input region starting at RegionStart has varying
+                                  attributes. See ActualCheckedLength for the length of
+                                  the contiguous region with the same attributes as
+                                  the start of the input region.
+  @retval EFI_NO_MAPPING          The region starting at RegionStart is not mapped. If
+                                  ActualCheckedLength == RegionLength, the region is
+                                  not mapped at all. Otherwise, ActualCheckedLength will
+                                  be the length of the unmapped region from RegionStart.
 **/
 EFI_STATUS
 EFIAPI
 GetRegionAccessAttributes (
   IN PAGE_MAP  *Map,
-  IN UINT64    Address,
-  IN UINT64    Length,
-  OUT UINT64   *Attributes
+  IN UINT64    RegionStart,
+  IN UINT64    RegionLength,
+  OUT UINT64   *Attributes,
+  OUT UINT64   *ActualCheckedLength
   );
 
 /**

--- a/UefiTestingPkg/Include/Library/FlatPageTableLib.h
+++ b/UefiTestingPkg/Include/Library/FlatPageTableLib.h
@@ -105,6 +105,15 @@ CreateFlatPageTable (
   );
 
 /**
+  Dumps the contents of the input PAGE_MAP to the debug log.
+**/
+VOID
+EFIAPI
+DumpPageMap (
+  IN PAGE_MAP  *Map
+  );
+
+/**
   Checks the input flat page/translation table for the input region and converts the associated
   table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). If the
   access attributes vary across the region, EFI_NO_MAPPING is returned.

--- a/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.c
@@ -14,12 +14,14 @@
 #include <Library/BaseLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/FlatPageTableLib.h>
+#include <Library/DebugLib.h>
 
-// TRUE if A and B have overlapping intervals
+// TRUE if A and B have overlapping intervals.
+// The intervals are inclusive.
 #define CHECK_OVERLAP(AStart, AEnd, BStart, BEnd)   \
-  ((AEnd > AStart) && (BEnd > BStart) &&            \
-  ((AStart <= BStart && AEnd > BStart) ||           \
-  (BStart <= AStart && BEnd > AStart)))
+  ((AEnd >= AStart) && (BEnd >= BStart) &&          \
+  ((AStart <= BStart && AEnd >= BStart) ||          \
+  (BStart <= AStart && BEnd >= AStart)))
 
 /**
   Dumps the contents of the input PAGE_MAP to the debug log.
@@ -53,48 +55,66 @@ DumpPageMap (
 
 /**
   Checks the input flat page/translation table for the input region and converts the associated
-  table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). If the
-  access attributes vary across the region, EFI_NOT_FOUND is returned.
+  table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). The caller
+  of this function is responsible for checking ActualCheckedLength if the return value is
+  EFI_NOT_FOUND or EFI_NO_MAPPING. EFI_NOT_FOUND indicates that the attributes vary across
+  the region. EFI_NO_MAPPING indicates that the section from RegionStart to RegionStart +
+  ActualCheckedLength is not mapped. If ActualCheckedLength == RegionLength,
+  when EFI_NO_MAPPING is returned, the entire input region is not mapped.
 
-  @param[in]  Map                 Pointer to the PAGE_MAP struct to be parsed
-  @param[in]  Length              Length in bytes of the region
-  @param[in]  Length              Length of the region
-  @param[out] Attributes          EFI Attributes of the region
+  @param[in]  Map                     Pointer to the PAGE_MAP struct to be parsed
+  @param[in]  RegionStart             Starting address of the region to check.
+  @param[in]  RegionLength            Length, in bytes, of the region to check.
+  @param[out] Attributes              EFI Attributes of the region.
+  @param[out] ActualCheckedLength     The length checked from RegionStart.
+                                      If the region has varying attributes or the start
+                                      of the region is not mapped, this will be the
+                                      length from RegionStart to which the return
+                                      value applies.
 
-  @retval EFI_SUCCESS             The output Attributes is valid
-  @retval EFI_INVALID_PARAMETER   The flat translation table has not been built or
-                                  Attributes was NULL or Length was 0
-  @retval EFI_NOT_FOUND           The input region could not be found
-  @retval EFI_NO_MAPPING          The access attributes are not consistent across the region.
+  @retval EFI_SUCCESS             The region attributes were successfully determined.
+  @retval EFI_INVALID_PARAMETER   An input argument is invalid.
+  @retval EFI_ABORTED             The input PAGE_MAP is invalid.
+  @retval EFI_NOT_FOUND           The input region starting at RegionStart has varying
+                                  attributes. See ActualCheckedLength for the length of
+                                  the contiguous region with the same attributes as
+                                  the start of the input region.
+  @retval EFI_NO_MAPPING          The region starting at RegionStart is not mapped. If
+                                  ActualCheckedLength == RegionLength, the region is
+                                  not mapped at all. Otherwise, ActualCheckedLength will
+                                  be the length of the unmapped region from RegionStart.
 **/
 EFI_STATUS
 EFIAPI
 GetRegionAccessAttributes (
   IN PAGE_MAP  *Map,
-  IN UINT64    Address,
-  IN UINT64    Length,
-  OUT UINT64   *Attributes
+  IN UINT64    RegionStart,
+  IN UINT64    RegionLength,
+  OUT UINT64   *Attributes,
+  OUT UINT64   *ActualCheckedLength
   )
 {
   UINTN    Index;
   UINT64   EntryStartAddress;
   UINT64   EntryEndAddress;
-  UINT64   InputEndAddress;
+  UINT64   CurrentStartAddress;
+  UINT64   RegionEnd;
   BOOLEAN  FoundRange;
   UINT64   FoundAttributes;
   UINT64   FoundAttributesOriginal;
 
   if ((Map->Entries == NULL) || (Map->EntryCount == 0) ||
-      (Attributes == NULL) || (Length == 0))
+      (Attributes == NULL) || (ActualCheckedLength == NULL) || (RegionLength == 0))
   {
     return EFI_INVALID_PARAMETER;
   }
 
-  FoundRange      = FALSE;
-  Index           = 0;
-  InputEndAddress = 0;
+  FoundRange          = FALSE;
+  Index               = 0;
+  CurrentStartAddress = RegionStart;
+  RegionEnd           = 0;
 
-  if (EFI_ERROR (SafeUint64Add (Address, Length - 1, &InputEndAddress))) {
+  if (EFI_ERROR (SafeUint64Add (RegionStart, RegionLength - 1, &RegionEnd))) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -108,37 +128,58 @@ GetRegionAccessAttributes (
             )
           ))
     {
+      *ActualCheckedLength = 0;
       return EFI_ABORTED;
     }
 
-    if (CHECK_OVERLAP (Address, InputEndAddress, EntryStartAddress, EntryEndAddress)) {
-      if (!FoundRange) {
-        FoundAttributesOriginal  = 0;
-        FoundAttributesOriginal |= IsPageExecutable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_XP;
-        FoundAttributesOriginal |= IsPageWritable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RO;
-        FoundAttributesOriginal |= IsPageReadable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RP;
-        FoundRange               = TRUE;
-      } else {
-        FoundAttributes  = 0;
-        FoundAttributes |= IsPageExecutable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_XP;
-        FoundAttributes |= IsPageWritable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RO;
-        FoundAttributes |= IsPageReadable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RP;
-        if (FoundAttributesOriginal != FoundAttributes) {
+    if (CHECK_OVERLAP (CurrentStartAddress, RegionEnd, EntryStartAddress, EntryEndAddress)) {
+      FoundAttributes  = IsPageExecutable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_XP;
+      FoundAttributes |= IsPageWritable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RO;
+      FoundAttributes |= IsPageReadable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RP;
+
+      // There is a gap between the current address and the start of the entry.
+      if (EntryStartAddress > CurrentStartAddress) {
+        if (FoundRange) {
+          *Attributes          = FoundAttributesOriginal;
+          *ActualCheckedLength = CurrentStartAddress - RegionStart;
+          return EFI_NOT_FOUND;
+        } else {
+          *Attributes          = 0;
+          *ActualCheckedLength = EntryStartAddress - RegionStart;
           return EFI_NO_MAPPING;
         }
       }
 
-      Address = EntryEndAddress + 1;
+      if (!FoundRange) {
+        FoundAttributesOriginal = FoundAttributes;
+        FoundRange              = TRUE;
+      } else if (FoundAttributesOriginal != FoundAttributes) {
+        *Attributes          = FoundAttributesOriginal;
+        *ActualCheckedLength = CurrentStartAddress - RegionStart;
+        return EFI_NOT_FOUND;
+      }
+
+      // The entry end address is inclusive, so add one to get the next region start.
+      // If the addition overflows, the region is contiguous to the end of the address space.
+      if (EFI_ERROR (SafeUint64Add (EntryEndAddress, 1, &CurrentStartAddress))) {
+        *Attributes          = FoundAttributesOriginal;
+        *ActualCheckedLength = RegionLength;
+        return EFI_SUCCESS;
+      }
     }
 
-    if (EntryEndAddress >= InputEndAddress) {
+    if (CurrentStartAddress >= RegionEnd) {
       break;
     }
   } while (++Index < Map->EntryCount);
 
   if (FoundRange) {
-    *Attributes = FoundAttributesOriginal;
+    *Attributes          = FoundAttributesOriginal;
+    *ActualCheckedLength = CurrentStartAddress >= RegionEnd ? RegionLength : CurrentStartAddress - RegionStart;
+  } else {
+    *Attributes          = 0;
+    *ActualCheckedLength = RegionLength;
   }
 
-  return FoundRange ? EFI_SUCCESS : EFI_NOT_FOUND;
+  return FoundRange ? EFI_SUCCESS : EFI_NO_MAPPING;
 }

--- a/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.c
@@ -22,6 +22,36 @@
   (BStart <= AStart && BEnd > AStart)))
 
 /**
+  Dumps the contents of the input PAGE_MAP to the debug log.
+**/
+VOID
+EFIAPI
+DumpPageMap (
+  IN PAGE_MAP  *Map
+  )
+{
+  UINTN   Index;
+  UINT64  Attributes;
+
+  DEBUG ((DEBUG_INFO, "Page Map: %p\n", Map));
+  DEBUG ((DEBUG_INFO, "  EntryCount: %d\n", Map->EntryCount));
+  DEBUG ((DEBUG_INFO, "  Entries:\n"));
+  for (Index = 0; Index < Map->EntryCount; Index++) {
+    Attributes  = IsPageExecutable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_XP;
+    Attributes |= IsPageWritable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RO;
+    Attributes |= IsPageReadable (Map->Entries[Index].PageEntry) ? 0 : EFI_MEMORY_RP;
+    DEBUG ((
+      DEBUG_INFO,
+      "    %d: %p-%p. Attributes: 0x%llx\n",
+      Index,
+      Map->Entries[Index].LinearAddress,
+      Map->Entries[Index].LinearAddress + Map->Entries[Index].Length - 1,
+      Attributes
+      ));
+  }
+}
+
+/**
   Checks the input flat page/translation table for the input region and converts the associated
   table entries to EFI access attributes (EFI_MEMORY_XP, EFI_MEMORY_RO, EFI_MEMORY_RP). If the
   access attributes vary across the region, EFI_NOT_FOUND is returned.


### PR DESCRIPTION
## Description

This change set was primarily created to improve the accuracy of the DXE paging audit shell test. The problem was two-fold:
1. The layout of memory would change as data was collected. This is solved by pre-allocating space for two of the memory maps (flat page table and EFI memory map). Those two maps will have their size requirement checked at the start of each function to ensure enough heap space has been allocated for them prior to populating them with memory information.
2. The shell test was imprecise when reporting which regions failed the various tests. I'll use the UnallocatedMemoryIsRP() test as an example. The test parses the EFI memory map for EfiConventionalMemory regions which indicate unallocated memory. If any subsection of the region was not read protected, then the entire region would be reported as failing. With this update, every subsection which does not comply will be individually reported giving platform developers more precise information on where the problem areas are.

Patch breakdown:

1. Updates the DXE paging audit to always write out all .dat files even if the buffers are empty. The presence of the file acts as a receipt that the audit was run successfully and helps with automated unit testing.
2. Adds a function to FlatPageTableLib to dump the contents of a flat page table to the console. This is useful for debugging.
3. Updates GetRegionAccessAttributes() in FlatPageTableLib to return the attributes of the first attribute-contiguous range found in the region and report the actual size of that range. This allows the caller to collect the attributes of the region by calling the function repeatedly instead of needing to guess which subsection of the region has contiguous attributes.
4. Updates the DXE paging audit shell tests to pre-allocate memory for memory maps. The page table map, EFI memory map, and EFI memory space map all describe the layout of the system address space. Because of this, if allocations are performed while these maps are being generated, then the maps generated the earliest will be inaccurate.
5. Adds ValidatePageTableAttributes() to the DXE paging audit shell test logic. This function validates the attributes of the input memory region. It uses GetRegionAccessAttributes() to get the attributes of the region and compares them to the attributes passed in. This function will be used by each test case to check that the page/translation table attributes match the memory protection requirements and enables more precise reporting of regions which do not match the requirements.
6. Updates the DXE paging audit shell tests to use ValidatePageTableAttributes() to determine policy compliance.

## How This Was Tested

This was tested on Q35 and an ARM platform. Some changes in test caused the UnallocatedMemoryIsRP() test to erroneously fail due to reason 1 above which has been fixed with this patch set. Additionally, this patch set was checked by comparing the shell test output to the full HTML paging audit to verify that errant regions are exact and consistent.

## Integration Instructions

N/A