### PR TITLE
MsWheaPkg: Add EFIAPI to relevant functions [Rebase & FF]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -159,17 +159,23 @@ jobs:
         import requests
 
         GITHUB_REPO = "sagiegurari/cargo-make"
-        API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.9"
 
-        # Default value in case getting latest fails, cache will fall
-        # back on this version.
-        latest_cargo_make_version = "0.36.13"
-        response = requests.get(API_URL)
+        response = requests.get(api_url)
+        if response.status_code == 200:
+          build_release_id = response.json()["id"]
+        else:
+          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          sys.exit(1)
 
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
+
+        response = requests.get(api_url)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get latest cargo-make version!")
+          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'
 

--- a/MsWheaPkg/MsWheaReport/Pei/MsWheaReportPei.c
+++ b/MsWheaPkg/MsWheaReport/Pei/MsWheaReportPei.c
@@ -31,6 +31,7 @@ Handler function that validates input arguments, and create a hob list entry for
 **/
 STATIC
 EFI_STATUS
+EFIAPI
 MsWheaReportHandlerPei (
   IN MS_WHEA_ERROR_ENTRY_MD  *MsWheaEntryMD
   )
@@ -95,6 +96,7 @@ for further processing.
 **/
 STATIC
 EFI_STATUS
+EFIAPI
 MsWheaRscHandlerPei (
   IN CONST EFI_PEI_SERVICES      **PeiServices,
   IN EFI_STATUS_CODE_TYPE        CodeType,


### PR DESCRIPTION
## Description

`MsWheaReportHandlerPei()` is passed to `ReportHwErrRecRouter()` for the
`MS_WHEA_ERR_REPORT_PS_FN` value where that is defined as:

```c
typedef
EFI_STATUS
(EFIAPI *MS_WHEA_ERR_REPORT_PS_FN)(
  IN MS_WHEA_ERROR_ENTRY_MD           *MsWheaEntryMD
  );
```

So, `MsWheaReportHandlerPei()` needs to include `EFIAPI` as well.

Similarly, `MsWheaRscHandlerPei()` needs `EFIAPI` due to the definition
of `EFI_PEI_RSC_HANDLER_CALLBACK`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified results from a GCC build that reported the issue before and after
  the change.

## Integration Instructions

N/A