### PR TITLE
[Cherry-pick] MfciPkg: Added information about the dependency on MuVarPolicyFoundationDxe

### DIFF
--- a/MfciPkg/Docs/Mfci_Integration_Guide.md
+++ b/MfciPkg/Docs/Mfci_Integration_Guide.md
@@ -94,6 +94,8 @@ When using `!include MfciPkg/MfciPkg.dsc.inc`, please ensure the platform pcds f
 
 * Variable Policy
   * Variable policy is used to protect MFCI's security data (UEFI variables) from malicious tampering
+* MsCorePkg's [MuVarPolicyFoundationDxe](../../MsCorePkg/MuVarPolicyFoundationDxe/Feature_MuVarPolicyFoundationDxe_Readme.md)
+  * Variable policy phase notification support is required to secure some of the MFCI variables.
 * EDK2's SecureBootVariableLib, specifically:
   * ```DeleteSecureBootVariables()```
 * EDK2's BaseCryptLib, specifically:


### PR DESCRIPTION
## Description

Mfci has a soft dependency on MuVarPolicyFoundationDxe. The phase based variables (Target\Manufacturer, Target\Product, Target\SerialNumber, Target\OEM_01 and Target\OEM_02) are locked using
RegisterVarStateVariablePolicy.

Adding documentation to explicitly call out the need for the MsCorePkg's MuVarPolicyFoundationDxe to enable phase based locking.

- [ ] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [ ] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran CI locally

## Integration Instructions

n/a
