### PR TITLE
Removed All References to PcdAdvancedLoggerPeiInRam

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -85,11 +85,6 @@
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM|FALSE|BOOLEAN|0x00010189
 
-  ## PcdAdvancedLoggerPeiInRAM - Tells the PEI Advanced Logger that this PEI can allocate memory
-  #                              and there is no need for a temporary memory buffer
-  #
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerPeiInRAM|FALSE|BOOLEAN|0x00010185
-
   ## PcdAdvancedLoggerLocator - Tells the Advanced Logger to publish a variable with the logger info block address
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerLocator|FALSE|BOOLEAN|0x00010186

--- a/AdvLoggerPkg/Docs/ReadMe.md
+++ b/AdvLoggerPkg/Docs/ReadMe.md
@@ -14,7 +14,7 @@ The following configurations are supported:
 | ---      | --- |
 | DXE Only | Uses DxeCore, DxeRuntime, and Dxe AdvancedLoggerLib libraries for logging from start of DXE CORE through Exit Boot Services.  Accepts the PEI Advanced Logger Hob if one is generated.  Produces the AdvancedLogger protocol. |
 | DXE+SMM  | Requires DXE modules above, and adds the Smm AdvancedLoggerLib library.  Collects SMM generated messages in the in memory log. |
-| PEI      | Uses PeiCore and Pei AdvancedLoggerLib libraries.  Creates the Advanced Logger Hob if PcdAdvancedLoggerPeiInRAM is set. |
+| PEI      | Uses PeiCore and Pei AdvancedLoggerLib libraries. |
 | SEC      | Uses the Sec Advanced Logger Library. SEC requires a fixed load address, so it piggy backs on the Temporary RAM PCD information.  Produces a Fixed Address temporary RAM log.  When memory is added, the Sec Advanced Logger library converts the Temporary RAM logging information to the PEI Advanced Logger Hob. |
 | PEI64    | Uses Pei64 Advanced Logger Library. Requires the SEC fixed address temporary log information in order to log Pei64 bit DEBUG messages. |
 | MM       | Standalone MM - Loads during PEI phase. |
@@ -25,7 +25,6 @@ PCD's used by Advanced Logger
 | PCD                                     | Function of the PCD|
 | ---                                     | --- |
 |PcdAdvancedLoggerForceEnable             | The default operation is to check if a Logs directory is present in the root of the filesystem.  If the UefiLogs directory is present, logging is enabled. When PcdAdvancedLoggerForceEnable is TRUE, and the device is not a USB device, a UefiLogs directory will be created and logging is enabled.  When logging is enabled, the proper log files will be created if not already preset.|
