### PR TITLE
MsCorePkg: Update telemetry logging with PI Spec EFI Status Code

### DIFF
--- a/MsCorePkg/Library/MemoryTypeInformationChangeLib/MemoryTypeInformationChangeLib.c
+++ b/MsCorePkg/Library/MemoryTypeInformationChangeLib/MemoryTypeInformationChangeLib.c
@@ -30,12 +30,12 @@ ReportMemoryTypeInformationChange (
 {
   //
   // This telemetry event is logged by a lib linked to BdsDxe, thus a EFI_SOFTWARE_DXE_BS_DRIVER
-  // subclass; the class EFI_SW_EC_MEMORY_TYPE_INFORMATION_CHANGE is custom for this event.
+  // subclass; the class EFI_SW_EC_ILLEGAL_SOFTWARE_STATE is used to indicate an illegal change in memory
   //
   return LogTelemetry (
            FALSE,
            NULL,
-           (EFI_SOFTWARE_DXE_BS_DRIVER | EFI_SW_EC_MEMORY_TYPE_INFORMATION_CHANGE),
+           (EFI_SOFTWARE_DXE_BS_DRIVER | EFI_SW_EC_ILLEGAL_SOFTWARE_STATE),
            NULL,
            NULL,
            Type,


### PR DESCRIPTION
## Description

Previously in MemoryTypeInformationChangeLib, we were using a custom Status Code. That code is being removed from MU_BASECORE  in [PR #1001](https://github.com/microsoft/mu_basecore/pull/1001) and we're using an existing code from PI Spec, EFI_SW_EC_ILLEGAL_SOFTWARE_STATE instead.



- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
 
## How This Was Tested

CI

## Integration Instructions

Upgrading to or already using mu_basecore release/202311, change any reference to the macro as follows:
Any instances of `EFI_SW_EC_MEMORY_TYPE_INFORMATION_CHANGE` will need to be replaced with `EFI_SW_EC_ILLEGAL_SOFTWARE_STATE`