### PR TITLE
MfciPkg: Removed TargetVerifyPhaseSuite Tests suite since it did not contain any tests.

### DIFF
--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeHostTest.c
@@ -799,7 +799,6 @@ UefiTestMain (
 {
   EFI_STATUS                  Status;
   UNIT_TEST_FRAMEWORK_HANDLE  Framework;
-  UNIT_TEST_SUITE_HANDLE      TargetVerifyPhaseSuite;
   UNIT_TEST_SUITE_HANDLE      VerifyAndChangePhaseSuite;
 
   Framework = NULL;
@@ -816,16 +815,6 @@ UefiTestMain (
   }
 
   // The blob parsing part is tested in MfciPolicyParsingUnitTest, so will not go through those here.
-
-  //
-  // Populate the TargetVerifyPhaseSuite Unit Test Suite.
-  //
-  Status = CreateUnitTestSuite (&TargetVerifyPhaseSuite, Framework, "TargetVerifyPhase", "ReportRouter.Phase", NULL, NULL);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for TargetVerifyPhaseSuite\n"));
-    Status = EFI_OUT_OF_RESOURCES;
-    goto EXIT;
-  }
 
   //
   // Populate the VerifyAndChangePhaseSuite Unit Test Suite.

--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
@@ -246,7 +246,6 @@ UefiTestMain (
 {
   EFI_STATUS                  Status;
   UNIT_TEST_FRAMEWORK_HANDLE  Framework;
-  UNIT_TEST_SUITE_HANDLE      TargetVerifyPhaseSuite;
   UNIT_TEST_SUITE_HANDLE      VerifyAndChangePhaseSuite;
 
   Framework = NULL;
@@ -263,16 +262,6 @@ UefiTestMain (
   }
 
   // The blob parsing part is tested in MfciPolicyParsingUnitTest, so will not go through those here.
-
-  //
-  // Populate the TargetVerifyPhaseSuite Unit Test Suite.
-  //
-  Status = CreateUnitTestSuite (&TargetVerifyPhaseSuite, Framework, "TargetVerifyPhase", "ReportRouter.Phase", NULL, NULL);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for TargetVerifyPhaseSuite\n"));
-    Status = EFI_OUT_OF_RESOURCES;
-    goto EXIT;
-  }
 
   //
   // Populate the VerifyAndChangePhaseSuite Unit Test Suite.

--- a/MsWheaPkg/MsWheaReport/Test/MsWheaReportCommonHostTest.c
+++ b/MsWheaPkg/MsWheaReport/Test/MsWheaReportCommonHostTest.c
@@ -757,8 +757,8 @@ UefiTestMain (
     goto EXIT;
   }
 
-  AddTestCase (ReportRouterDataSuite, "ReportHwErrRecRouter should populate the extra WHEA data", "PopulateExtraData", ReportRouterPopulateWheaExtraData, NULL, NULL, NULL);
-  AddTestCase (ReportRouterDataSuite, "ReportHwErrRecRouter should not populate the extra WHEA data in invalid phases", "SkipEsPhases", ReportRouterSkipExtraDataInInvalidPhases, NULL, NULL, NULL);
+  AddTestCase (ReportRouterExtraDataSuite, "ReportHwErrRecRouter should populate the extra WHEA data", "PopulateExtraData", ReportRouterPopulateWheaExtraData, NULL, NULL, NULL);
+  AddTestCase (ReportRouterExtraDataSuite, "ReportHwErrRecRouter should not populate the extra WHEA data in invalid phases", "SkipEsPhases", ReportRouterSkipExtraDataInInvalidPhases, NULL, NULL, NULL);
 
   //
   // Execute the tests.

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library==0.21.8
-edk2-pytool-extensions==0.27.6
+edk2-pytool-extensions==0.27.10
 antlr4-python3-runtime==4.13.1
 regex==2024.5.15
 pygount==1.8.0


### PR DESCRIPTION
## Description

MfciVerifyPolicyAndChangeRoTHostTest.c and  MfciVerifyPolicyAndChangeHostTest.c both contained an additonal registered test suite that did not contain any tests.

MsWheaPkg also contained a test suite where the tests associated were not registered correctly.

This started failing after [fd8a09795aa](https://github.com/microsoft/mu_basecore/commit/fd8a09795aa2ea2a091906efb92124eb85d49e05) where empty test suites will now be reported as an error. 

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [X] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Local CI passed after change. 

## Integration Instructions

N/A