### PR TITLE
When recovering Pei buffer from hob list, need to fix internal pointe…

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -484,6 +484,9 @@ AdvancedLoggerGetLoggerInfo (
       (PEI_CORE_INSTANCE_FROM_PS_THIS (PeiServices))->PlatformBlob = PA_FROM_PTR (LoggerInfo);
       LogPtr->LogBuffer                                            = PA_FROM_PTR (LoggerInfo);
 
+      LoggerInfo->LogCurrent = PA_FROM_PTR (LoggerInfo + 1) + LoggerInfo->LogCurrent - LoggerInfo->LogBuffer;
+      LoggerInfo->LogBuffer  = PA_FROM_PTR (LoggerInfo + 1);
+
       // return the pointer
       return LoggerInfo;
     }


### PR DESCRIPTION
## Description

For the case where advanced logger starts in the PeiCore (through a memory allocation hob in CAR) when attempting to recover the log buffer from the hob list after peicore and transitioned everything to physical ram, the internal pointers in the log buffer also need to be updated to point to the start of the log buffer and the next available log buffer entry.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a platform where logging starts at peicore into a CAR Hob.
Platform uses gEfiTemporaryRamDonePpiGuid to tear down CAR prior to gEfiPeiMemoryDiscoveredPpiGuid being notified to allow the debugger to switch over to physical ram.

## Integration Instructions

N/A