### PR TITLE
Put log entries into HOBs in PEI during log buffer initialization

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -57,6 +57,16 @@
   #
   gAdvancedLoggerPreDxeLogsGuid = { 0x751fc006, 0x5804, 0x440d, { 0x8b, 0x15, 0x61, 0x8c, 0xf6, 0x56, 0xae, 0x76 } }
 
+  ## GUID for specifying Advanced logger interim hob, which is used to indicate whether the logger in the
+  # interim phase of logger buffer being initialized.
+  #
+  gAdvancedLoggerInterimHobGuid = { 0x36587034, 0xfcde, 0x45b4, { 0x9a, 0x2b, 0xd5, 0xc4, 0xc1, 0x39, 0x96, 0x5a } }
+
+  ## GUID for specifying Advanced logger interim buffer hob, which is used to carry interim log entries during the
+  # interim phase of being initialized.
+  #
+  gAdvancedLoggerInterimBufHobGuid = { 0x4c4f8c0b, 0xbe54, 0x49b3, { 0xba, 0x54, 0x33, 0xbf, 0x14, 0x47, 0x75, 0x24 } }
+
 [Ppis]
   ## Advanced Logger Ppi - Communication from PEIM to PEI_CORE library implementation
   #

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -560,6 +560,8 @@ AdvancedLoggerGetLoggerInfo (
         Type  =  EfiReservedMemoryType;
       } else {
         Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
+        // This is to workaround the interim blackout window before the memory is discovered.
+        // The permanent buffer will be allocated in the memory discovered callback.
         Type  =  EfiBootServicesData;
       }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -14,13 +14,6 @@
 #include <AdvancedLoggerInternalProtocol.h>
 #include <Library/AdvancedLoggerAccessLib.h>
 
