### PR TITLE
[MERGE ON REBASE] Fix Wrong mMaxAddress Calculation in AdvLogger

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -392,7 +392,7 @@ DxeCoreAdvancedLoggerLibConstructor (
         LoggerInfo->HdwPortInitialized = TRUE;
       }
 
-      mMaxAddress = TOTAL_LOG_SIZE_WITH_ALI (LoggerInfo);
+      mMaxAddress = LOG_MAX_ADDRESS (LoggerInfo);
       mBufferSize = LoggerInfo->LogBufferSize;
     } else {
       DEBUG ((DEBUG_ERROR, "%a: Error allocating Advanced Logger Buffer\n", __FUNCTION__));

--- a/AdvLoggerPkg/UnitTests/AdvancedLoggerWrapper/AdvancedLoggerWrapperTestApp.c
+++ b/AdvLoggerPkg/UnitTests/AdvancedLoggerWrapper/AdvancedLoggerWrapperTestApp.c
@@ -179,7 +179,7 @@ InitializeInMemoryLog (
   if (!EFI_ERROR (Status)) {
     mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     if (mLoggerInfo != NULL) {
-      mMaxAddress = TOTAL_LOG_SIZE_WITH_ALI (mLoggerInfo);
+      mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
       mBufferSize = mLoggerInfo->LogBufferSize;
     }
 


### PR DESCRIPTION
## Description

In two places in the Adv Logger v5 update, the incorrect macro was used to calculate mMaxAddress, which led to the log not being fully printed on some architectures. Fixing these leads to the log to be printed.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a physical platform where this was broken.

## Integration Instructions

N/A. On Mu rebase, this commit can be merged with the AdvLogger v5 commit.
