### PR TITLE
Enable Pre-DXE Logs for Platforms Which Can't use Pre-DXE AdvancedLoggerLib Instances

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -50,6 +50,13 @@
   #
   gAdvancedFileLoggerPolicyGuid = { 0x6c3fd4f1, 0xb596, 0x438e, { 0x8a, 0xb8, 0x53, 0xf1, 0xc, 0x9c, 0x27, 0x74 } }
 
+  ## GUID for specifying Advanced logger pre-DXE logs
+  # Platforms which don't use a Pre-DXE AdvancedLoggerLib instance but still produce logging
+  # can use this GUID to publish the location of the logs so they can be written to the advanced
+  # logger buffer created in early DXE.
+  #
+  gAdvancedLoggerPreDxeLogsGuid = { 0x751fc006, 0x5804, 0x440d, { 0x8b, 0x15, 0x61, 0x8c, 0xf6, 0x56, 0xae, 0x76 } }
+
 [Ppis]
   ## Advanced Logger Ppi - Communication from PEIM to PEI_CORE library implementation
   #

--- a/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
+++ b/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
@@ -7,9 +7,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
-#define __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
+#ifndef ADVANCED_LOGGER_PRE_DXE_LOGS_H_
+#define ADVANCED_LOGGER_PRE_DXE_LOGS_H_
 
+#pragma pack(1)
 // The region specified by this HOB entry should contain raw log output.
 // The Advanced Logger library will serialize the contents of the buffer
 // when adding it to the advanced logger output.
@@ -18,6 +19,7 @@ typedef struct _ADVANCED_LOGGER_PRE_DXE_LOGS_HOB {
   UINT64    BaseAddress;
   UINT64    LengthInBytes;
 } ADVANCED_LOGGER_PRE_DXE_LOGS_HOB;
