### PR TITLE
Removed reference to PcdAdvancedHdwLoggerDisable in the README

### DIFF
--- a/AdvLoggerPkg/Docs/ReadMe.md
+++ b/AdvLoggerPkg/Docs/ReadMe.md
@@ -28,7 +28,6 @@ PCD's used by Advanced Logger
 |PcdAdvancedLoggerPeiInRAM                | For systems that have memory at PeiCore entry. The full in memory log buffer if PcdAdvancedLoggerPages is allocated in the Pei Core constructor and PcdAdvancedLoggerPreMemPages is ignored.|
 |PcdAdvancedLoggerFixedInRAM              | For systems that have a fixed memory buffer prior to UEFI. The full in memory log buffer is assumed.|
 |PcdAdvancedHdwLoggerDebugPrintErrorLevel | The standard debug flags filter which log messages are produced.  This PCD allow a subset of log messages to be forwarded to the Hdw Port Lib.|
-|PcdAdvancedHdwLoggerDisable              | Specifies when to disable writing to the Hdw Port.|
 |PcdAdvancedLoggerPreMemPages             | Amount of temporary RAM used for the debug log.|
 |PcdAdvancedLoggerPages                   | Amount of system RAM used for the debug log|
 |PcdAdvancedLoggerLocator                 | When enabled, the AdvLogger creates a variable "AdvLoggerLocator" with the address of the LoggerInfo buffer|


### PR DESCRIPTION
## Description

Removed reference to PcdAdvHdwLoggerDisable in the ReadMe MarkDown document.

In commit 38339016109e88a3f4ebaf8a7728b68bde0ca95f, PcdAdvancedSerialLoggerDisable in AdvLoggerPkg.dec was changed to PcdAdvancedLoggerHdwPortDisable but in the ReadMe was changed to PcdAdvancedHdwLoggerDisable.

This PCD was later removed from the .DEC in commit 8770182b7b18d55497763c4771f0804bc1e6d783 but wasn't removed from the ReadMe due to the naming difference.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran CI for X64 Architecture. All Test Passed.

## Integration Instructions

N/A