### PR TITLE
DxePagingAudit: Skip Stack Publishing if Stack Info Isn't Valid

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -1281,14 +1281,16 @@ SpecialMemoryDump (
       }
 
       // Capture the stack
-      AsciiSPrint (
-        TempString,
-        MAX_STRING_SIZE,
-        "Stack,0x%016lx,0x%016lx\n",
-        StackBase,
-        StackLength
-        );
-      AppendToMemoryInfoDatabase (TempString);
+      if (StackLength > 0) {
+        AsciiSPrint (
+          TempString,
+          MAX_STRING_SIZE,
+          "Stack,0x%016lx,0x%016lx\n",
+          StackBase,
+          StackLength
+          );
+        AppendToMemoryInfoDatabase (TempString);
+      }
 
       break;
     }
@@ -1328,26 +1330,30 @@ SpecialMemoryDump (
         }
 
         // Capture the AP stack
-        AsciiSPrint (
-          TempString,
-          MAX_STRING_SIZE,
-          "ApStack,0x%016lx,0x%016lx,0x%x\n",
-          StackBase,
-          StackLength,
-          Entry->CpuNumber
-          );
-        AppendToMemoryInfoDatabase (TempString);
+        if (StackLength > 0) {
+          AsciiSPrint (
+            TempString,
+            MAX_STRING_SIZE,
+            "ApStack,0x%016lx,0x%016lx,0x%x\n",
+            StackBase,
+            StackLength,
+            Entry->CpuNumber
+            );
+          AppendToMemoryInfoDatabase (TempString);
+        }
       } else {
         // Capture the AP switch stack
-        AsciiSPrint (
-          TempString,
-          MAX_STRING_SIZE,
-          "ApSwitchStack,0x%016lx,0x%016lx,0x%x\n",
-          StackBase,
-          StackLength,
-          Entry->CpuNumber
-          );
-        AppendToMemoryInfoDatabase (TempString);
+        if (StackLength > 0) {
+          AsciiSPrint (
+            TempString,
+            MAX_STRING_SIZE,
+            "ApSwitchStack,0x%016lx,0x%016lx,0x%x\n",
+            StackBase,
+            StackLength,
+            Entry->CpuNumber
+            );
+          AppendToMemoryInfoDatabase (TempString);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

The MemoryInfoDatabase.dat file contains information about the content of memory regions. If an entry in the database file is invalid, it will break the generation of the paging audit. Before adding the stack info to the database file, check that the stack size is greater than zero.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 by generating the paging audit

## Integration Instructions

N/A
