### PR TITLE
Sample MfciPolicy script for interacting with Mfci from windows

### DIFF
--- a/MfciPkg/Application/MfciPolicy/MfciPolicy.py
+++ b/MfciPkg/Application/MfciPolicy/MfciPolicy.py
@@ -13,14 +13,11 @@ import argparse
 import ctypes
 from UefiVariableSupport.UefiVariablesSupportLib import UefiVariable
 
-gMfciVendorGuid = "EBA1A9D2-BF4D-4736-B680-B36AFB4DD65B"
-
-CurrentPolicyBlob = "CurrentMfciPolicyBlob"
-CurrentMfciPolicy = "CurrentMfciPolicy"
-NextPolicyBlob = "NextMfciPolicyBlob"
-
-MfciPolicyInfo = ["CurrentMfciPolicyNonce", "NextMfciPolicyNonce", "Target\\Manufacturer", "Target\\Product", "Target\\SerialNumber", "Target\\OEM_01", "Target\\OEM_02"]
-
+MFCI_VENDOR_GUID = "EBA1A9D2-BF4D-4736-B680-B36AFB4DD65B"
+CURRENT_POLICY_BLOB = "CurrentMfciPolicyBlob"
+CURRENT_MFCI_POLICY = "CurrentMfciPolicy"
+NEXT_MFCI_POLICY_BLOB = "NextMfciPolicyBlob"
+MFCI_POLICY_INFO_VARIABLES = ["CurrentMfciPolicyNonce", "NextMfciPolicyNonce", "Target\\Manufacturer", "Target\\Product", "Target\\SerialNumber", "Target\\OEM_01", "Target\\OEM_02"]
 
 def option_parser():
     parser = argparse.ArgumentParser()
@@ -79,8 +76,8 @@ def option_parser():
 def get_system_info():
     UefiVar = UefiVariable()
 
-    for Variable in MfciPolicyInfo:
-        (errorcode, data, errorstring) = UefiVar.GetUefiVar(Variable, gMfciVendorGuid)
+    for Variable in MFCI_POLICY_INFO_VARIABLES:
+        (errorcode, data, errorstring) = UefiVar.GetUefiVar(Variable, MFCI_VENDOR_GUID)
         if errorcode != 0:
             logging.critical(f"Failed to get policy variable {Variable}")
         else:
@@ -88,43 +85,40 @@ def get_system_info():
                 print(f" {Variable} = {hex(int.from_bytes(data, byteorder='little', signed=False))}")
             else:
                 print(f" {Variable} = \"{data.decode("utf16")[0:-1]}\"")
-
     return
 
 
 def get_current_mfci_policy():
     UefiVar = UefiVariable()
 
-    (errorcode, data, errorstring) = UefiVar.GetUefiVar(CurrentMfciPolicy, gMfciVendorGuid)
+    (errorcode, data, errorstring) = UefiVar.GetUefiVar(CURRENT_MFCI_POLICY, MFCI_VENDOR_GUID)
     if errorcode == 0:
         result = hex(int.from_bytes(data, byteorder="little", signed=False))
         logging.info(f" Current MFCI Policy is {result}")
-        print(f"{CurrentMfciPolicy} is {result}")
+        print(f"{CURRENT_MFCI_POLICY} is {result}")
     else:
-        logging.critical(f"Failed to get {CurrentMfciPolicy}")
+        logging.critical(f"Failed to get {CURRENT_MFCI_POLICY}")
     return
 
 
 def delete_current_mfci_policy():
     UefiVar = UefiVariable()
 
-    (errorcode, data, errorstring) = UefiVar.SetUefiVar(CurrentPolicyBlob, gMfciVendorGuid, None, 3)
+    (errorcode, data, errorstring) = UefiVar.SetUefiVar(CURRENT_POLICY_BLOB, MFCI_VENDOR_GUID, None, 3)
     if errorcode == 0:
-        logging.info(f"Failed to Delete {CurrentPolicyBlob}\n {errorcode}{errorstring}")
-        print(f"Failed to delete {CurrentPolicyBlob}")
+        logging.info(f"Failed to Delete {CURRENT_POLICY_BLOB}\n {errorcode}{errorstring}")
+        print(f"Failed to delete {CURRENT_POLICY_BLOB}")
     else:
