### PR TITLE
Updated MorLockTestApp to expect the new standard return values

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.c
@@ -236,7 +236,7 @@ MorLockShouldNotBeSet (
   }
 
   UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_UNLOCKED);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
 
   return UNIT_TEST_PASSED;
 } // MorLockShouldNotBeSet()
@@ -790,7 +790,7 @@ MorLockv2ShouldReportCorrectly (
   UT_LOG_VERBOSE ("%a - Status = %r, MorLock = %d\n", __FUNCTION__, Status, MorLock);
 
   UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITH_KEY);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
 
   return UNIT_TEST_PASSED;
 } // MorLockv2ShouldReportCorrectly()


### PR DESCRIPTION
## Description

In TcgMorLockSmm.c the SetVariableCheckHandlerMorLock() function was changed to set the MorLock variable Value to 0x01 to indicate Locked Without Key to match the spec when addressing a possible dictionary attack.

The commit in question is [here](https://github.com/microsoft/mu_basecore/commit/63923a5642e86f386a5c719a90cfc6a929ea9cb0).

This PR changes the checked test results to match the new expected behavior.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in the uefi shell.  The tests that previously failed now pass.

## Integration Instructions

N/A