### PR TITLE
Fixing uninitialized variable used in AdvLoggerOsConnectorPrmConfigLib

### DIFF
--- a/AdvLoggerPkg/AdvLoggerOsConnectorPrm/Library/AdvLoggerOsConnectorPrmConfigLib/AdvLoggerOsConnectorPrmConfigLib.c
+++ b/AdvLoggerPkg/AdvLoggerOsConnectorPrm/Library/AdvLoggerOsConnectorPrmConfigLib/AdvLoggerOsConnectorPrmConfigLib.c
@@ -150,6 +150,7 @@ AdvLoggerOsConnectorPrmConfigLibConstructor (
       __func__
       ));
     ASSERT (FixedPcdGet32 (PcdAdvancedLoggerPages) >= sizeof (ADVANCED_LOGGER_INFO));
+    Status = EFI_BAD_BUFFER_SIZE;
     goto Done;
   }
 
@@ -161,6 +162,7 @@ AdvLoggerOsConnectorPrmConfigLibConstructor (
   mStaticDataBuffer = AllocateRuntimeZeroPool (DataBufferLength);
   if (mStaticDataBuffer == NULL) {
     DEBUG ((DEBUG_ERROR, "%a Failed to allocate static buffer\n", __func__));
+    Status = EFI_OUT_OF_RESOURCES;
     goto Done;
   }
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change fixes an code path when the error occurs early enough, the Status might get evaluated without being initialized.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested building with CLANGPDB. The build failure is gone after the fix.

## Integration Instructions

N/A