-        logging.info(f"{CurrentPolicyBlob} was deleted")
-        print(f"{CurrentPolicyBlob} was deleted")
+        logging.info(f"{CURRENT_POLICY_BLOB} was deleted")
+        print(f"{CURRENT_POLICY_BLOB} was deleted")
         
-    (errorcode, data, errorstring) = UefiVar.SetUefiVar(NextPolicyBlob, gMfciVendorGuid, None, 3)
+    (errorcode, data, errorstring) = UefiVar.SetUefiVar(NEXT_MFCI_POLICY_BLOB, MFCI_VENDOR_GUID, None, 3)
     if errorcode == 0:
-        logging.info(f"Failed to Delete {NextPolicyBlob}\n {errorcode}{errorstring}")
-        print(f"Failed to delete {NextPolicyBlob}")
+        logging.info(f"Failed to Delete {NEXT_MFCI_POLICY_BLOB}\n {errorcode}{errorstring}")
+        print(f"Failed to delete {NEXT_MFCI_POLICY_BLOB}")
     else:
-        logging.info(f"{NextPolicyBlob} was deleted")
-        print(f"{NextPolicyBlob} was deleted")
-        
-        
+        logging.info(f"{NEXT_MFCI_POLICY_BLOB} was deleted")
+        print(f"{NEXT_MFCI_POLICY_BLOB} was deleted")
     return
 
 
@@ -134,21 +128,21 @@ def set_next_mfci_policy(policy):
         var = file.read()
         UefiVar = UefiVariable()
 
-        (errorcode, data, errorstring) = UefiVar.SetUefiVar(NextPolicyBlob, gMfciVendorGuid, var, 3)
+        (errorcode, data, errorstring) = UefiVar.SetUefiVar(NEXT_MFCI_POLICY_BLOB, MFCI_VENDOR_GUID, var, 3)
         if errorcode == 0:
             logging.info("Next Policy failed: {errorstring}")
         else:
             logging.info("Next Policy was set")
-            print(f"{NextPolicyBlob} was set")
+            print(f"{NEXT_MFCI_POLICY_BLOB} was set")
     return
 
 def get_next_mfci_policy():
     UefiVar = UefiVariable()
 
-    (errorcode, data, errorstring) = UefiVar.GetUefiVar(NextPolicyBlob, gMfciVendorGuid)
+    (errorcode, data, errorstring) = UefiVar.GetUefiVar(NEXT_MFCI_POLICY_BLOB, MFCI_VENDOR_GUID)
     if errorcode != 0:
         logging.info("No Next Mfci Policy Set")
-        print(f"No variable {NextPolicyBlob} found")
+        print(f"No variable {NEXT_MFCI_POLICY_BLOB} found")
     else:
         logging.info(f"{data}")
         print(f"{data}")
@@ -162,28 +156,27 @@ def main():
 
     if arguments.getsysteminfo:
         get_system_info()
-        return
+        return 0
 
     elif arguments.retrievepolicy:
         get_current_mfci_policy()
-        return
+        return 0
 
     elif arguments.deletepolicy:
         delete_current_mfci_policy()
-        return
+        return 0
 
     elif arguments.policyblob != "":
         if not os.path.isfile(arguments.policyblob):
             logging.critical(f"File {arguments.policyblob} does not exist")
-            return
+            return 0
 
         set_next_mfci_policy(arguments.policyblob)
-        return
+        return 0
 
     elif arguments.retrievenextpolicy:
         get_next_mfci_policy()
-        return
-
+        return 0
     return 0
 
 

