### PR TITLE
MsGraphicsPkg: Correct positioning of trash can icon in Load Option's list box

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
@@ -982,9 +982,9 @@ Ctor (
 
       SWM_RECT_INIT2 (
         this->m_pCells[Index].CellTrashcanBounds,
-        CellBounds->Left,
+        CellBounds->Right - TrashcanHitAreaWidth,
         CellBounds->Top,
-        CheckBoxHitAreaWidth,
+        TrashcanHitAreaWidth,
         SWM_RECT_HEIGHT (*CellBounds)
         );
     }


### PR DESCRIPTION
## Description

Fixes #554 

- Adjusted CellTrashcanBounds.Left to be CellBounds->Right - TrashcanHitAreaWidth
  to ensure the trash can icon is displayed to the right of the list box.
- Updated width parameter in SWM_RECT_INIT2 to use TrashcanHitAreaWidth instead
  of CheckBoxHitAreaWidth for correct dimensions.

This resolves the issue of the trash can icon overlapping with the ListBox's deletable item's checkbox thus ensuring its related operations work correctly: activating/deactivating the Load Option or deleting it.

## How This Was Tested

Verified that a Load Option allowed to be deleted, such as 'Windows Boot Manager', can now be deleted by pressing the trash icon in its proper position or activated via its check-box.

## Integration Instructions

N/A