### PR TITLE
UefiTestingPkg: DxePagingAuditTestApp Fix Inaccessible Memory Test

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -1370,6 +1370,7 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   EFI_MEMORY_DESCRIPTOR  *CurrentEfiMemoryMapEntry;
   BOOLEAN                TestFailure;
   EFI_PHYSICAL_ADDRESS   LastMemoryMapEntryEnd;
+  EFI_STATUS             Status;
 
   DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
 
@@ -1388,16 +1389,18 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   CurrentEfiMemoryMapEntry = mEfiMemoryMap;
 
   if (CurrentEfiMemoryMapEntry->PhysicalStart > StartOfAddressSpace) {
-    if (!ValidateRegionAttributes (
-           &mMap,
-           StartOfAddressSpace,
-           CurrentEfiMemoryMapEntry->PhysicalStart - StartOfAddressSpace,
-           EFI_MEMORY_RP,
-           TRUE,
-           TRUE,
-           TRUE
-           ))
-    {
+    Status = ValidateRegionAttributes (
+               &mMap,
+               StartOfAddressSpace,
+               CurrentEfiMemoryMapEntry->PhysicalStart - StartOfAddressSpace,
+               EFI_MEMORY_RP,
+               TRUE,
+               TRUE,
+               TRUE
+               );
+
+    // Inaccessible could mean EFI_MEMORY_RP or completely unmapped in page table
+    if (EFI_ERROR (Status) && (Status != EFI_NO_MAPPING)) {
       TestFailure = TRUE;
     }
   }
@@ -1408,16 +1411,18 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
 
   while ((UINTN)CurrentEfiMemoryMapEntry < (UINTN)EndOfEfiMemoryMap) {
     if (CurrentEfiMemoryMapEntry->PhysicalStart > LastMemoryMapEntryEnd) {
-      if (!ValidateRegionAttributes (
-             &mMap,
-             LastMemoryMapEntryEnd,
-             CurrentEfiMemoryMapEntry->PhysicalStart - LastMemoryMapEntryEnd,
-             EFI_MEMORY_RP,
-             TRUE,
-             TRUE,
-             TRUE
-             ))
-      {
+      Status = ValidateRegionAttributes (
+                 &mMap,
+                 LastMemoryMapEntryEnd,
+                 CurrentEfiMemoryMapEntry->PhysicalStart - LastMemoryMapEntryEnd,
+                 EFI_MEMORY_RP,
+                 TRUE,
+                 TRUE,
+                 TRUE
+                 );
+
+      // Inaccessible could mean EFI_MEMORY_RP or completely unmapped in page table
+      if (EFI_ERROR (Status) && (Status != EFI_NO_MAPPING)) {
         TestFailure = TRUE;
       }
     }
@@ -1428,16 +1433,18 @@ MemoryOutsideEfiMemoryMapIsInaccessible (
   }
 
   if (LastMemoryMapEntryEnd < EndOfAddressSpace) {
-    if (!ValidateRegionAttributes (
-           &mMap,
-           LastMemoryMapEntryEnd,
-           EndOfAddressSpace - LastMemoryMapEntryEnd,
-           EFI_MEMORY_RP,
-           TRUE,
-           TRUE,
-           TRUE
-           ))
-    {
+    Status = ValidateRegionAttributes (
+               &mMap,
+               LastMemoryMapEntryEnd,
+               EndOfAddressSpace - LastMemoryMapEntryEnd,
+               EFI_MEMORY_RP,
+               TRUE,
+               TRUE,
+               TRUE
+               );
+
+    // Inaccessible could mean EFI_MEMORY_RP or completely unmapped in page table
+    if (EFI_ERROR (Status) && (Status != EFI_NO_MAPPING)) {
       TestFailure = TRUE;
     }
   }


### PR DESCRIPTION
## Description

Security.Misc.MemoryOutsideEfiMemoryMapIsInaccessible was failing because it was not checking the return status of
ValidateRegionAttributes, which could return EFI_NO_MAPPING to indicate a given range was not in the page table. There are two independent criteria that can be satisfied to indicate that a region is inaccessible: it is marked EFI_MEMORY_RP or it is not mapped in the page table. This test was only checking the first case and not the second case. With this update it now correctly checks both cases.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 and saw that the formerly failing test is now passing.

## Integration Instructions

N/A.