### PR TITLE
Improve robustness of XmlTreeLib

### DIFF
--- a/XmlSupportPkg/Library/XmlTreeLib/XmlTreeLib.c
+++ b/XmlSupportPkg/Library/XmlTreeLib/XmlTreeLib.c
@@ -877,14 +877,15 @@ BuildNodeList (
     //
     Status = RtlXmlNextToken (&State, &Next, FALSE);
     if (EFI_ERROR (Status)) {
-      DEBUG ((EFI_D_ERROR, "Failed to get the next token, Status = 0x%x\n", Status));
+      DEBUG ((EFI_D_ERROR, "Failed to get the next token, Status = %r\n", Status)); // MS_CHANGE
       goto Exit;
     } else if (Next.fError) {
       //
       // Errors in parse, such as bad characters, come out here in the
       // fError member
       //
-      DEBUG ((EFI_D_ERROR, "Error during tokenization, Status = 0x%x\n", Next.fError));
+      DEBUG ((EFI_D_ERROR, "Error during tokenization, Next.fError = %d\n", Next.fError)); // MS_CHANGE
+      Status = EFI_ABORTED;                                                                // MS_CHANGE
       goto Exit;
     }
 
@@ -1071,7 +1072,7 @@ BuildNodeList (
       //
       Status = AddAttributeToNode (CurrentNode, AttributeName, AttributeValue);
       if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "ERROR:  AddAttributeToNode() failed, Status = 0x%x\n", Status));
