### PR TITLE
AdvLoggerPkg: Remove NVMe Check from File Logger File Creation

### DIFF
--- a/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
@@ -24,43 +24,6 @@ STATIC DEBUG_LOG_FILE_INFO  mLogFiles[] = {
 #define DEBUG_LOG_FILE_COUNT  ARRAY_SIZE(mLogFiles)
 
 /**
-  CheckIfNVME
-
-  Checks if the device path is an NVME device path.
-
-  @param Handle     Handle with Device Path protocol
-
-  @retval  TRUE     Device is NVME
-  @retval  FALSE    Device is NOT NVME or Unable to get Device Path.
-
-  **/
-STATIC
-BOOLEAN
-CheckIfNVME (
-  IN EFI_HANDLE  Handle
-  )
-{
-  EFI_DEVICE_PATH_PROTOCOL  *DevicePath;
-
-  DevicePath = DevicePathFromHandle (Handle);
-  if (DevicePath == NULL) {
-    return FALSE;
-  }
-
-  while (!IsDevicePathEnd (DevicePath)) {
-    if ((MESSAGING_DEVICE_PATH == DevicePathType (DevicePath)) &&
-        (MSG_NVME_NAMESPACE_DP == DevicePathSubType (DevicePath)))
-    {
-      return TRUE;
-    }
-
-    DevicePath = NextDevicePathNode (DevicePath);
-  }
-
-  return FALSE;
-}
-
-/**
   VolumeFromFileSystemHandle
 
   LogDevice->Handle must have a FileSystemProtocol on it.  Get the FileSystemProtocol
@@ -141,13 +104,6 @@ VolumeFromFileSystemHandle (
                      );
 
   if (EFI_ERROR (Status)) {
-    // Logs directory doesn't exist.  If NVME, allow forced logging
-    if (!CheckIfNVME (LogDevice->Handle)) {
-      DEBUG ((DEBUG_INFO, "Logs directory not found on device.  No logging.\n"));
-      Volume->Close (Volume);
-      return NULL;
-    }
-
     // Logs directory doesn't exist, see if we can create the Logs directory.
     if (!FeaturePcdGet (PcdAdvancedFileLoggerForceEnable)) {
       DEBUG ((DEBUG_INFO, "Creating the Logs directory is not allowed.\n"));


### PR DESCRIPTION
## Description

Currently, File Logger will only create the UefiLogs directory on the ESP if the device is an NVMe device. This is an unneccesary restriction and is removed in this patch.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a system with a non-NVMe drive that failed to have the FileLogger directory created before this change and succeeds now.

## Integration Instructions

If the integrating platform has a filesystem that does not support being logged to, it should set PcdAdvancedFileLoggerForceEnable to FALSE so that the directory is not attempted to be created.