### PR TITLE
Updated logic to allocate more data once it needs to query memory map

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.c
@@ -605,6 +605,8 @@ InitializeTestEnvironment (
     return EFI_UNSUPPORTED;
   }
 
+  // Allocate extra memory in case this allocation caused the memory to change.
+  MapSize     += SIZE_1KB;
   EfiMemoryMap = AllocateZeroPool (MapSize);
   if (!EfiMemoryMap) {
     return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
## Description

This change updates the logic to allocate 1KB extra data for the subsequent GetMemoryMap function call to avoid once and done failure in the test app.

Fixes https://github.com/microsoft/mu_tiano_platforms/issues/1017.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 and verified fixed the original issue.

## Integration Instructions

N/A