### PR TITLE
Fixing precedence of "not" and bitwise operators

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/X64/PageSplitTest.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/X64/PageSplitTest.c
@@ -38,14 +38,14 @@ GetUnsplitPageTableEntry (
   L4Table = (UINT64 *)AsmReadCr3 ();
 
   for (Index4 = 0x0; Index4 < 0x200; Index4++) {
-    if (!L4Table[Index4] & PAGE_TABLE_PRESENT_BIT) {
+    if (!(L4Table[Index4] & PAGE_TABLE_PRESENT_BIT)) {
       continue;
     }
 
     L3Table = (UINT64 *)(L4Table[Index4] & PAGE_TABLE_BASE_ADDRESS);
 
     for (Index3 = 0x0; Index3 < 0x200; Index3++ ) {
-      if (!L3Table[Index3] & PAGE_TABLE_PRESENT_BIT) {
+      if (!(L3Table[Index3] & PAGE_TABLE_PRESENT_BIT)) {
         continue;
       }
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change fixed the incorrect precendence where the "not" operator will be evaluated before the bitwise operator.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

The test does not change result.

## Integration Instructions

N/A
