### PR TITLE
[REBASE ON MERGE] Fix Incorrect mHighAddress Calculation

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
@@ -439,7 +439,7 @@ AdvancedLoggerAccessLibUnitTestInitialize (
   if (!EFI_ERROR (Status)) {
     mLoggerInfo  = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     mLowAddress  = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (mLoggerInfo));
-    mHighAddress = PA_FROM_PTR (TOTAL_LOG_SIZE_WITH_ALI (mLoggerInfo));
+    mHighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (mLoggerInfo));
   }
 
   return Status;
@@ -466,7 +466,7 @@ AdvancedLoggerAccessLibConstructor (
   if (!EFI_ERROR (Status)) {
     mLoggerInfo  = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     mLowAddress  = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (mLoggerInfo));
-    mHighAddress = PA_FROM_PTR (TOTAL_LOG_SIZE_WITH_ALI (mLoggerInfo));
+    mHighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (mLoggerInfo));
 
     // Leave this debug message as ERROR.
 


### PR DESCRIPTION
## Description

Fix an error made in the AdvLogger v5 PR (#471). This is the same fix (but for a different variable name which is why it was mixed on the last fix up) as #483.

Usage of mHighAddress (and mMaxAddress) will be evaluated as part of issue #474.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35, LineParserTestApp was failing because of this.

## Integration Instructions

N/A for a platform. For the next Mu integration, this should be combined with the Advanced Logger v5 commit be9a3d273ffabebca606266c6cb3a47bbf49c4d5.