### PR TITLE
Add call to HdwPortInitialize() when instantiating logger in DXE

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -384,10 +384,12 @@ DxeCoreAdvancedLoggerLibConstructor (
       LoggerInfo->LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
       LoggerInfo->LogCurrent    = LoggerInfo->LogBuffer;
       LoggerInfo->HwPrintLevel  = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-      AdvancedLoggerHdwPortInitialize ();
-      mLoggerInfo->HdwPortInitialized = TRUE;
-      mMaxAddress                     = LoggerInfo->LogBuffer + LoggerInfo->LogBufferSize;
-      mBufferSize                     = LoggerInfo->LogBufferSize;
+      if (LoggerInfo->HdwPortInitialized == FALSE) {
+        AdvancedLoggerHdwPortInitialize ();
+        LoggerInfo->HdwPortInitialized = TRUE;
+      }
+      mMaxAddress = LoggerInfo->LogBuffer + LoggerInfo->LogBufferSize;
+      mBufferSize = LoggerInfo->LogBufferSize;
     } else {
       DEBUG ((DEBUG_ERROR, "%a: Error allocating Advanced Logger Buffer\n", __FUNCTION__));
     }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -388,6 +388,7 @@ DxeCoreAdvancedLoggerLibConstructor (
         AdvancedLoggerHdwPortInitialize ();
         LoggerInfo->HdwPortInitialized = TRUE;
       }
+
       mMaxAddress = LoggerInfo->LogBuffer + LoggerInfo->LogBufferSize;
       mBufferSize = LoggerInfo->LogBufferSize;
     } else {

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -384,8 +384,10 @@ DxeCoreAdvancedLoggerLibConstructor (
       LoggerInfo->LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
       LoggerInfo->LogCurrent    = LoggerInfo->LogBuffer;
       LoggerInfo->HwPrintLevel  = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-      mMaxAddress               = LoggerInfo->LogBuffer + LoggerInfo->LogBufferSize;
-      mBufferSize               = LoggerInfo->LogBufferSize;
+      AdvancedLoggerHdwPortInitialize ();
+      mLoggerInfo->HdwPortInitialized = TRUE;
+      mMaxAddress                     = LoggerInfo->LogBuffer + LoggerInfo->LogBufferSize;
+      mBufferSize                     = LoggerInfo->LogBufferSize;
     } else {
       DEBUG ((DEBUG_ERROR, "%a: Error allocating Advanced Logger Buffer\n", __FUNCTION__));
     }


### PR DESCRIPTION
## Description

This change adds a call to AdvancedLoggerHdwPortInitialize() when the advanced logger is created in the DxeCoreAdvancedLoggerLibConstructor(). Previously, hardware port was only initalized in AdvancedLoggerGetInfo() if the logging info structure was present at a fixed location or in a HOB; this would cause writes to the hardware port to potentially fail in the path where the logger is not initialized until the Constructor is called. 

- [x] Impacts functionality?
  - AdvancedLoggerHdwPortInitialize() is now called in the DxeCoreAdvancedLoggerLibConstructor if the logger is instantiated there.
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified on a platform where this was not working due to missing HdwPort initialization; verified after this patch that it works as expected. 

## Integration Instructions

N/A
