### PR TITLE
MfciPkg & MsCorePkg: Fix unit test compilation errors.

### DIFF
--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeHostTest.c
@@ -85,24 +85,10 @@ UnitTestSetVariable (
   IN  VOID      *Data
   );
 
-EFI_STATUS
-EFIAPI
-UnitTestLocateProtocol (
-  IN  EFI_GUID  *Protocol,
-  IN  VOID      *Registration  OPTIONAL,
-  OUT VOID      **Interface
-  );
-
 EFI_RUNTIME_SERVICES  mMockRuntime = {
   .GetVariable = UnitTestGetVariable,
   .SetVariable = UnitTestSetVariable,
 };
-
-EFI_BOOT_SERVICES  mBootSvc = {
-  .LocateProtocol = UnitTestLocateProtocol
-};
-
-EFI_BOOT_SERVICES  *gBS = &mBootSvc;
 
 extern BOOLEAN  mVarPolicyRegistered;
 
@@ -180,17 +166,6 @@ MFCI_UT_VERIFY_CONTEXT  mMfciVerifyContext05 = {
     .Nonce    = MFCI_TEST_NONCE_TARGET,
   }
 };
-
-EFI_STATUS
-EFIAPI
-UnitTestLocateProtocol (
-  IN  EFI_GUID  *Protocol,
-  IN  VOID      *Registration  OPTIONAL,
-  OUT VOID      **Interface
-  )
-{
-  return EFI_SUCCESS;
-}
 
 /**
 A mocked version of GetVariable.

--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
@@ -52,8 +52,6 @@ EFI_RUNTIME_SERVICES  mMockRuntime = {
   .SetVariable = UnitTestSetVariable,
 };
 
-EFI_BOOT_SERVICES  *gBS = NULL;
-
 extern MFCI_POLICY_TYPE  mCurrentPolicy;
 extern BOOLEAN           mVarPolicyRegistered;
 

--- a/MsCorePkg/MacAddressEmulationDxe/Test/MacAddressEmulationDxeHostTest.inf
+++ b/MsCorePkg/MacAddressEmulationDxe/Test/MacAddressEmulationDxeHostTest.inf
@@ -41,7 +41,6 @@
   BaseMemoryLib
   DebugLib
   MemoryAllocationLib
-  UefiLib
   UefiBootServicesTableLib
   UnitTestLib
 


### PR DESCRIPTION
## Description

Unit tests started failing due to compilation errors. This stemmed from a bug fixed in microsoft/mu_basecore#891. Once this bug was fixed, the unit tests starting to be compiled which blocked pipelines.


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Ran Local CI to verify unit tests change. 

## Integration Instructions
N/A