### PR TITLE
[MsGraphicsPkg] Fix the bounds of the Trashcan within the ListBox

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/ListBox.c
@@ -982,7 +982,7 @@ Ctor (
 
       SWM_RECT_INIT2 (
         this->m_pCells[Index].CellTrashcanBounds,
-        CellBounds->Left,
+        CellBounds->Right - TrashcanHitAreaWidth,
         CellBounds->Top,
         CheckBoxHitAreaWidth,
         SWM_RECT_HEIGHT (*CellBounds)


### PR DESCRIPTION
## Description

https://github.com/microsoft/mu_plus/issues/554

Fix the bounds of the Trashcan within the ListBox which was introduced in https://github.com/microsoft/mu_plus/commit/a447466ab740870ef82f2242a433ca8c768d5cc3.
The Trashcan should be shown on the right side of the ListBox, but it is currently showing on the left side and overlapping the checkbox icon.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Surface Laptop and Pro devices. The Trashcan icon is showing on the right side of the Boot Device List Box.

## Integration Instructions

N/A
