### PR TITLE
Switch MmCoreArm advanced logger to use updated MMU functions

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -15,7 +15,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/SynchronizationLib.h>
-#include <Library/ArmMmuLib.h>
+#include <Library/MmuLib.h>
 
 #include "../AdvancedLoggerCommon.h"
 
@@ -114,20 +114,16 @@ AdvancedLoggerGetLoggerInfo (
     // If this is the first time for MM core to get here, the memory attributes of this module
     // may not be fully set yet. Thus set the memory for global variables attributes to RW first.
     Address = ALIGN_VALUE ((EFI_PHYSICAL_ADDRESS)(UINTN)&mInitialized - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
-    Status  = ArmSetMemoryAttributes (
-                Address,
-                EFI_PAGE_SIZE,
-                EFI_MEMORY_XP,
-                EFI_MEMORY_ACCESS_MASK
-                );
+    Status  = MmuSetAttributes (Address, EFI_PAGE_SIZE, EFI_MEMORY_XP);
+    ASSERT_EFI_ERROR (Status);
+    Status = MmuClearAttributes (Address, EFI_PAGE_SIZE, EFI_MEMORY_RO);
+    ASSERT_EFI_ERROR (Status);
 
     Address = ALIGN_VALUE ((EFI_PHYSICAL_ADDRESS)(UINTN)&mLoggerInfo - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
-    Status  = ArmSetMemoryAttributes (
-                Address,
-                EFI_PAGE_SIZE,
-                EFI_MEMORY_XP,
-                EFI_MEMORY_ACCESS_MASK
-                );
+    Status  = MmuSetAttributes (Address, EFI_PAGE_SIZE, EFI_MEMORY_XP);
+    ASSERT_EFI_ERROR (Status);
+    Status = MmuClearAttributes (Address, EFI_PAGE_SIZE, EFI_MEMORY_RO);
+    ASSERT_EFI_ERROR (Status);
 
     mInitialized = TRUE;            // Only allow initialization once
     mLoggerInfo  = (ADVANCED_LOGGER_INFO *)(VOID *)FixedPcdGet64 (PcdAdvancedLoggerBase);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -114,12 +114,20 @@ AdvancedLoggerGetLoggerInfo (
     // If this is the first time for MM core to get here, the memory attributes of this module
     // may not be fully set yet. Thus set the memory for global variables attributes to RW first.
     Address = ALIGN_VALUE ((EFI_PHYSICAL_ADDRESS)(UINTN)&mInitialized - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
-    Status  = ArmSetMemoryRegionNoExec (Address, EFI_PAGE_SIZE);
-    Status  = ArmClearMemoryRegionReadOnly (Address, EFI_PAGE_SIZE);
+    Status  = ArmSetMemoryAttributes (
+                Address,
+                EFI_PAGE_SIZE,
+                EFI_MEMORY_XP,
+                EFI_MEMORY_ACCESS_MASK
+                );
 
     Address = ALIGN_VALUE ((EFI_PHYSICAL_ADDRESS)(UINTN)&mLoggerInfo - EFI_PAGE_SIZE + 1, EFI_PAGE_SIZE);
-    Status  = ArmSetMemoryRegionNoExec (Address, EFI_PAGE_SIZE);
-    Status  = ArmClearMemoryRegionReadOnly (Address, EFI_PAGE_SIZE);
+    Status  = ArmSetMemoryAttributes (
+                Address,
+                EFI_PAGE_SIZE,
+                EFI_MEMORY_XP,
+                EFI_MEMORY_ACCESS_MASK
+                );
 
     mInitialized = TRUE;            // Only allow initialization once
     mLoggerInfo  = (ADVANCED_LOGGER_INFO *)(VOID *)FixedPcdGet64 (PcdAdvancedLoggerBase);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
@@ -36,7 +36,7 @@
   BaseMemoryLib
   DebugLib
   SynchronizationLib
-  ArmMmuLib
+  MmuLib
 
 [Guids]
   gAdvancedLoggerHobGuid


### PR DESCRIPTION
## Description

As part of 202311, ArmMmuLib switched to use ArmSetMemoryAttributes instead of the individual set/clear routines. This was also implemented in the MU change to converge ArmMmuStandaloneMmLib's use with ArmMmuLib. This changed fixes MmCoreArm/AdvancedLoggerLib.c to use the updated functions. 

It seems this went unnoticed originally due to issue #434 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually tested.

## Integration Instructions

N/A