-VOID
-EFIAPI
-InternalPrintMessage (
-  IN  CONST CHAR8  *Format,
-  ...
-  );
-
 /**
   Including the PeiMain.h from PeiCore in order to access the Platform Blob data member.
 
@@ -214,13 +207,11 @@ InstallPermanentMemoryBuffer (
       //
       // Must be PeiCore allocated small memory buffer
       //
-
       Status = PeiServicesAllocatePages (
                  EfiReservedMemoryType,
                  FixedPcdGet32 (PcdAdvancedLoggerPages),
                  &NewLogBuffer
                  );
-
       if (!EFI_ERROR (Status)) {
         NewLoggerInfo = ALI_FROM_PA (NewLogBuffer);
         CopyMem ((VOID *)NewLoggerInfo, (VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
@@ -452,19 +443,20 @@ AdvancedLoggerGetLoggerInfo (
   VOID
   )
 {
-  UINTN                   BufferSize;
-  EFI_HOB_GUID_TYPE       *GuidHob;
-  EFI_HOB_GUID_TYPE       *GuidHobInterim;
-  EFI_HOB_GUID_TYPE       *GuidHobInterimBuf;
-  PEI_CORE_INSTANCE       *PeiCoreInstance;
-  ADVANCED_LOGGER_INFO    *LoggerInfo;
-  ADVANCED_LOGGER_INFO    *LoggerInfoSec;
-  ADVANCED_LOGGER_PTR     *LogPtr;
-  EFI_PHYSICAL_ADDRESS    NewLoggerInfo;
-  UINTN                   Pages;
-  CONST EFI_PEI_SERVICES  **PeiServices;
-  EFI_STATUS              Status;
-  EFI_MEMORY_TYPE         Type;
+  UINTN                             BufferSize;
+  EFI_HOB_GUID_TYPE                 *GuidHob;
+  EFI_HOB_GUID_TYPE                 *GuidHobInterim;
+  EFI_HOB_GUID_TYPE                 *GuidHobInterimBuf;
+  PEI_CORE_INSTANCE                 *PeiCoreInstance;
+  ADVANCED_LOGGER_INFO              *LoggerInfo;
+  ADVANCED_LOGGER_INFO              *LoggerInfoSec;
+  ADVANCED_LOGGER_PTR               *LogPtr;
+  EFI_PHYSICAL_ADDRESS              NewLoggerInfo;
+  UINTN                             Pages;
+  CONST EFI_PEI_SERVICES            **PeiServices;
+  EFI_STATUS                        Status;
+  EFI_MEMORY_TYPE                   Type;
+  ADVANCED_LOGGER_MESSAGE_ENTRY_V2  *LogEntry;
 
   // Try to do the minimum work at the start of this function as this
   // is called quite often.
@@ -614,7 +606,7 @@ AdvancedLoggerGetLoggerInfo (
         // If we have an interim buffer, copy it to the new buffer
         //
         LoggerInfo = (ADVANCED_LOGGER_INFO *)GET_GUID_HOB_DATA (GuidHobInterimBuf);
-        ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *LogEntry = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)LoggerInfo->LogBuffer;
+        LogEntry = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)(UINTN)LoggerInfo->LogBuffer;
         AdvancedLoggerMemoryLoggerWrite (LogEntry->DebugLevel, LogEntry->MessageText, LogEntry->MessageLen);
         GuidHobInterimBuf = GetNextGuidHob (&gAdvancedLoggerInterimHobGuid, GuidHobInterimBuf);
       }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -560,8 +560,7 @@ AdvancedLoggerGetLoggerInfo (
         Type  =  EfiReservedMemoryType;
       } else {
         Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
-        // This is to workaround the interim blackout window before the memory is discovered.
-        // The permanent buffer will be allocated in the memory discovered callback.
+        // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
         Type  =  EfiBootServicesData;
       }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -507,7 +507,11 @@ AdvancedLoggerGetLoggerInfo (
                (UINT16)(sizeof (EFI_HOB_GUID_TYPE) + sizeof (ADVANCED_LOGGER_INFO) + ADVANCED_LOGGER_MAX_MESSAGE_SIZE),
                (VOID **)&GuidHobInterimBuf
                );
+    if (EFI_ERROR (Status)) {
+      return NULL;
+    }
     LoggerInfo = (ADVANCED_LOGGER_INFO *)GET_GUID_HOB_DATA (GuidHobInterimBuf);
+    BufferSize = sizeof (ADVANCED_LOGGER_INFO) + ADVANCED_LOGGER_MAX_MESSAGE_SIZE;
     ZeroMem ((VOID *)LoggerInfo, BufferSize);
     LoggerInfo->Signature     = ADVANCED_LOGGER_SIGNATURE;
     LoggerInfo->Version       = ADVANCED_LOGGER_VERSION;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -527,6 +527,7 @@ AdvancedLoggerGetLoggerInfo (
                );
     CopyGuid (&GuidHobInterim->Name, &gAdvancedLoggerInterimHobGuid);
   }
+
   //
   // No Logger Info - this must be the time to allocate a new LoggerInfo and save
   // the pointer in the PeiCoreInstance.
@@ -597,6 +598,7 @@ AdvancedLoggerGetLoggerInfo (
       if ((LoggerInfoSec != NULL) && !(LoggerInfoSec->InPermanentRAM)) {
         UpdateSecLoggerInfo (LoggerInfo);
       }
+
       //
       // Check to see if we have anything in the interim buffer
       //
@@ -606,10 +608,11 @@ AdvancedLoggerGetLoggerInfo (
         // If we have an interim buffer, copy it to the new buffer
         //
         LoggerInfo = (ADVANCED_LOGGER_INFO *)GET_GUID_HOB_DATA (GuidHobInterimBuf);
-        LogEntry = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)(UINTN)LoggerInfo->LogBuffer;
+        LogEntry   = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)(UINTN)LoggerInfo->LogBuffer;
         AdvancedLoggerMemoryLoggerWrite (LogEntry->DebugLevel, LogEntry->MessageText, LogEntry->MessageLen);
         GuidHobInterimBuf = GetNextGuidHob (&gAdvancedLoggerInterimHobGuid, GuidHobInterimBuf);
       }
+
       //
       // Publish the Advanced Logger Ppi
       //

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -561,7 +561,7 @@ AdvancedLoggerGetLoggerInfo (
       } else {
         Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
         // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
-        Type  =  EfiBootServicesData;
+        Type =  EfiBootServicesData;
       }
 
       BufferSize = EFI_PAGES_TO_SIZE (Pages);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -510,6 +510,7 @@ AdvancedLoggerGetLoggerInfo (
     if (EFI_ERROR (Status)) {
       return NULL;
     }
+
     LoggerInfo = (ADVANCED_LOGGER_INFO *)GET_GUID_HOB_DATA (GuidHobInterimBuf);
     BufferSize = sizeof (ADVANCED_LOGGER_INFO) + ADVANCED_LOGGER_MAX_MESSAGE_SIZE;
     ZeroMem ((VOID *)LoggerInfo, BufferSize);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -46,6 +46,8 @@
 [Guids]
   gAdvancedLoggerHobGuid
   gEfiFirmwareFileSystem2Guid
+  gAdvancedLoggerInterimHobGuid
+  gAdvancedLoggerInterimBufHobGuid
 
 [Ppis]
   gAdvancedLoggerPpiGuid                                                    ## PRODUCES


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The current implementation will directly allocation pages through PEI services when Advanced logger is not initialized. This cause an issue of permanent loop if/when there are prints from the allocation routine.

This change will create a hob during this interim state and log messages to hobs temporarily and coalesce the hobs after the allocation is finalized. This will reduce the print restriction down to hob creation only.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested on QEMU SBSA as well as Q35. Both booted to UEFI shell.

## Integration Instructions

N/A
