### PR TITLE
AdvLoggerPkg: Exit from write call if signature mismatch

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/AdvancedLoggerLib.c
@@ -43,8 +43,15 @@ AdvancedLoggerWrite (
              );
 
   if (Status == EFI_SUCCESS) {
-    ASSERT (AdvancedLoggerPpi->Signature == ADVANCED_LOGGER_PPI_SIGNATURE);
-    ASSERT (AdvancedLoggerPpi->Version == ADVANCED_LOGGER_PPI_VERSION);
+    if ((AdvancedLoggerPpi->Signature != ADVANCED_LOGGER_PPI_SIGNATURE) ||
+        (AdvancedLoggerPpi->Version != ADVANCED_LOGGER_PPI_VERSION))
+    {
+      ASSERT (AdvancedLoggerPpi->Signature == ADVANCED_LOGGER_PPI_SIGNATURE);
+      ASSERT (AdvancedLoggerPpi->Version == ADVANCED_LOGGER_PPI_VERSION);
+
+      // Signature/Version mismatch, don't attempt to use the PPI.
+      return;
+    }
 
     AdvancedLoggerPpi->AdvancedLoggerWritePpi (ErrorLevel, Buffer, NumberOfBytes);
   }


### PR DESCRIPTION
## Description

Current behavior allows the PPI to be used if there is a signature or version mismatch. This fix returns from the function to exit gracefully and prevent memory corruption. 

Create a bug to track this behavior elsewhere in Advanced Logger Library: https://github.com/microsoft/mu_plus/issues/567

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local CI and unit test.

## Integration Instructions

N/A