--- a/MfciPkg/Application/MfciPolicy/MfciPolicy.py
+++ b/MfciPkg/Application/MfciPolicy/MfciPolicy.py
@@ -1,0 +1,207 @@
+# @file
+#
+# Write MFCI packet into the MFCI mailbox
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import sys
+import logging
+import argparse
+import ctypes
+from UefiVariableSupport.UefiVariablesSupportLib import UefiVariable
+
+gMfciVendorGuid = "EBA1A9D2-BF4D-4736-B680-B36AFB4DD65B"
+
+CurrentPolicyBlob = "CurrentMfciPolicyBlob"
+CurrentMfciPolicy = "CurrentMfciPolicy"
+NextPolicyBlob = "NextMfciPolicyBlob"
+
+MfciPolicyInfo = ["CurrentMfciPolicyNonce", "NextMfciPolicyNonce", "Target\\Manufacturer", "Target\\Product", "Target\\SerialNumber", "Target\\OEM_01", "Target\\OEM_02"]
+
+
+def option_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-a",
+        "--apply",
+        dest="policyblob",
+        required=False,
+        type=str,
+        default='',
+        help="""Apply a signed Mfci Policy Blob to be processed on next reboot"""
+    )
+
+    parser.add_argument(
+        "-del",
+        "--delete",
+        action='store_true',
+        dest="deletepolicy",
+        required=False,
+        help="""Delete the current Mfci Policy and the next Mfci Policy"""
+    )
+
+    parser.add_argument(
+        "-r",
+        "--retrieve",
+        action='store_true',
+        dest="retrievepolicy",
+        required=False,
+        help="""Retrieve Current Mfci Policy"""
+    )
+
+    parser.add_argument(
+        "-rn",
+        "--retrievenext",
+        action='store_true',
+        dest="retrievenextpolicy",
+        required=False,
+        help="""Retrieve Next Mfci Policy"""
+    )
+
+    parser.add_argument(
+        "-d",
+        "--dump",
+        action='store_true',
+        dest="getsysteminfo",
+        required=False,
+        help="""Get System Info required for policy generation""",
+    )
+
+    arguments = parser.parse_args()
+
+    return arguments
+
+
+def get_system_info():
+    UefiVar = UefiVariable()
+
+    for Variable in MfciPolicyInfo:
+        (errorcode, data, errorstring) = UefiVar.GetUefiVar(Variable, gMfciVendorGuid)
+        if errorcode != 0:
+            logging.critical(f"Failed to get policy variable {Variable}")
+        else:
+            if Variable == "NextMfciPolicyNonce" or Variable == "CurrentMfciPolicyNonce":
+                print(f" {Variable} = {hex(int.from_bytes(data, byteorder='little', signed=False))}")
+            else:
+                print(f" {Variable} = \"{data.decode("utf16")[0:-1]}\"")
+
+    return
+
+
+def get_current_mfci_policy():
+    UefiVar = UefiVariable()
+
+    (errorcode, data, errorstring) = UefiVar.GetUefiVar(CurrentMfciPolicy, gMfciVendorGuid)
+    if errorcode == 0:
+        result = hex(int.from_bytes(data, byteorder="little", signed=False))
+        logging.info(f" Current MFCI Policy is {result}")
+        print(f"{CurrentMfciPolicy} is {result}")
+    else:
+        logging.critical(f"Failed to get {CurrentMfciPolicy}")
+    return
+
+
+def delete_current_mfci_policy():
+    UefiVar = UefiVariable()
+
+    (errorcode, data, errorstring) = UefiVar.SetUefiVar(CurrentPolicyBlob, gMfciVendorGuid, None, 3)
+    if errorcode == 0:
+        logging.info(f"Failed to Delete {CurrentPolicyBlob}\n {errorcode}{errorstring}")
+        print(f"Failed to delete {CurrentPolicyBlob}")
+    else:
+        logging.info(f"{CurrentPolicyBlob} was deleted")
+        print(f"{CurrentPolicyBlob} was deleted")
+        
+    (errorcode, data, errorstring) = UefiVar.SetUefiVar(NextPolicyBlob, gMfciVendorGuid, None, 3)
+    if errorcode == 0:
+        logging.info(f"Failed to Delete {NextPolicyBlob}\n {errorcode}{errorstring}")
+        print(f"Failed to delete {NextPolicyBlob}")
+    else:
+        logging.info(f"{NextPolicyBlob} was deleted")
+        print(f"{NextPolicyBlob} was deleted")
+        
+        
+    return
+
+
+def set_next_mfci_policy(policy):
+    # read the entire file
+    with open(policy, "rb") as file:
+        var = file.read()
+        UefiVar = UefiVariable()
+
+        (errorcode, data, errorstring) = UefiVar.SetUefiVar(NextPolicyBlob, gMfciVendorGuid, var, 3)
+        if errorcode == 0:
+            logging.info("Next Policy failed: {errorstring}")
+        else:
+            logging.info("Next Policy was set")
+            print(f"{NextPolicyBlob} was set")
+    return
+
+def get_next_mfci_policy():
+    UefiVar = UefiVariable()
+
+    (errorcode, data, errorstring) = UefiVar.GetUefiVar(NextPolicyBlob, gMfciVendorGuid)
+    if errorcode != 0:
+        logging.info("No Next Mfci Policy Set")
+        print(f"No variable {NextPolicyBlob} found")
+    else:
+        logging.info(f"{data}")
+        print(f"{data}")
+    return
+
+#
+# main script function
+#
+def main():
+    arguments = option_parser()
+
+    if arguments.getsysteminfo:
+        get_system_info()
+        return
+
+    elif arguments.retrievepolicy:
+        get_current_mfci_policy()
+        return
+
+    elif arguments.deletepolicy:
+        delete_current_mfci_policy()
+        return
+
+    elif arguments.policyblob != "":
+        if not os.path.isfile(arguments.policyblob):
+            logging.critical(f"File {arguments.policyblob} does not exist")
+            return
+
+        set_next_mfci_policy(arguments.policyblob)
+        return
+
+    elif arguments.retrievenextpolicy:
+        get_next_mfci_policy()
+        return
+
+    return 0
+
+
+if __name__ == "__main__":
+    # setup main console as logger
+    logger = logging.getLogger("")
+    logger.setLevel(logging.CRITICAL)
+    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    console = logging.StreamHandler()
+    console.setLevel(logging.CRITICAL)
+
+    # check the privilege level and report error
+    if not ctypes.windll.shell32.IsUserAnAdmin():
+        print("Administrator privilege required. Please launch from an Administrator privilege level.")
+        sys.exit(1)
+
+    # call main worker function
+    retcode = main()
+
+    logging.shutdown()
+    sys.exit(retcode)

