### PR TITLE
Relax report length requirements

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/keyboard/mod.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/mod.rs
@@ -389,8 +389,8 @@ impl KeyboardHidHandler {
   fn initialize_keyboard_layout(&mut self) -> Result<(), efi::Status> {
     self.install_layout_change_event()?;
 
-    //signal event to pick up any existing layout
-    self.boot_services.signal_event(self.layout_change_event);
+    //fake signal event to pick up any existing layout
+    on_layout_update(self.layout_change_event, self.layout_context as *mut c_void);
 
     //install a default layout if no layout is installed.
     if self.key_queue.get_layout().is_none() {

--- a/HidPkg/UefiHidDxeV2/src/keyboard/mod.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/mod.rs
@@ -33,7 +33,7 @@ use crate::{
   keyboard::key_queue::OrdKeyData,
 };
 
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_WARN};
+use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
 
 // usages supported by this module
 const KEYBOARD_MODIFIER_USAGE_MIN: u32 = 0x000700E0;
@@ -555,7 +555,18 @@ impl HidReportReceiver for KeyboardHidHandler {
 
       if let Some(report_data) = self.input_reports.get(&report_id).cloned() {
         if report.len() != report_data.report_size {
-          break 'report_processing;
+          //Some devices report extra bytes in their reports. Warn about this, but try and process anyway.
+          debugln!(
+            DEBUG_VERBOSE,
+            "{:?}:{:?} unexpected report length for report_id: {:?}. expected {:?}, actual {:?}",
+            function!(),
+            line!(),
+            report_id,
+            report_data.report_size,
+            report.len()
+          );
+          debugln!(DEBUG_VERBOSE, "report: {:x?}", report);
+          //break 'report_processing;
         }
 
         //reset currently active keys to empty set.

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -461,6 +461,7 @@ mod test {
     boot_services.expect_create_event_ex().returning(|_, _, _, _, _, _| efi::Status::SUCCESS);
     boot_services.expect_signal_event().returning(|_| efi::Status::SUCCESS);
     boot_services.expect_open_protocol().returning(|_, _, _, _, _, _| efi::Status::NOT_FOUND);
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
 
     let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
@@ -586,6 +587,7 @@ mod test {
 
     // used in install
     boot_services.expect_create_event().returning(|_, _, _, _, _| efi::Status::SUCCESS);
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
     boot_services.expect_install_protocol_interface().returning(|_, protocol, _, interface| {
       if unsafe { *protocol } == protocols::simple_text_input::PROTOCOL_GUID {
         CONTEXT_PTR.store(interface, core::sync::atomic::Ordering::SeqCst);

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -599,6 +599,7 @@ mod test {
     boot_services.expect_create_event_ex().returning(|_, _, _, _, _, _| efi::Status::SUCCESS);
     boot_services.expect_signal_event().returning(|_| efi::Status::SUCCESS);
     boot_services.expect_open_protocol().returning(|_, _, _, _, _, _| efi::Status::NOT_FOUND);
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
 
     let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
@@ -742,6 +743,7 @@ mod test {
       CONTEXT_PTR.store(interface, core::sync::atomic::Ordering::SeqCst);
       efi::Status::SUCCESS
     });
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
 
     // used in set state
     boot_services.expect_raise_tpl().returning(|_| efi::TPL_APPLICATION);
@@ -827,6 +829,7 @@ mod test {
       CONTEXT_PTR.store(interface, core::sync::atomic::Ordering::SeqCst);
       efi::Status::SUCCESS
     });
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
 
     // used in read key stroke
     boot_services.expect_raise_tpl().returning(|_| efi::TPL_APPLICATION);
@@ -967,6 +970,8 @@ mod test {
       }
       efi::Status::SUCCESS
     });
+    boot_services.expect_locate_protocol().returning(|_, _, _| efi::Status::NOT_FOUND);
+
     boot_services.expect_create_event_ex().returning(|_, _, _, _, _, _| efi::Status::SUCCESS);
     boot_services.expect_raise_tpl().returning(|_| efi::TPL_APPLICATION);
     boot_services.expect_restore_tpl().returning(|_| ());

--- a/HidPkg/UefiHidDxeV2/src/pointer/mod.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/mod.rs
@@ -600,7 +600,7 @@ mod test {
   }
 
   #[test]
-  fn bad_reports_should_be_ignored() {
+  fn bad_reports_should_be_processed_with_best_effort() {
     let boot_services = create_fake_static_boot_service();
     static mut ABS_PTR_INTERFACE: *mut c_void = core::ptr::null_mut();
 
@@ -661,19 +661,19 @@ mod test {
     pointer_handler.receive_report(report, &hid_io);
 
     assert_eq!(pointer_handler.current_state.active_buttons, 0);
-    assert_eq!(pointer_handler.current_state.current_x, CENTER);
-    assert_eq!(pointer_handler.current_state.current_y, CENTER);
-    assert_eq!(pointer_handler.current_state.current_z, 0);
-    assert_eq!(pointer_handler.state_changed, false);
+    assert_eq!(pointer_handler.current_state.current_x, 0);
+    assert_eq!(pointer_handler.current_state.current_y, 4);
+    assert_eq!(pointer_handler.current_state.current_z, 4);
+    assert_eq!(pointer_handler.state_changed, true);
 
     //report too short
     let report: &[u8] = &[0x00, 0x10, 0x00, 0x10, 0x00, 0x10];
     pointer_handler.receive_report(report, &hid_io);
 
     assert_eq!(pointer_handler.current_state.active_buttons, 0);
-    assert_eq!(pointer_handler.current_state.current_x, CENTER);
-    assert_eq!(pointer_handler.current_state.current_y, CENTER);
-    assert_eq!(pointer_handler.current_state.current_z, 0);
-    assert_eq!(pointer_handler.state_changed, false);
+    assert_eq!(pointer_handler.current_state.current_x, 4);
+    assert_eq!(pointer_handler.current_state.current_y, 4);
+    assert_eq!(pointer_handler.current_state.current_z, 4);
+    assert_eq!(pointer_handler.state_changed, true);
   }
 }

--- a/HidPkg/UefiHidDxeV2/src/pointer/mod.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/mod.rs
@@ -21,7 +21,7 @@ use hidparser::{
 };
 use r_efi::{efi, protocols};
 
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE};
 
 use crate::{
   boot_services::UefiBootServices,
@@ -262,7 +262,18 @@ impl HidReportReceiver for PointerHidHandler {
 
       if let Some(report_data) = self.input_reports.get(&report_id).cloned() {
         if report.len() != report_data.report_size {
-          break 'report_processing;
+          //Some devices report extra bytes in their reports. Warn about this, but try and process anyway.
+          debugln!(
+            DEBUG_VERBOSE,
+            "{:?}:{:?} unexpected report length for report_id: {:?}. expected {:?}, actual {:?}",
+            function!(),
+            line!(),
+            report_id,
+            report_data.report_size,
+            report.len()
+          );
+          debugln!(DEBUG_VERBOSE, "report: {:x?}", report);
+          //break 'report_processing;
         }
 
         // hand the report data to the handler for each relevant field for field-specific processing.


### PR DESCRIPTION
## Description

This PR brings in two fixes to support a wider variety of devices, some of which might not be completely self-consistent:
* Allow report lengths that don't match the report descriptor. Reports that are shorter than the Report Descriptor specifies will be processed for whatever fields are fully present. Reports that are longer than the Report descriptor specifies will simply ignore the extra bytes in the report.
* Move away from using `signal_event` to force keyboard layout initialization, and install call the layout change routine directly. This avoids introducing sequencing issues based on the TPL that the keyboard is being initialized at, resulting in more deterministic behavior.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Rust unit tests updated to cover new functionality all pass. Functional testing on hardware with the changes also passes.

## Integration Instructions

N/A
