### PR TITLE
[REBASE & FF] Advanced Logger Cherry-Picks From 202311

### DIFF
--- a/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
@@ -24,43 +24,6 @@ STATIC DEBUG_LOG_FILE_INFO  mLogFiles[] = {
 #define DEBUG_LOG_FILE_COUNT  ARRAY_SIZE(mLogFiles)
 
 /**
-  CheckIfNVME
-
-  Checks if the device path is an NVME device path.
-
-  @param Handle     Handle with Device Path protocol
-
-  @retval  TRUE     Device is NVME
-  @retval  FALSE    Device is NOT NVME or Unable to get Device Path.
-
-  **/
-STATIC
-BOOLEAN
-CheckIfNVME (
-  IN EFI_HANDLE  Handle
-  )
-{
-  EFI_DEVICE_PATH_PROTOCOL  *DevicePath;
-
-  DevicePath = DevicePathFromHandle (Handle);
-  if (DevicePath == NULL) {
-    return FALSE;
-  }
-
-  while (!IsDevicePathEnd (DevicePath)) {
-    if ((MESSAGING_DEVICE_PATH == DevicePathType (DevicePath)) &&
-        (MSG_NVME_NAMESPACE_DP == DevicePathSubType (DevicePath)))
-    {
-      return TRUE;
-    }
-
-    DevicePath = NextDevicePathNode (DevicePath);
-  }
-
-  return FALSE;
-}
-
-/**
   VolumeFromFileSystemHandle
 
   LogDevice->Handle must have a FileSystemProtocol on it.  Get the FileSystemProtocol
@@ -141,13 +104,6 @@ VolumeFromFileSystemHandle (
                      );
 
   if (EFI_ERROR (Status)) {
-    // Logs directory doesn't exist.  If NVME, allow forced logging
-    if (!CheckIfNVME (LogDevice->Handle)) {
-      DEBUG ((DEBUG_INFO, "Logs directory not found on device.  No logging.\n"));
-      Volume->Close (Volume);
-      return NULL;
-    }
-
     // Logs directory doesn't exist, see if we can create the Logs directory.
     if (!FeaturePcdGet (PcdAdvancedFileLoggerForceEnable)) {
       DEBUG ((DEBUG_INFO, "Creating the Logs directory is not allowed.\n"));

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -450,6 +450,7 @@ AdvancedLoggerGetLoggerInfo (
   UINTN                   Pages;
   CONST EFI_PEI_SERVICES  **PeiServices;
   EFI_STATUS              Status;
+  EFI_MEMORY_TYPE         Type;
 
   // Try to do the minimum work at the start of this function as this
   // is called quite often.
@@ -513,14 +514,17 @@ AdvancedLoggerGetLoggerInfo (
 
       if (FeaturePcdGet (PcdAdvancedLoggerPeiInRAM)) {
         Pages =  FixedPcdGet32 (PcdAdvancedLoggerPages);
+        Type  =  EfiRuntimeServicesData;
       } else {
         Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
+        // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
+        Type =  EfiBootServicesData;
       }
 
       BufferSize = EFI_PAGES_TO_SIZE (Pages);
 
       Status = PeiServicesAllocatePages (
-                 EfiReservedMemoryType,
+                 Type,
                  Pages,
                  &NewLoggerInfo
                  );


### PR DESCRIPTION
## Description

This PR cherry-picks one full commit and one very small part of another commit from 202311:

Remove NVMe Check from File Logger
--
This is a complete cherry-pick from c024ed1e61108d71e7e8fa4693c2d55839f87ac0. It adds support for File Logger to create the UefiLogs directory on non-NVMe devices.

Allocate AdvLogger Pre-Mem Pages as EfiBootServicesData
--
This is a part of be9a3d273ffabebca606266c6cb3a47bbf49c4d5. The rest of this commit is not taken because it is a new feature (a new version of the AdvLogger structure). This portion of the commit was taken because it is a bugfix for when ARM64 switched over to 64k runtime page allocation granularity. Because PeiCore has a hardcoded assumption it is operating pre-mem, which is not true for ARM64, we cannot allocate a minimum of 16 pages for a runtime type at the start of PeiCore (when AdvLogger is initialized there). We instead need to allocate as EfiBootServicesData (which does not have the runtime page allocation granularity) and reallocate as EfiRuntimeServicesData after permanent memory is installed.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A