-|PcdAdvancedLoggerPeiInRAM                | For systems that have memory at PeiCore entry. The full in memory log buffer if PcdAdvancedLoggerPages is allocated in the Pei Core constructor and PcdAdvancedLoggerPreMemPages is ignored.|
 |PcdAdvancedLoggerFixedInRAM              | For systems that have a fixed memory buffer prior to UEFI. The full in memory log buffer is assumed.|
 |PcdAdvancedHdwLoggerDebugPrintErrorLevel | The standard debug flags filter which log messages are produced.  This PCD allow a subset of log messages to be forwarded to the Hdw Port Lib.|
 |PcdAdvancedLoggerPreMemPages             | Amount of temporary RAM used for the debug log.|

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -76,7 +76,6 @@ ValidateInfoBlock (
 
   The following PCD settings are assumed:
 
-  PcdAdvancedLoggerPeiInRAM    -- TRUE
   PcdAdvancedLoggerBase        -- NOT NULL and pointer to memory to be used
   PcdAdvancedLoggerPages       -- > 64KB of pages
   PcdAdvancedLoggerCarBase     -- NOT USED, leave at default

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -31,7 +31,6 @@
 
   The following PCD settings are assumed:
 
-  PcdAdvancedLoggerPeiInRAM    -- TRUE
   PcdAdvancedLoggerBase        -- NOT NULL and pointer to memory to be used
   PcdAdvancedLoggerPages       -- > 64KB of pages
   PcdAdvancedLoggerCarBase     -- NOT USED, leave at default

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -453,7 +453,6 @@ AdvancedLoggerGetLoggerInfo (
   UINTN                             Pages;
   CONST EFI_PEI_SERVICES            **PeiServices;
   EFI_STATUS                        Status;
-  EFI_MEMORY_TYPE                   Type;
   ADVANCED_LOGGER_MESSAGE_ENTRY_V2  *LogEntry;
 
   // Try to do the minimum work at the start of this function as this
@@ -554,13 +553,11 @@ AdvancedLoggerGetLoggerInfo (
       //
 
       Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
-      // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
-      Type =  EfiBootServicesData;
 
       BufferSize = EFI_PAGES_TO_SIZE (Pages);
 
       Status = PeiServicesAllocatePages (
-                 Type,
+                 EfiBootServicesData,
                  Pages,
                  &NewLoggerInfo
                  );

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -553,14 +553,9 @@ AdvancedLoggerGetLoggerInfo (
       // Memory Discovered Ppi.  At that time, the full in memory log buffer is allocated.
       //
 
-      if (FeaturePcdGet (PcdAdvancedLoggerPeiInRAM)) {
-        Pages =  FixedPcdGet32 (PcdAdvancedLoggerPages);
-        Type  =  EfiRuntimeServicesData;
-      } else {
-        Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
-        // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
-        Type =  EfiBootServicesData;
-      }
+      Pages =  FixedPcdGet32 (PcdAdvancedLoggerPreMemPages);
+      // This is to avoid the interim buffer being allocated to consume 64KB on ARM64 platforms.
+      Type =  EfiBootServicesData;
 
       BufferSize = EFI_PAGES_TO_SIZE (Pages);
 
@@ -623,17 +618,7 @@ AdvancedLoggerGetLoggerInfo (
       Status = PeiServicesInstallPpi (mAdvancedLoggerPpiList);
       ASSERT_EFI_ERROR (Status);
 
-      if (FeaturePcdGet (PcdAdvancedLoggerPeiInRAM)) {
-        LoggerInfo->InPermanentRAM = TRUE;
-        Status                     = MmUnblockMemoryRequest (NewLoggerInfo, Pages);
-        if (EFI_ERROR (Status)) {
-          if (Status != EFI_UNSUPPORTED) {
-            DEBUG ((DEBUG_ERROR, "%a: Unable to notify StandaloneMM. Code=%r\n", __FUNCTION__, Status));
-          }
-        } else {
-          DEBUG ((DEBUG_INFO, "%a: StandaloneMM Hob data published\n", __FUNCTION__));
-        }
-      } else if (FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+      if (FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
         DEBUG ((DEBUG_INFO, "%a: Standalone MM Hob of fixed data published\n", __FUNCTION__));
       } else {
         PeiServicesNotifyPpi (mMemoryDiscoveredNotifyList);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -54,7 +54,6 @@
   gEfiPeiMemoryDiscoveredPpiGuid                                            ## CONSUMES
 
 [FeaturePcd]
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerPeiInRAM                     ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM                   ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
 


### PR DESCRIPTION
## Description

The PCD PcdAdvancedLoggerPeiInRam does not work and is being removed. For Intel systems, the PEI phase uses cache-as-ram and determines that there is no way to allocate memory. This PCD was supposed to signal to the logger that it could allocate memory, however, it would error as memory allocation was not allowed in that phase.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran the CI build for all packages in mu_plus for the X64 architecture. All tests passing.

## Integration Instructions

Users of PcdAdvancedLoggerPeiInRam will need to remove that PCD from DSCs. It is not expected there are users as the PCD does not work, although platforms may have specifically set it to FALSE.