### PR TITLE
[REBASE && FF] Documentation Updates to Paging Audit

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/Driver/DxePagingAuditDriver.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/Driver/DxePagingAuditDriver.c
@@ -53,7 +53,7 @@ PagingAuditDriverEntryPoint (
                   TPL_CALLBACK,
                   DumpPagingInfoEvent,
                   NULL,
-                  &gMuEventPreExitBootServicesGuid,
+                  &gEfiEventBeforeExitBootServicesGuid,
                   &Event
                   );
   DEBUG ((DEBUG_ERROR, "%a leave - %r\n", __FUNCTION__, Status));

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
@@ -58,7 +58,7 @@
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID
   gEfiMemoryAttributesTableGuid
-  gMuEventPreExitBootServicesGuid
+  gEfiEventBeforeExitBootServicesGuid
   gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
 
 [Protocols]


### PR DESCRIPTION
This PR updates the documentation of the SMM and DXE paging audits to reflect recent changes and describe usage.

This PR also removes the AllocatedPagesAndPoolsAreProtected test because it is not required according to the Enhanced Memory Protection spec and a similar test is run in the DxeMemoryProtectionTestApp. The NullCheck test is renamed to better reflect purpose.