### PR TITLE
Update MorLockTestApp to fix errors with new standard return values

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.c
@@ -236,7 +236,7 @@ MorLockShouldNotBeSet (
   }
 
   UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_UNLOCKED);
 
   return UNIT_TEST_PASSED;
 } // MorLockShouldNotBeSet()
@@ -776,7 +776,7 @@ MorLockv2ShouldBeLockable (
 
 UNIT_TEST_STATUS
 EFIAPI
-MorLockv2ShouldReportCorrectly (
+MorLockv2LockedWithoutKeyShouldReportCorrectly (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
@@ -793,7 +793,28 @@ MorLockv2ShouldReportCorrectly (
   UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
 
   return UNIT_TEST_PASSED;
-} // MorLockv2ShouldReportCorrectly()
+} // MorLockv2LockedWithoutKeyShouldReportCorrectly()
+
+UNIT_TEST_STATUS
+EFIAPI
+MorLockv2LockedWithKeyShouldReportCorrectly (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       MorLock;
+
+  UT_LOG_VERBOSE ("%a()\n", __FUNCTION__);
+
+  Status = GetMorLockVariable (&MorLock);
+
+  UT_LOG_VERBOSE ("%a - Status = %r, MorLock = %d\n", __FUNCTION__, Status, MorLock);
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITH_KEY);
+
+  return UNIT_TEST_PASSED;
+} // MorLockv2LockedWithKeyShouldReportCorrectly()
 
 UNIT_TEST_STATUS
 EFIAPI
@@ -1040,7 +1061,7 @@ MorLockv2ShouldNotClearWithWrongKey (
   // Verify that mode is still enabled.
   Status = GetMorLockVariable (&MorLock);
   UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITH_KEY);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
 
   return UNIT_TEST_PASSED;
 } // MorLockv2ShouldNotClearWithWrongKey()
@@ -1181,7 +1202,7 @@ MorLockv2ShouldSetClearSet (
   // Verify that mode is still enabled.
   Status = GetMorLockVariable (&MorLock);
   UT_ASSERT_NOT_EFI_ERROR (Status);
-  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITH_KEY);
+  UT_ASSERT_EQUAL (MorLock, MOR_LOCK_DATA_LOCKED_WITHOUT_KEY);
 
   return UNIT_TEST_PASSED;
 } // MorLockv2ShouldSetClearSet()
@@ -1296,14 +1317,14 @@ MorLockTestApp (
   //       reboots. So let's say this is for efficiency.
   //
   AddTestCase (MorLockV2Tests, "Should be able to set the v2 MORLock", "Security.MOR.LockV2.SetLock", MorLockv2ShouldBeLockable, MorLockShouldNotBeSet, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should report version correctly when locked with MORLock v2", "Security.MOR.LockV2.LockVersion", MorLockv2ShouldReportCorrectly, NULL, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should only return one byte when reading MORLock v2", "Security.MOR.LockV2.LockSize", MorLockv2ShouldOnlyReturnOneByte, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should not return the key contents when locked with MORLock v2", "Security.MOR.LockV2.LockDataProtection", MorLockv2ShouldNotReturnKey, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should not be able to change the MOR control when locked with MORLock v2", "Security.MOR.LockV2.Lock", MorControlShouldNotChange, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should not be able to change the key when locked with MORLock v2", "Security.MOR.LockV2.LockImmutable", MorLockv2ShouldNotChangeWhenLocked, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should not be able to change to MORLock v1 when locked with MORLock v2", "Security.MOR.LockV2.ChangeToV1Lock", MorLockv2ShouldNotChangeTov1, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "Should not be able to delete the MORLock when locked with MORLock v2", "Security.MOR.LockV2.LockDelete", MorLockv2ShouldNotBeDeleteable, MorLockv2ShouldReportCorrectly, NULL, NULL);
-  AddTestCase (MorLockV2Tests, "MORLock v2 should clear after reboot", "Security.MOR.MorLockV2.ClearOnReboot", MorLockShouldClearAfterReboot, MorLockv2ShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should report version correctly when locked with MORLock v2", "Security.MOR.LockV2.LockVersion", MorLockv2LockedWithKeyShouldReportCorrectly, NULL, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should only return one byte when reading MORLock v2", "Security.MOR.LockV2.LockSize", MorLockv2ShouldOnlyReturnOneByte, MorLockv2LockedWithKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should not return the key contents when locked with MORLock v2", "Security.MOR.LockV2.LockDataProtection", MorLockv2ShouldNotReturnKey, MorLockv2LockedWithKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should not be able to change the MOR control when locked with MORLock v2", "Security.MOR.LockV2.Lock", MorControlShouldNotChange, MorLockv2LockedWithKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should not be able to change the key when locked with MORLock v2", "Security.MOR.LockV2.LockImmutable", MorLockv2ShouldNotChangeWhenLocked, MorLockv2LockedWithKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should not be able to change to MORLock v1 when locked with MORLock v2", "Security.MOR.LockV2.ChangeToV1Lock", MorLockv2ShouldNotChangeTov1, MorLockv2LockedWithoutKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "Should not be able to delete the MORLock when locked with MORLock v2", "Security.MOR.LockV2.LockDelete", MorLockv2ShouldNotBeDeleteable, MorLockv2LockedWithoutKeyShouldReportCorrectly, NULL, NULL);
+  AddTestCase (MorLockV2Tests, "MORLock v2 should clear after reboot", "Security.MOR.MorLockV2.ClearOnReboot", MorLockShouldClearAfterReboot, MorLockv2LockedWithoutKeyShouldReportCorrectly, NULL, NULL);
   //
   // End of tests that assume precedence.
   // From here on, each test is isolated and will clean up after itself.


### PR DESCRIPTION
## Description

When TcgMorLockSmm.c the SetVariableCheckHandlerMorLock() function was changed to set the MorLock variable Value to 0x01 to indicate Locked Without Key, MorLockTestApp also need to be changed to make sure the test flow can get positive results.

Changes are listed as below
1. MorLockShouldNotBeSet(): This function should compare with MOR_LOCK_DATA_UNLOCKED.
2. MorLockv2LockedWithoutKeyShouldReportCorrectly(): Rename from MorLockv2ShouldReportCorrectly() and update usage in MorLockTestApp() as it is compared with MOR_LOCK_DATA_LOCKED_WITHOUT_KEY.
3. MorLockv2LockedWithKeyShouldReportCorrectly(): This new function compares MorLock with MOR_LOCK_DATA_LOCKED_WITH_KEY for Morlock V2 testing. Also update usage in MorLockTestApp().
4. MorLockv2ShouldNotClearWithWrongKey(): Should compare with MOR_LOCK_DATA_LOCKED_WITHOUT_KEY when using wrong key to clear MorLock.
5. MorLockv2ShouldSetClearSet(): Should compare with MOR_LOCK_DATA_LOCKED_WITHOUT_KEY when using different key to clear MorLock.
6. MorLockTestApp(): Update above function usage in different test cases to make sure the test can be finished.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in the uefi shell.  The tests should get positive results and no errors are reported.

## Integration Instructions

N/A