--- a/MfciPkg/Application/MfciPolicy/Readme.md
+++ b/MfciPkg/Application/MfciPolicy/Readme.md
@@ -12,7 +12,7 @@ to generate a policy.
 
 ## Usage
 
-Copy the two files, DecodeUefiLog.py and UefiVaiableSupport folder to the Mfci enabled
+Copy the two files, DecodeUefiLog.py and UefiVariableSupport folder to the Mfci enabled
 system.
 
 The simplest case:
@@ -45,7 +45,7 @@ Retrieve the information necessary to generate a Mfci Policy:
   Target\OEM_02 = ""
 ```
 
-Apply a new Mfci Policy to the sytem, to be processed on reboot.
+Apply a new Mfci Policy to the system, to be processed on reboot.
 
 ```.sh
   py -3 MfciPolicy.py -a PolicyBlob.bin.p7

--- a/MfciPkg/Application/MfciPolicy/Readme.md
+++ b/MfciPkg/Application/MfciPolicy/Readme.md
@@ -1,0 +1,70 @@
+# MfciPkg - MfciPolicy
+
+MfciPolicy.py is a simple testing script for interacting with Mfci on windows.
+
+## About
+
+MfciPolicy can be used to interact with the Mfci mailboxes.
+
+After a policy is generated, the policy can be written into the NextMfciPolicyBlob mailbox
+through this utility. Additionally, this utility will display the information necessary
+to generate a policy.
+
+## Usage
+
+Copy the two files, DecodeUefiLog.py and UefiVaiableSupport folder to the Mfci enabled
+system.
+
+The simplest case:
+
+```.sh
+  py -3 MfciPolicy.py -h
+usage: MfciPolicy.py [-h] [-a POLICYBLOB] [-del] [-r] [-rn] [-d]
+
+options:
+  -h, --help            show this help message and exit
+  -a POLICYBLOB, --apply POLICYBLOB
+                        Apply a signed Mfci Policy Blob to be processed on next reboot
+  -del, --delete        Delete the current Mfci Policy and the next Mfci Policy
+  -r, --retrieve        Retrieve Current Mfci Policy
+  -rn, --retrievenext   Retrieve Next Mfci Policy
+  -d, --dump            Get System Info required for policy generation
+```
+
+Retrieve the information necessary to generate a Mfci Policy:
+
+```.sh
+  py -3 MfciPolicy.py -d
+
+  CurrentMfciPolicyNonce = 0x0
+  NextMfciPolicyNonce = 0xD5CFCBC5C1BBB6A7
+  Target\Manufacturer = "Palindrome"
+  Target\Product = "QEMU Q35"
+  Target\SerialNumber = "42-42-42-42"
+  Target\OEM_01 = ""
+  Target\OEM_02 = ""
+```
+
+Apply a new Mfci Policy to the sytem, to be processed on reboot.
+
+```.sh
+  py -3 MfciPolicy.py -a PolicyBlob.bin.p7
+
+  NextMfciPolicyBlob was set
+```
+
+Delete the current and next Mfci Policy (restore policy back to original state)
+
+```.sh
+  py -3 MfciPolicy.py -del
+
+  CurrentMfciPolicyBlob was deleted
+  Failed to delete NextMfciPolicyBlob
+```
+
+---
+
+## Copyright
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MfciPkg/Application/MfciPolicy/UefiVariableSupport/UefiVariablesSupportLib.py
+++ b/MfciPkg/Application/MfciPolicy/UefiVariableSupport/UefiVariablesSupportLib.py
@@ -1,0 +1,169 @@
+# @file
+#
+# Python lib to support Reading and writing UEFI variables from windows
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+from ctypes import (
+    windll,
+    c_wchar_p,
+    c_void_p,
+    c_int,
+    c_char,
+    create_string_buffer,
+    WinError,
+)
+import logging
+from win32 import win32api
+from win32 import win32process
+from win32 import win32security
+
+kernel32 = windll.kernel32
+EFI_VAR_MAX_BUFFER_SIZE = 1024 * 1024
+
+
+class UefiVariable(object):
+    def __init__(self):
+        # enable required SeSystemEnvironmentPrivilege privilege
+        privilege = win32security.LookupPrivilegeValue(
+            None, "SeSystemEnvironmentPrivilege"
+        )
+        token = win32security.OpenProcessToken(
+            win32process.GetCurrentProcess(),
+            win32security.TOKEN_READ | win32security.TOKEN_ADJUST_PRIVILEGES,
+        )
+        win32security.AdjustTokenPrivileges(
+            token, False, [(privilege, win32security.SE_PRIVILEGE_ENABLED)]
+        )
+        win32api.CloseHandle(token)
+
+        # import firmware variable API
+        try:
+            self._GetFirmwareEnvironmentVariable = (
+                kernel32.GetFirmwareEnvironmentVariableW
+            )
+            self._GetFirmwareEnvironmentVariable.restype = c_int
+            self._GetFirmwareEnvironmentVariable.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+            ]
+            self._SetFirmwareEnvironmentVariable = (
+                kernel32.SetFirmwareEnvironmentVariableW
+            )
+            self._SetFirmwareEnvironmentVariable.restype = c_int
+            self._SetFirmwareEnvironmentVariable.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+            ]
+            self._SetFirmwareEnvironmentVariableEx = (
+                kernel32.SetFirmwareEnvironmentVariableExW
+            )
+            self._SetFirmwareEnvironmentVariableEx.restype = c_int
+            self._SetFirmwareEnvironmentVariableEx.argtypes = [
+                c_wchar_p,
+                c_wchar_p,
+                c_void_p,
+                c_int,
+                c_int,
+            ]
+        except:
+            logging.warn(
+                "G[S]etFirmwareEnvironmentVariableW function doesn't seem to exist"
+            )
+            pass
+
+    #
+    # Helper function to create buffer for var read/write
+    #
+    def CreateBuffer(self, init, size=None):
+        """CreateBuffer(aString) -> character array
+        CreateBuffer(anInteger) -> character array
+        CreateBuffer(aString, anInteger) -> character array
+        """
+        if isinstance(init, str):
+            if size is None:
+                size = len(init) + 1
+            buftype = c_char * size
+            buf = buftype()
+            buf.value = init
+            return buf
+        elif isinstance(init, int):
+            buftype = c_char * init
+            buf = buftype()
+            return buf
+        raise TypeError(init)
+
+    #
+    # Function to get variable
+    # return a tuple of error code and variable data as string
+    #
+    def GetUefiVar(self, name, guid):
+        # success
+        err = 0
+        efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
+        if self._GetFirmwareEnvironmentVariable is not None:
+            logging.info(
+                "calling GetFirmwareEnvironmentVariable( name='%s', GUID='%s' ).."
+                % (name, "{%s}" % guid)
+            )
+            length = self._GetFirmwareEnvironmentVariable(
+                name, "{%s}" % guid, efi_var, EFI_VAR_MAX_BUFFER_SIZE
+            )
+        if (0 == length) or (efi_var is None):
+            err = kernel32.GetLastError()
+            logging.error(
+                "GetFirmwareEnvironmentVariable[Ex] failed (GetLastError = 0x%x)" % err
+            )
+            logging.error(WinError())
+            return (err, None, WinError(err))
+        return (err, efi_var[:length], None)
+
+    #
+    # Function to set variable
+    # return a tuple of boolean status, error_code, error_string (None if not error)
+    #
+    def SetUefiVar(self, name, guid, var=None, attrs=None):
+        var_len = 0
+        err = 0
+        error_string = None
+        if var is None:
+            var = bytes(0)
+        else:
+            var_len = len(var)
+        success = 0  # Fail
+        if attrs is None:
+            if self._SetFirmwareEnvironmentVariable is not None:
+                logging.info(
+                    "Calling SetFirmwareEnvironmentVariable (name='%s', Guid='%s')..."
+                    % (
+                        name,
+                        "{%s}" % guid,
+                    )
+                )
+                success = self._SetFirmwareEnvironmentVariable(
+                    name, "{%s}" % guid, var, var_len
+                )
+        else:
+            attrs = int(attrs)
+            if self._SetFirmwareEnvironmentVariableEx is not None:
+                logging.info(
+                    "Calling SetFirmwareEnvironmentVariableEx( name='%s', GUID='%s', length=0x%X, attributes=0x%X ).."
+                    % (name, "{%s}" % guid, var_len, attrs)
+                )
+                success = self._SetFirmwareEnvironmentVariableEx(
+                    name, "{%s}" % guid, var, var_len, attrs
+                )
+
+        if 0 == success:
+            err = kernel32.GetLastError()
+            logging.error(
+                "SetFirmwareEnvironmentVariable failed (GetLastError = 0x%x)" % err
+            )
+            logging.error(WinError())
+            error_string = WinError(err)
+        return (success, err, error_string)

--- a/MfciPkg/Application/MfciPolicy/UefiVariableSupport/UefiVariablesSupportLib.py
+++ b/MfciPkg/Application/MfciPolicy/UefiVariableSupport/UefiVariablesSupportLib.py
@@ -71,7 +71,7 @@ class UefiVariable(object):
                 c_int,
                 c_int,
             ]
-        except:
+        except Exception:
             logging.warn(
                 "G[S]etFirmwareEnvironmentVariableW function doesn't seem to exist"
             )


### PR DESCRIPTION
## Description

Adding a sample python script that enables retrieving Policy information from a system. 
Script enables applying a new policy into the mailbox for processing on next reboot.
Script enables deleting an existing policy (forcing the system back into its default policy on reboot)


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Tested from Windows.
- Retrieving policy information for generating a new policy (external tool)
- Inserting a new policy for consumption on reboot
- deleting an applied policy
- 
## Integration Instructions
N/A