+#pragma pack()
 
 #define ADVANCED_LOGGER_PRE_DXE_LOGS_GUID \
 { \

--- a/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
+++ b/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
@@ -1,0 +1,28 @@
+/** @file
+  This file defines GUIDs and data structure for producing HOB entry describing
+  the location of pre-DXE logs. For platforms which use a Pre-DXE AdvancedLoggerLib
+  implementation, this HOB is not necessary.
+
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
+#define __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
+
+typedef struct _ADVANCED_LOGGER_PRE_DXE_LOGS_HOB {
+  UINT32    Signature;
+  UINT64    BaseAddress;
+  UINT64    LengthInBytes;
+} ADVANCED_LOGGER_PRE_DXE_LOGS_HOB;
+
+#define ADVANCED_LOGGER_PRE_DXE_LOGS_GUID \
+{ \
+  0x751fc006, 0x5804, 0x440d, { 0x8b, 0x15, 0x61, 0x8c, 0xf6, 0x56, 0xae, 0x76 } \
+}
+
+extern EFI_GUID  gAdvancedLoggerPreDxeLogsGuid;
+
+#define ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE  SIGNATURE_32 ('A', 'L', 'P', 'D')
+
+#endif

--- a/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
+++ b/AdvLoggerPkg/Include/Guid/AdvancedLoggerPreDxeLogs.h
@@ -10,6 +10,9 @@
 #ifndef __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
 #define __ADVANCED_LOGGER_PRE_DXE_LOGS_H__
 
+// The region specified by this HOB entry should contain raw log output.
+// The Advanced Logger library will serialize the contents of the buffer
+// when adding it to the advanced logger output.
 typedef struct _ADVANCED_LOGGER_PRE_DXE_LOGS_HOB {
   UINT32    Signature;
   UINT64    BaseAddress;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -31,7 +31,6 @@
   @retval LoggerInfo       Returns the logger info block. Returns NULL if it cannot
                            be located. This occurs prior to SEC completion.
 **/
-STATIC
 ADVANCED_LOGGER_INFO *
 EFIAPI
 AdvancedLoggerMemoryLoggerWrite (

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -58,4 +58,24 @@ AdvancedLoggerGetPhase (
   VOID
   );
 
+/**
+  Write data from buffer into the in memory logging buffer.
+
+  Writes NumberOfBytes data bytes from Buffer to the logging buffer.
+
+  @param  DebugLevel       Debug level of the message
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to be written to the Advanced Logger log.
+
+  @retval LoggerInfo       Returns the logger info block. Returns NULL if it cannot
+                           be located. This occurs prior to SEC completion.
+**/
+ADVANCED_LOGGER_INFO *
+EFIAPI
+AdvancedLoggerMemoryLoggerWrite (
+  IN       UINTN  DebugLevel,
+  IN CONST CHAR8  *Buffer,
+  IN       UINTN  NumberOfBytes
+  );
+
 #endif // __ADVANCED_LOGGER_COMMON_H__

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -368,7 +368,7 @@ DxeCoreAdvancedLoggerLibConstructor (
 {
   ADVANCED_LOGGER_INFO              *LoggerInfo;
   EFI_STATUS                        Status;
-  ADVANCED_LOGGER_PRE_DXE_LOGS_HOB  PreDxeLogs;
+  ADVANCED_LOGGER_PRE_DXE_LOGS_HOB  *PreDxeLogs;
   EFI_HOB_GUID_TYPE                 *PreDxeLogsHobEntry;
 
   LoggerInfo = AdvancedLoggerGetLoggerInfo ();      // Sets mLoggerInfo if Logger Information block found in HOB.
@@ -407,11 +407,11 @@ DxeCoreAdvancedLoggerLibConstructor (
     PreDxeLogsHobEntry = GetFirstGuidHob (&gAdvancedLoggerPreDxeLogsGuid);
 
     if (PreDxeLogsHobEntry != NULL) {
-      PreDxeLogs = *(ADVANCED_LOGGER_PRE_DXE_LOGS_HOB *)GET_GUID_HOB_DATA (PreDxeLogsHobEntry);
-      if (PreDxeLogs.Signature != ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE) {
-        ASSERT (PreDxeLogs.Signature == ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE);
+      PreDxeLogs = (ADVANCED_LOGGER_PRE_DXE_LOGS_HOB *)GET_GUID_HOB_DATA (PreDxeLogsHobEntry);
+      if (PreDxeLogs->Signature != ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE) {
+        ASSERT (PreDxeLogs->Signature == ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE);
       } else {
-        AdvancedLoggerMemoryLoggerWrite (DEBUG_INFO, (CONST CHAR8 *)(UINTN)PreDxeLogs.BaseAddress, PreDxeLogs.LengthInBytes);
+        AdvancedLoggerMemoryLoggerWrite (DEBUG_INFO, (CONST CHAR8 *)(UINTN)PreDxeLogs->BaseAddress, PreDxeLogs->LengthInBytes);
       }
     }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -11,6 +11,7 @@
 #include <AdvancedLoggerInternal.h>
 
 #include <Protocol/AdvancedLogger.h>
+#include <Guid/AdvancedLoggerPreDxeLogs.h>
 #include <Protocol/VariablePolicy.h>
 #include <AdvancedLoggerInternalProtocol.h>
 
@@ -365,8 +366,10 @@ DxeCoreAdvancedLoggerLibConstructor (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  ADVANCED_LOGGER_INFO  *LoggerInfo;
-  EFI_STATUS            Status;
+  ADVANCED_LOGGER_INFO              *LoggerInfo;
+  EFI_STATUS                        Status;
+  ADVANCED_LOGGER_PRE_DXE_LOGS_HOB  PreDxeLogs;
+  EFI_HOB_GUID_TYPE                 *PreDxeLogsHobEntry;
 
   LoggerInfo = AdvancedLoggerGetLoggerInfo ();      // Sets mLoggerInfo if Logger Information block found in HOB.
 
@@ -400,12 +403,24 @@ DxeCoreAdvancedLoggerLibConstructor (
   if (LoggerInfo != NULL) {
     mAdvLoggerProtocol.LoggerInfo = LoggerInfo;
     mLoggerInfo->TimerFrequency   = GetPerformanceCounterProperties (NULL, NULL);
-    Status                        = SystemTable->BootServices->InstallProtocolInterface (
-                                                                 &ImageHandle,
-                                                                 &gAdvancedLoggerProtocolGuid,
-                                                                 EFI_NATIVE_INTERFACE,
-                                                                 &mAdvLoggerProtocol.AdvLoggerProtocol
-                                                                 );
+
+    PreDxeLogsHobEntry = GetFirstGuidHob (&gAdvancedLoggerPreDxeLogsGuid);
+
+    if (PreDxeLogsHobEntry != NULL) {
+      PreDxeLogs = *(ADVANCED_LOGGER_PRE_DXE_LOGS_HOB *)GET_GUID_HOB_DATA (PreDxeLogsHobEntry);
+      if (PreDxeLogs.Signature != ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE) {
+        ASSERT (PreDxeLogs.Signature == ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE);
+      } else {
+        AdvancedLoggerMemoryLoggerWrite (DEBUG_INFO, (CONST CHAR8 *)(UINTN)PreDxeLogs.BaseAddress, PreDxeLogs.LengthInBytes);
+      }
+    }
+
+    Status = SystemTable->BootServices->InstallProtocolInterface (
+                                          &ImageHandle,
+                                          &gAdvancedLoggerProtocolGuid,
+                                          EFI_NATIVE_INTERFACE,
+                                          &mAdvLoggerProtocol.AdvLoggerProtocol
+                                          );
 
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Error installing protocol - %r\n", __FUNCTION__, Status));

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -46,6 +46,7 @@
 [Guids]
   gAdvancedLoggerHobGuid
   gEfiEndOfDxeEventGroupGuid
+  gAdvancedLoggerPreDxeLogsGuid
 
 [Protocols]
   gAdvancedLoggerProtocolGuid                                               ## PRODUCES


### PR DESCRIPTION
## Description

Create a new guid and HOB entry definition for specifying a pre-DXE log buffer on platforms which can't use a pre-DXE AdvancedLoggerLib instance. After the advanced logger info buffer is created, the DxeCore AdvancedLoggerLib constructor will search for the guided HOB and, if found, write the contents of the buffer specified by the entry to the advanced logger buffer.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by creating the HOB and verifying that the DxeCore constructor located it.

## Integration Instructions

N/A
