### PR TITLE
remove edk2-basetools

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -6,15 +6,13 @@
 import glob
 import os
 import logging
-import sys
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
-from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
+from edk2toolext.invocables.edk2_setup import SetupSettingsManager
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
-from pathlib import Path
 
 from edk2toolext import codeql as codeql_helpers
 

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -26,18 +26,12 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         self.ActualArchitectures = []
         self.ActualToolChainTag = ""
         self.ActualScopes = None
-        # In tree BaseTools are required for Rust build support so enable
-        # it by default.
-        self.UseBuiltInBaseTools = False
 
     # ####################################################################################### #
     #                             Extra CmdLine configuration                                 #
     # ####################################################################################### #
 
     def AddCommandLineOptions(self, parserObj):
-        group = parserObj.add_mutually_exclusive_group()
-        group.add_argument("-force_piptools", "--fpt", dest="force_piptools", action="store_true", default=False, help="Force the system to use pip tools")
-
         try:
             codeql_helpers.add_command_line_option(parserObj)
         except NameError:
@@ -45,10 +39,6 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
 
     def RetrieveCommandLineOptions(self, args):
         super().RetrieveCommandLineOptions(args)
-
-        if args.force_piptools:
-            self.UseBuiltInBaseTools = True
-
         try:
             self.codeql = codeql_helpers.is_codeql_enabled_on_command_line(args)
         except NameError:
@@ -148,12 +138,6 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue("TOOL_CHAIN_TAG", "")
 
             is_linux = GetHostInfo().os.upper() == "LINUX"
-
-            if self.UseBuiltInBaseTools == True:
-                scopes += ('pipbuild-unix',) if is_linux else ('pipbuild-win',)
-                logging.warning("Using Pip Tools based BaseTools")
-            else:
-                logging.info("Using in-tree BaseTools")
 
             if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
                 if "AARCH64" in self.ActualArchitectures:

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,7 +14,6 @@
 
 edk2-pytool-library==0.21.2
 edk2-pytool-extensions==0.27.2
-edk2-basetools==0.1.29
 antlr4-python3-runtime==4.13.1
 regex==2023.12.25
 pygount==1.6.1


### PR DESCRIPTION
## Description

Removes edk2-basetools from pip-requirements.txt and any usage of it in the CISettings.py. The is done as there are changes in the build tools python source code that are available locally in BaseTools (as it is managed by Project Mu) that is not available in edk2-basetools.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the build system continues to use the local python source

## Integration Instructions

N/A - only effects this repository's CI system.
