### PR TITLE
Fix DxePagingAuditTestApp Typo, Update FlatPageTableLib AARCH64 IsPageReadable() Check 

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -1301,7 +1301,7 @@ ImageCodeSectionsRoDataSectionsXp (
       // Check if the section contains code and data
       if (((Section[Index2].Characteristics & EFI_IMAGE_SCN_CNT_CODE) != 0) &&
           ((Section[Index2].Characteristics &
-            (EFI_IMAGE_SCN_CNT_INITIALIZED_DATA || EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) != 0))
+            (EFI_IMAGE_SCN_CNT_INITIALIZED_DATA | EFI_IMAGE_SCN_CNT_UNINITIALIZED_DATA)) != 0))
       {
         UT_LOG_ERROR (
           "Image %a: Section 0x%llx-0x%llx contains code and data\n",

--- a/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
@@ -336,7 +336,7 @@ IsPageWritable (
   IN UINT64  Page
   )
 {
-  return ((Page & TT_AP_RW_RW) != 0) || ((Page & TT_AP_MASK) == 0);
+  return ((Page & TT_AP_MASK) == TT_AP_RW_RW) || ((Page & TT_AP_MASK) == TT_AP_NO_RW);
 }
 
 /**


### PR DESCRIPTION
## Description

DxePagingAuditTestApp: When checking an image section characteristics, a bitmasking is done which incorrectly includes a logical OR instead of a bitwise OR.
FlatPageTableLib: The AARCH64 IsPageReadable() routine correctly checks for the no access, r/w case (0b00) but not the r/w, r/w case (0b01) because both 0b11 and 0b01 would pass the latter check.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a Surface ARM platform and SBSA

## Integration Instructions

N/A