### PR TITLE
Fixing uninitialized variable build error

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
@@ -314,6 +314,7 @@ AdvancedLoggerAccessLibGetNextFormattedLine (
   // GetNextLine.
 
   // In case this is a restart of the same Message, initialize the time stamp and prefix.
+  PhaseStringLen = 0;
   if (LineEntry->BlockEntry.Message != NULL) {
     FormatTimeStamp (TimeStampString, sizeof (TimeStampString), LineEntry->BlockEntry.TimeStamp);
     CopyMem (LineBuffer, TimeStampString, sizeof (TimeStampString) - sizeof (CHAR8));


### PR DESCRIPTION
## Description

https://github.com/microsoft/mu_plus/commit/267e27f6a64a80fe82e5ea9adef25edc71776ba3 change introduced a build error on certain platforms, due to a local variable being used uninitialized. This change will set the variable to 0 before usage.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change is tested with LineParserTestApp on QEMU Q35 platform.

## Integration Instructions

N/A