### PR TITLE
AdvLoggerPkg: AssertLib update PI Status Code to match PI spec

### DIFF
--- a/AdvLoggerPkg/Library/AssertTelemetryLib/AssertLib.c
+++ b/AdvLoggerPkg/Library/AssertTelemetryLib/AssertLib.c
@@ -110,7 +110,7 @@ DebugAssert (
     LogTelemetry (
       TRUE,
       NULL,
-      (EFI_SOFTWARE_UNSPECIFIED | EFI_SW_EC_RELEASE_ASSERT),
+      (EFI_SOFTWARE_UNSPECIFIED | EFI_SW_EC_ILLEGAL_SOFTWARE_STATE),
       NULL,
       NULL,
       Data1,


### PR DESCRIPTION
## Description

Remove usage of custom Pi Status code to use one defined in spec, `EFI_SW_EC_ILLEGAL_SOFTWARE_STATE`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
  

## How This Was Tested

CI

## Integration Instructions

For any telemetry report that used `EFI_SW_EC_RELEASE_ASSERT`, replace with `EFI_SW_EC_ILLEGAL_SOFTWARE_STATE`
