### PR TITLE
UEFI HID DXE V2 to improve Idiomatic Rust patterns

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/boot_services.rs
+++ b/HidPkg/UefiHidDxeV2/src/boot_services.rs
@@ -11,6 +11,7 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 use core::{ffi::c_void, fmt::Debug, sync::atomic::AtomicPtr};
+
 #[cfg(test)]
 use mockall::automock;
 use r_efi::efi;

--- a/HidPkg/UefiHidDxeV2/src/hid.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid.rs
@@ -41,21 +41,19 @@
 //!
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
+use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
+
+#[cfg(test)]
+use mockall::automock;
+use r_efi::efi;
+use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
 
 use crate::{
     boot_services::UefiBootServices,
     driver_binding::DriverBinding,
     hid_io::{HidIo, HidIoFactory, HidReportReceiver},
 };
-
-use alloc::{boxed::Box, vec::Vec};
-
-use r_efi::efi;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
-
-#[cfg(test)]
-use mockall::automock;
 
 /// This trait defines an abstraction for getting a list of receivers for HID reports.
 ///

--- a/HidPkg/UefiHidDxeV2/src/lib.rs
+++ b/HidPkg/UefiHidDxeV2/src/lib.rs
@@ -30,12 +30,14 @@ pub mod hid_io;
 pub mod keyboard;
 pub mod pointer;
 
-use boot_services::StandardUefiBootServices;
-use core::sync::atomic::AtomicPtr;
+use core::{ptr, sync::atomic::AtomicPtr};
+
 use r_efi::efi;
+
+use boot_services::StandardUefiBootServices;
 
 /// Global instance of UEFI Boot Services.
 pub static BOOT_SERVICES: StandardUefiBootServices = StandardUefiBootServices::new();
 
 /// Global instance of UEFI Runtime Services.
-pub static RUNTIME_SERVICES: AtomicPtr<efi::RuntimeServices> = AtomicPtr::new(core::ptr::null_mut());
+pub static RUNTIME_SERVICES: AtomicPtr<efi::RuntimeServices> = AtomicPtr::new(ptr::null_mut());

--- a/HidPkg/UefiHidDxeV2/src/main.rs
+++ b/HidPkg/UefiHidDxeV2/src/main.rs
@@ -15,9 +15,8 @@
 #[cfg(target_os = "uefi")]
 mod uefi_entry {
     extern crate alloc;
-    use core::{panic::PanicInfo, sync::atomic::Ordering};
-
     use alloc::{boxed::Box, vec::Vec};
+    use core::{panic::PanicInfo, sync::atomic::Ordering};
 
     use r_efi::{efi, system};
 

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -15,20 +15,20 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
+
+use r_efi::{efi, protocols};
+
 use hidparser::{
     report_data_types::{ReportId, Usage},
     ReportDescriptor, ReportField, VariableField,
 };
-use r_efi::{efi, protocols};
-
 use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE};
 
+use self::absolute_pointer::PointerContext;
 use crate::{
     boot_services::UefiBootServices,
     hid_io::{HidIo, HidReportReceiver},
 };
-
-use self::absolute_pointer::PointerContext;
 
 // Usages supported by this module.
 const GENERIC_DESKTOP_X: u32 = 0x00010030;
@@ -147,7 +147,6 @@ impl PointerHidHandler {
                 self.input_reports.insert(report_data.report_id, report_data);
             }
         }
-
         if !self.input_reports.is_empty() {
             Ok(())
         } else {


### PR DESCRIPTION
- use more rust idiomatic naming convention
- use `let else` syntax for better readability
- Organize import with the same logic in every file.
  1. crate from rust
  2. crate from crate.io
  3. crate from Microsoft
  4. use from the same crate

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Test that the keyboard was still working.

## Integration Instructions

N/A
