### PR TITLE
AdvLoggerPkg: Add GoogleTest for AdvancedLoggerPeiLib

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
+++ b/AdvLoggerPkg/AdvLoggerPkg.ci.yaml
@@ -89,7 +89,9 @@
           DEBUGAGENT,
           POSTMEM,
           MMARM,
-          BLKIO
+          BLKIO,
+          dlink,
+          uintn
         ]
     },
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
@@ -1,0 +1,227 @@
+/** @file AdvancedLoggerPeiLibGoogleTest.cpp
+
+    This file contains the unit tests for the Advanced Logger DXE Library.
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockPeiServicesLib.h>
+#include <GoogleTest/Ppi/MockAdvancedLogger.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Base.h>
+  #include <Library/BaseLib.h>
+  #include <Library/DebugLib.h>
+  #include <AdvancedLoggerInternal.h>
+  #include "../../AdvancedLoggerCommon.h"
+}
+
+using namespace testing;
+
+/**
+  Test class for AdvancedLoggerWrite Function
+**/
+class AdvancedLoggerWriteTestPei : public Test {
+protected:
+  StrictMock<MockPeiServicesLib> PeiServicesMock;
+  StrictMock<MockAdvancedLoggerPpi> AdvancedLoggerPpiMock;
+  UINTN DebugLevel;
+  UINTN Instance;
+  CHAR8 *Buffer;
+  UINTN NumberOfBytes;
+
+  void
+  SetUp (
+    ) override
+  {
+    CHAR8  OutputBuf[] = "MyUnitTestLog";
+
+    NumberOfBytes     = sizeof (OutputBuf);
+    Buffer            = OutputBuf;
+    DebugLevel        = DEBUG_ERROR;
+    Instance          = 0;
+    gALPpi->Signature = ADVANCED_LOGGER_PPI_SIGNATURE;
+    gALPpi->Version   = ADVANCED_LOGGER_PPI_VERSION;
+  }
+};
+
+TEST_F (AdvancedLoggerWriteTestPei, PpiNotFounfFailure) {
+  // Expect the locate PPI call to fail
+  EXPECT_CALL (
+    PeiServicesMock,
+    PeiServicesLocatePpi (
+      BufferEq (&gAdvancedLoggerPpiGuid, sizeof (EFI_GUID)),
+      Eq (Instance),
+      IsNull (),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       Return (EFI_NOT_FOUND)
+       );
+
+  AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
+}
+
+TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteSuccess) {
+  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
+  EXPECT_CALL (
+    PeiServicesMock,
+    PeiServicesLocatePpi (
+      BufferEq (&gAdvancedLoggerPpiGuid, sizeof (EFI_GUID)),
+      Eq (Instance),
+      IsNull (),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgPointee<3>(ByRef (gALPpi)),
+         Return (EFI_SUCCESS)
+         )
+       );
+
+  // Expect the call to AdvancedLoggerWritePpi
+  EXPECT_CALL (
+    AdvancedLoggerPpiMock,
+    gAL_AdvancedLoggerWritePpi (
+      Eq (DebugLevel),
+      BufferEq (Buffer, NumberOfBytes),
+      Eq (NumberOfBytes)
+      )
+    )
+    .WillOnce (
+       Return ()
+       );
+
+  AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
+}
+
+/* Passing an invalid buffer - should be caught/handled by the protocol */
+TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteInvalidBuffer) {
+  Buffer = nullptr;
+  UINTN  numBytesZero = 0;
+
+  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
+  EXPECT_CALL (
+    PeiServicesMock,
+    PeiServicesLocatePpi (
+      BufferEq (&gAdvancedLoggerPpiGuid, sizeof (EFI_GUID)),
+      Eq (Instance),
+      IsNull (),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgPointee<3>(ByRef (gALPpi)),
+         Return (EFI_SUCCESS)
+         )
+       );
+
+  // Expect the call to AdvancedLoggerWritePpi
+  EXPECT_CALL (
+    AdvancedLoggerPpiMock,
+    gAL_AdvancedLoggerWritePpi (
+      Eq (DebugLevel),
+      BufferEq (Buffer, numBytesZero),
+      Eq (NumberOfBytes)
+      )
+    )
+    .WillOnce (
+       Return ()
+       );
+
+  AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
+}
+
+/* Attempting to write 0 bytes - should be caught/handled by the protocol */
+TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteZeroBytes) {
+  UINTN  NumberOfBytesZero = 0;
+
+  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
+  EXPECT_CALL (
+    PeiServicesMock,
+    PeiServicesLocatePpi (
+      BufferEq (&gAdvancedLoggerPpiGuid, sizeof (EFI_GUID)),
+      Eq (Instance),
+      IsNull (),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgPointee<3>(ByRef (gALPpi)),
+         Return (EFI_SUCCESS)
+         )
+       );
+
+  // Expect the call to AdvancedLoggerWritePpi
+  EXPECT_CALL (
+    AdvancedLoggerPpiMock,
+    gAL_AdvancedLoggerWritePpi (
+      Eq (DebugLevel),
+      BufferEq (Buffer, NumberOfBytes),
+      Eq (NumberOfBytesZero)
+      )
+    )
+    .WillOnce (
+       Return ()
+       );
+
+  AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytesZero);
+}
+
+/* Passing a mismatched signature. Asserts are disabled so execution will continue */
+TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteFailMismatchedSignature) {
+  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
+  gALPpi->Signature = SIGNATURE_32 ('T', 'E', 'S', 'T');
+  gALPpi->Version   = ADVANCED_LOGGER_PPI_VERSION + 1;
+
+  EXPECT_CALL (
+    PeiServicesMock,
+    PeiServicesLocatePpi (
+      BufferEq (&gAdvancedLoggerPpiGuid, sizeof (EFI_GUID)),
+      Eq (Instance),
+      IsNull (),
+      NotNull ()
+      )
+    )
+    .WillOnce (
+       DoAll (
+         SetArgPointee<3>(ByRef (gALPpi)),
+         Return (EFI_SUCCESS)
+         )
+       );
+
+  // TODO - why do we still expect a call to AdvancedLoggerWritePpi? shouldn't we exit?
+  // Or are we expecting the call to AdvancedLoggerWritePpi to check the signature and fail?
+
+  // Expect the call to AdvancedLoggerWritePpi
+  EXPECT_CALL (
+    AdvancedLoggerPpiMock,
+    gAL_AdvancedLoggerWritePpi (
+      Eq (DebugLevel),
+      BufferEq (Buffer, NumberOfBytes),
+      Eq (NumberOfBytes)
+      )
+    )
+    .WillOnce (
+       Return ()
+       );
+
+  AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
+}
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
@@ -1,6 +1,6 @@
 /** @file AdvancedLoggerPeiLibGoogleTest.cpp
 
-    This file contains the unit tests for the Advanced Logger DXE Library.
+    This file contains the unit tests for the Advanced Logger PEI Library.
 
     Copyright (c) Microsoft Corporation.
     SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -48,7 +48,7 @@ protected:
   }
 };
 
-TEST_F (AdvancedLoggerWriteTestPei, PpiNotFounfFailure) {
+TEST_F (AdvancedLoggerWriteTestPei, PpiNotFoundFailure) {
   // Expect the locate PPI call to fail
   EXPECT_CALL (
     PeiServicesMock,
@@ -175,12 +175,14 @@ TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteZeroBytes) {
   AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytesZero);
 }
 
-/* Passing a mismatched signature. Asserts are disabled so execution will continue */
+/* Passing a mismatched signature. Asserts are disabled so execution will continue.
+   Expecting the write function to exit gracefully and not call gAL_AdvancedLoggerWritePpi
+ */
 TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteFailMismatchedSignature) {
-  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
   gALPpi->Signature = SIGNATURE_32 ('T', 'E', 'S', 'T');
   gALPpi->Version   = ADVANCED_LOGGER_PPI_VERSION + 1;
 
+  // Expect the call to LocatePpi to return success, "found" AdvancedLoggerPpi (mocked)
   EXPECT_CALL (
     PeiServicesMock,
     PeiServicesLocatePpi (
@@ -195,22 +197,6 @@ TEST_F (AdvancedLoggerWriteTestPei, AdvLoggerWriteFailMismatchedSignature) {
          SetArgPointee<3>(ByRef (gALPpi)),
          Return (EFI_SUCCESS)
          )
-       );
-
-  // TODO - why do we still expect a call to AdvancedLoggerWritePpi? shouldn't we exit?
-  // Or are we expecting the call to AdvancedLoggerWritePpi to check the signature and fail?
-
-  // Expect the call to AdvancedLoggerWritePpi
-  EXPECT_CALL (
-    AdvancedLoggerPpiMock,
-    gAL_AdvancedLoggerWritePpi (
-      Eq (DebugLevel),
-      BufferEq (Buffer, NumberOfBytes),
-      Eq (NumberOfBytes)
-      )
-    )
-    .WillOnce (
-       Return ()
        );
 
   AdvancedLoggerWrite (DebugLevel, Buffer, NumberOfBytes);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.inf
@@ -1,0 +1,39 @@
+## @file AdvancedLoggerPeiLibGoogleTest.inf
+#
+#  Google Test for PEI instance of the Advanced Logger library.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = AdvancedLoggerPeiLibGoogleTest
+  FILE_GUID                      = 95196693-DA35-4775-887C-1FF9C65D5054
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  AdvancedLoggerPeiLibGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AdvLoggerPkg/AdvLoggerPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  AdvancedLoggerLib
+
+[Ppis]
+  gAdvancedLoggerPpiGuid                                    ## CONSUMES
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/AdvLoggerPkg/Test/AdvLoggerHostTest.dsc
+++ b/AdvLoggerPkg/Test/AdvLoggerHostTest.dsc
@@ -50,3 +50,8 @@
   AdvLoggerPkg/AdvLoggerOsConnectorPrm/Library/AdvLoggerOsConnectorPrmConfigLib/GoogleTest/AdvLoggerPrmConfigLibGoogleTest.inf
   AdvLoggerPkg/AdvLoggerOsConnectorPrm/GoogleTest/AdvLoggerOsConnectorPrmGoogleTest.inf
   AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/GoogleTest/AdvancedLoggerDxeLibGoogleTest.inf
+  AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.inf {
+    <LibraryClasses>
+      AdvancedLoggerLib|AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/AdvancedLoggerLib.inf
+      PeiServicesLib|MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
+  }

--- a/AdvLoggerPkg/Test/Mock/Include/GoogleTest/Ppi/MockAdvancedLogger.h
+++ b/AdvLoggerPkg/Test/Mock/Include/GoogleTest/Ppi/MockAdvancedLogger.h
@@ -29,14 +29,6 @@ struct MockAdvancedLoggerPpi {
 
   MOCK_FUNCTION_DECLARATION (
     VOID,
-    gAL_AdvancedLoggerPrintPpi,
-    (IN        UINTN    ErrorLevel,
-     IN  CONST CHAR8    *Format,
-     IN        VA_LIST  VaListMarker)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
-    VOID,
     gAL_AdvancedLoggerAssertPpi,
     (IN CONST CHAR8    *FileName,
      IN       UINTN    LineNumber,
@@ -51,8 +43,22 @@ struct MockAdvancedLoggerPpi {
 //
 MOCK_INTERFACE_DEFINITION (MockAdvancedLoggerPpi);
 MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerWritePpi, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerPrintPpi, 3, EFIAPI);
+// MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerPrintPpi, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerAssertPpi, 3, EFIAPI);
+
+// Mock function definition for gAL_AdvancedLoggerPrintPpi to use C standard VA_LIST
+extern "C" {
+  VOID
+  EFIAPI
+  gAL_AdvancedLoggerPrintPpi (
+    IN        UINTN    ErrorLevel,
+    IN  CONST CHAR8    *Format,
+    IN        VA_LIST  VaListMarker
+    )
+  {
+    return;
+  }
+}
 
 ADVANCED_LOGGER_PPI  advancedLoggerPpiInstance = {
   ADVANCED_LOGGER_PPI_SIGNATURE, // UINT32

--- a/AdvLoggerPkg/Test/Mock/Include/GoogleTest/Ppi/MockAdvancedLogger.h
+++ b/AdvLoggerPkg/Test/Mock/Include/GoogleTest/Ppi/MockAdvancedLogger.h
@@ -1,0 +1,69 @@
+/** @file MockAdvancedLogger.h
+    This file declares a mock of the Advanced Logger Ppi.
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_ADVANCED_LOGGER_PPI_H_
+#define MOCK_ADVANCED_LOGGER_PPI_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Ppi/AdvancedLogger.h>
+}
+
+struct MockAdvancedLoggerPpi {
+  MOCK_INTERFACE_DECLARATION (MockAdvancedLoggerPpi);
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gAL_AdvancedLoggerWritePpi,
+    (IN        UINTN    ErrorLevel,
+     IN  CONST CHAR8    *Buffer,
+     IN        UINTN    NumberOfBytes)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gAL_AdvancedLoggerPrintPpi,
+    (IN        UINTN    ErrorLevel,
+     IN  CONST CHAR8    *Format,
+     IN        VA_LIST  VaListMarker)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gAL_AdvancedLoggerAssertPpi,
+    (IN CONST CHAR8    *FileName,
+     IN       UINTN    LineNumber,
+     IN CONST CHAR8    *Description)
+    );
+};
+
+//
+// Mock function definitions in header file to prevent need of cpp file and
+// make it easier to consume in tests.
+// This is only suitable for protocol mocks.
+//
+MOCK_INTERFACE_DEFINITION (MockAdvancedLoggerPpi);
+MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerWritePpi, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerPrintPpi, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAdvancedLoggerPpi, gAL_AdvancedLoggerAssertPpi, 3, EFIAPI);
+
+ADVANCED_LOGGER_PPI  advancedLoggerPpiInstance = {
+  ADVANCED_LOGGER_PPI_SIGNATURE, // UINT32
+  ADVANCED_LOGGER_PPI_VERSION,   // UINT32
+  gAL_AdvancedLoggerWritePpi,    // ADVANCED_LOGGER_WRITE_PPI
+  gAL_AdvancedLoggerPrintPpi,    // ADVANCED_LOGGER_PRINT_PPI
+  gAL_AdvancedLoggerAssertPpi    // ADVANCED_LOGGER_ASSERT_PPI
+};
+
+extern "C" {
+  ADVANCED_LOGGER_PPI  *gALPpi = &advancedLoggerPpiInstance;
+}
+
+#endif // MOCK_ADVANCED_LOGGER_PPI_H_


### PR DESCRIPTION
## Description
Add GoogleTest for AdvancedLoggerPeiLib.
Add a mock for the AdvancedLoggerPpi to be used in the GoogleTest.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI. Building the test locally.

## Integration Instructions

N/A