+        DEBUG ((EFI_D_ERROR, "ERROR:  AddAttributeToNode() failed, Status = %r\n", Status));  // MS_CHANGE
         goto Exit;
       }
     } else if (Next.State == XTSS_ENDELEMENT_NAME) {
@@ -1105,6 +1106,20 @@ BuildNodeList (
       //
       if (CurrentNode) {
         CurrentNode = CurrentNode->ParentNode;
+        // MS_CHANGE  [begin]
+        //
+        // Topmost node, ignore tailing characters
+        //
+        // DONE-CCC:
+        //   See also,  TODO-AAA and TODO-BBB in `xml_fasterxml.c`
+        //
+        DEBUG ((DEBUG_VERBOSE, "New CurrentNode, %p\n", CurrentNode));
+        if (CurrentNode == NULL) {
+          DEBUG ((DEBUG_VERBOSE, "At the end of the Root node\n"));
+          break;
+        }
+
+        // MS_CHANGE  [end]
       }
     } else if (Next.State == XTSS_ELEMENT_CLOSE_EMPTY) {
       DEBUG ((DEBUG_VERBOSE, "XTSS_ELEMENT_CLOSE_EMPTY, empty close\n"));
@@ -1115,6 +1130,19 @@ BuildNodeList (
       //
       if (CurrentNode) {
         CurrentNode = CurrentNode->ParentNode;
+        DEBUG ((DEBUG_VERBOSE, "New CurrentNode, %p\n", CurrentNode));
+
+        // MS_CHANGE  [begin]
+        //
+        // DONE-CCC-2:
+        //
+        DEBUG ((DEBUG_VERBOSE, "New CurrentNode, %p\n", CurrentNode));
+        if (CurrentNode == NULL) {
+          DEBUG ((DEBUG_VERBOSE, "At the end of the Root node\n"));
+          break;
+        }
+
+        // MS_CHANGE  [end]
       }
     }
 

--- a/XmlSupportPkg/Library/XmlTreeLib/fasterxml/xml_fasterxml.c
+++ b/XmlSupportPkg/Library/XmlTreeLib/fasterxml/xml_fasterxml.c
@@ -2700,6 +2700,22 @@ RtlXmlNextToken (
         pToken->fError = TRUE;
         return success;
       }
+      // MS_CHANGE
+      //
+      // TODO-BBB:  See TODO-AAA
+      //
+      // if (pRawToken->TokenName == NTXML_RAWTOKEN_ERROR) {
+      //   pToken->fError = TRUE;
+      //   success = EFI_ABORTED;
+      //   return success;
+      // }
+      //
+      // Why TODO?
+      //   If we turn on this, we will be endless on other place..
+      //
+      // Work around?
+      //   See DONE-CCC in `XmlTreeLib.c`
+      //
 
       cbTotalTokenLength = pRawToken->Run.cbData;
 
@@ -2945,6 +2961,14 @@ RtlXmlNextToken (
                     );
 
         cbTotalTokenLength = pRawToken->Run.cbData;
+
+        // MS_CHANGE
+        //
+        // TODO-AAA: 
+        //  if we encounter a NTXML_RAWTOKEN_ERROR, 
+        //    we will run into endless XTSS_STREAM_HYPERSPACE
+        //
+        // DEBUG ((DEBUG_VERBOSE, "pRawToken->TokenName = %d\n", pRawToken->TokenName));
 
         NextState = XTSS_STREAM_HYPERSPACE;
       }

--- a/XmlSupportPkg/Test/UnitTest/XmlTreeLib/TestData.h
+++ b/XmlSupportPkg/Test/UnitTest/XmlTreeLib/TestData.h
@@ -42,6 +42,29 @@ typedef struct {
   XmlNode        *Node;
 } XmlTestContext;
 
+CONST CHAR8  VerySimpleElementsOnly1[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode>"
+  "</RootNode>";
+
+CONST CHAR8  VerySimpleElementsOnly2[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode/>";
+
+CONST CHAR8  VerySimpleElementsOnly3[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode>"
+  "</RootNode>\r\n\xcd\xcd";
+
+CONST CHAR8  VerySimpleElementsOnly4[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode/>\r\n\xcd\xcd";
+
+XmlTestContext  VerySimpleElementsOnly1Context = { 1, 0, 1, 0, VerySimpleElementsOnly1, NULL, NULL };
+XmlTestContext  VerySimpleElementsOnly2Context = { 1, 0, 1, 0, VerySimpleElementsOnly2, NULL, NULL };
+XmlTestContext  VerySimpleElementsOnly3Context = { 1, 0, 1, 0, VerySimpleElementsOnly3, NULL, NULL };
+XmlTestContext  VerySimpleElementsOnly4Context = { 1, 0, 1, 0, VerySimpleElementsOnly4, NULL, NULL };
+
 CONST CHAR8  SimpleElementsOnly[] =
   "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
   "<RootNode>"

--- a/XmlSupportPkg/Test/UnitTest/XmlTreeLib/TestData.h
+++ b/XmlSupportPkg/Test/UnitTest/XmlTreeLib/TestData.h
@@ -45,6 +45,7 @@ typedef struct {
 CONST CHAR8  VerySimpleElementsOnly1[] =
   "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
   "<RootNode>"
+  "abcd-1"
   "</RootNode>";
 
 CONST CHAR8  VerySimpleElementsOnly2[] =
@@ -54,16 +55,33 @@ CONST CHAR8  VerySimpleElementsOnly2[] =
 CONST CHAR8  VerySimpleElementsOnly3[] =
   "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
   "<RootNode>"
+  "abcd-3"
   "</RootNode>\r\n\xcd\xcd";
 
 CONST CHAR8  VerySimpleElementsOnly4[] =
   "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
   "<RootNode/>\r\n\xcd\xcd";
 
+CONST CHAR8  VerySimpleElementsOnly5[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode>"
+  "abcd-5"
+  "</RootNode>"
+  "<RootNode2>"
+  "xyz-5"
+  "</RootNode2>";
+
+CONST CHAR8  VerySimpleElementsOnly6[] =
+  "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+  "<RootNode/>"
+  "<RootNode2/>";
+
 XmlTestContext  VerySimpleElementsOnly1Context = { 1, 0, 1, 0, VerySimpleElementsOnly1, NULL, NULL };
 XmlTestContext  VerySimpleElementsOnly2Context = { 1, 0, 1, 0, VerySimpleElementsOnly2, NULL, NULL };
 XmlTestContext  VerySimpleElementsOnly3Context = { 1, 0, 1, 0, VerySimpleElementsOnly3, NULL, NULL };
 XmlTestContext  VerySimpleElementsOnly4Context = { 1, 0, 1, 0, VerySimpleElementsOnly4, NULL, NULL };
+XmlTestContext  VerySimpleElementsOnly5Context = { 1, 0, 1, 0, VerySimpleElementsOnly5, NULL, NULL };
+XmlTestContext  VerySimpleElementsOnly6Context = { 1, 0, 1, 0, VerySimpleElementsOnly6, NULL, NULL };
 
 CONST CHAR8  SimpleElementsOnly[] =
   "<?xml version=\"1.0\" encoding=\"utf-8\"?>"

--- a/XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTests.c
+++ b/XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTests.c
@@ -521,6 +521,10 @@ UnitTestingEntry (
     goto EXIT;
   }
 
+  AddTestCase (InputTestSuite, "Parse Valid XML with a very simple root", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly1Context);
+  AddTestCase (InputTestSuite, "Parse Valid XML with a very simple empty tag root", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly2Context);
+  AddTestCase (InputTestSuite, "Parse Valid XML with a very simple root, tailing with uninitialized memory", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly3Context);
+  AddTestCase (InputTestSuite, "Parse Valid XML with a very simple empty tag root, tailing with uninitialized memory", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly4Context);
   AddTestCase (InputTestSuite, "Parse Valid XML with simple elements 3 layers", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &SimpleElementsOnlyContext);
   AddTestCase (InputTestSuite, "Parse Valid XML with 2 elements and 2 attributes", "ValidElementsAndAttributes", ParseValidXml, NULL, CleanUpXmlTestContext, &SimpleElementsAttributesContext);
   AddTestCase (InputTestSuite, "Parse Invalid XML string containing an attribute with invalid xml chars", "NonXmlEncodedAttribute", ParseValidXml, NULL, CleanUpXmlTestContext, &NonEncodedXmlAttribute1Context);

--- a/XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTests.c
+++ b/XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTests.c
@@ -525,6 +525,9 @@ UnitTestingEntry (
   AddTestCase (InputTestSuite, "Parse Valid XML with a very simple empty tag root", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly2Context);
   AddTestCase (InputTestSuite, "Parse Valid XML with a very simple root, tailing with uninitialized memory", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly3Context);
   AddTestCase (InputTestSuite, "Parse Valid XML with a very simple empty tag root, tailing with uninitialized memory", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly4Context);
+  AddTestCase (InputTestSuite, "Parse Valid XML with two very simple roots, report only first root", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly5Context);
+  AddTestCase (InputTestSuite, "Parse Valid XML with two very simple empty tag roots, report only first root", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &VerySimpleElementsOnly6Context);
+
   AddTestCase (InputTestSuite, "Parse Valid XML with simple elements 3 layers", "ValidElements", ParseValidXml, NULL, CleanUpXmlTestContext, &SimpleElementsOnlyContext);
   AddTestCase (InputTestSuite, "Parse Valid XML with 2 elements and 2 attributes", "ValidElementsAndAttributes", ParseValidXml, NULL, CleanUpXmlTestContext, &SimpleElementsAttributesContext);
   AddTestCase (InputTestSuite, "Parse Invalid XML string containing an attribute with invalid xml chars", "NonXmlEncodedAttribute", ParseValidXml, NULL, CleanUpXmlTestContext, &NonEncodedXmlAttribute1Context);


### PR DESCRIPTION
## Description

Improve robustness of XmlTreeLib for handling tailing invalid (?) characters.

Current XmlTreeLib will run into **endless loop** if there are some non-whitespace chars after root node. Take `malloc()` on Windows as an example, the memory will be initialized to `0xcd` on debug build. If we put data on this buffer without a proper ending char (null), the `CreateXmlTree()` call will **never return** on this buffer. 

**This is strange.** A better parser lib should (a) report this as an error or (2) stop parsing at the place. 

This PR will stop parsing after _first_ Root node was parsed, discarding any characters after it. As a side effect,  if we have more than one root, only the first root will be reported. This is reasonable, since XML allows only one root node.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ X] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Added test cases and passed unit test on host test.

## Integration Instructions

None.