### PR TITLE
AdvLoggerPkg: Run AARCH64 CI

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dsc
+++ b/AdvLoggerPkg/AdvLoggerPkg.dsc
@@ -11,7 +11,7 @@
   PLATFORM_VERSION               = .10
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/AdvLoggerPkg
-  SUPPORTED_ARCHITECTURES        = IA32|X64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -65,16 +65,14 @@
   ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
   FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
   AdvancedLoggerAccessLib|AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.inf
-
-[LibraryClasses.common.UEFI_APPLICATION]
-  UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
-  UnitTestResultReportLib|XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.inf
-
-[LibraryClasses.X64]
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   AdvancedLoggerLib|AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/AdvancedLoggerLib.inf
   AdvancedLoggerHdwPortLib|AdvLoggerPkg/Library/AdvancedLoggerHdwPortLib/AdvancedLoggerHdwPortLib.inf
   AssertLib|AdvLoggerPkg/Library/AssertLib/AssertLib.inf
+
+[LibraryClasses.common.UEFI_APPLICATION]
+  UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
+  UnitTestResultReportLib|XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.inf
 
 [LibraryClasses.common.PEIM]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
@@ -84,8 +82,6 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   AdvancedLoggerLib|AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/AdvancedLoggerLib.inf
 
-[LibraryClasses.common.DXE_CORE]
-
 [LibraryClasses.common.DXE_DRIVER]
   PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
 
@@ -93,6 +89,8 @@
   AdvancedLoggerLib|AdvLoggerPkg/Library/AdvancedLoggerLib/Smm/AdvancedLoggerLib.inf
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
 
+[LibraryClasses.AARCH64]
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
 
 ###################################################################################################
 #

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -53,7 +53,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if (PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress) ||
+  if ((PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress) ||
       (mLoggerInfo->LogCurrentOffset < mLoggerInfo->LogBufferOffset))
   {
     return FALSE;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -108,7 +108,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if (PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress ||
+  if ((PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress) ||
       (mLoggerInfo->LogCurrentOffset < mLoggerInfo->LogBufferOffset))
   {
     return FALSE;
@@ -382,12 +382,12 @@ DxeCoreAdvancedLoggerLibConstructor (
     LoggerInfo = (ADVANCED_LOGGER_INFO *)AllocateReservedPages (FixedPcdGet32 (PcdAdvancedLoggerPages));
     if (LoggerInfo != NULL) {
       ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
-      LoggerInfo->Signature     = ADVANCED_LOGGER_SIGNATURE;
-      LoggerInfo->Version       = ADVANCED_LOGGER_VERSION;
-      LoggerInfo->LogBufferOffset     = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-      LoggerInfo->LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
-      LoggerInfo->LogCurrentOffset    = LoggerInfo->LogBufferOffset;
-      LoggerInfo->HwPrintLevel  = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+      LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+      LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+      LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+      LoggerInfo->LogBufferSize    = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
+      LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
+      LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
       if (LoggerInfo->HdwPortInitialized == FALSE) {
         AdvancedLoggerHdwPortInitialize ();
         LoggerInfo->HdwPortInitialized = TRUE;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
@@ -189,7 +189,6 @@ TEST_F (AdvancedLoggerDxeCoreTest, AdvLoggerContructorSuccess) {
   DxeCoreAdvancedLoggerLibConstructor (ImageHandle, SystemTable);
 }
 */
-
 int
 main (
   int   argc,

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
@@ -50,7 +50,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if(mLoggerInfo->Version != ADVANCED_LOGGER_VERSION) {
+  if (mLoggerInfo->Version != ADVANCED_LOGGER_VERSION) {
     return FALSE;
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.cpp
@@ -78,7 +78,7 @@ TEST_F (AdvancedLoggerMmCoreTest, AdvLoggerGetInfoFail) {
   mLoggerInfo->Signature = ADVANCED_LOGGER_SIGNATURE;
 
   // Invalid Version
-  mLoggerInfo->Version = (UINT32) ADVANCED_LOGGER_VERSION + 1;
+  mLoggerInfo->Version = (UINT32)ADVANCED_LOGGER_VERSION + 1;
   Status               = ValidateInfoBlock ();
   EXPECT_EQ (Status, FALSE);
   mLoggerInfo->Version = ADVANCED_LOGGER_VERSION;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -82,7 +82,7 @@ AdvancedLoggerGetLoggerInfo (
   }
 
   // Make sure the size of the buffer does not overrun it's fixed size.
-  MaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
+  MaxAddress = LOG_MAX_ADDRESS (LoggerInfo);
   if ((MaxAddress - PA_FROM_PTR (LoggerInfo)) >
       (FixedPcdGet32 (PcdAdvancedLoggerPages) * EFI_PAGE_SIZE))
   {
@@ -90,7 +90,7 @@ AdvancedLoggerGetLoggerInfo (
   }
 
   // Ensure the current pointer does not overrun.
-  if ((LOG_CURRENT_FROM_ALI (LoggerInfo) > MaxAddress) ||
+  if ((*LOG_CURRENT_FROM_ALI (LoggerInfo) > MaxAddress) ||
       (LoggerInfo->LogCurrentOffset < LoggerInfo->LogBufferOffset))
   {
     return NULL;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -511,12 +511,12 @@ AdvancedLoggerGetLoggerInfo (
     LoggerInfo = (ADVANCED_LOGGER_INFO *)GET_GUID_HOB_DATA (GuidHobInterimBuf);
     BufferSize = sizeof (ADVANCED_LOGGER_INFO) + ADVANCED_LOGGER_MAX_MESSAGE_SIZE;
     ZeroMem ((VOID *)LoggerInfo, BufferSize);
-    LoggerInfo->Signature     = ADVANCED_LOGGER_SIGNATURE;
-    LoggerInfo->Version       = ADVANCED_LOGGER_VERSION;
-    LoggerInfo->LogBufferOffset     = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-    LoggerInfo->LogBufferSize = (UINT32)(BufferSize - sizeof (ADVANCED_LOGGER_INFO));
-    LoggerInfo->LogCurrentOffset    = LoggerInfo->LogBufferOffset;
-    LoggerInfo->HwPrintLevel  = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+    LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+    LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+    LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+    LoggerInfo->LogBufferSize    = (UINT32)(BufferSize - sizeof (ADVANCED_LOGGER_INFO));
+    LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
+    LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
     AdvancedLoggerHdwPortInitialize ();
     CopyGuid (&GuidHobInterimBuf->Name, &gAdvancedLoggerInterimBufHobGuid);
     LoggerInfo->HdwPortInitialized = TRUE;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -58,7 +58,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if (PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress ||
+  if ((PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress) ||
       (mLoggerInfo->LogCurrentOffset < mLoggerInfo->LogBufferOffset))
   {
     return FALSE;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
@@ -99,7 +99,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if (PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress ||
+  if ((PA_FROM_PTR (LOG_CURRENT_FROM_ALI (mLoggerInfo)) > mMaxAddress) ||
       (mLoggerInfo->LogCurrentOffset < mLoggerInfo->LogBufferOffset))
   {
     return FALSE;

--- a/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
@@ -128,8 +128,8 @@ InitializeDebugAgent (
       LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
       LoggerInfo->Version            = ADVANCED_LOGGER_VERSION;
       LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
-      LoggerInfo->LogBufferOffset          = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-      LoggerInfo->LogCurrentOffset         = LoggerInfo->LogBufferOffset;
+      LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+      LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
       LoggerInfo->HdwPortInitialized = TRUE;
       LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
       LogPtr->LogBuffer              = NewLogBuffer; // Set physical address of Logger Memory at TemporaryRamBase
@@ -195,7 +195,7 @@ InitializeDebugAgent (
           NewLoggerInfo = ALI_FROM_PA (NewLogBuffer);
           CopyMem ((VOID *)NewLoggerInfo, (VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
           NewLoggerInfo->LogBufferOffset = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-          TargetLog                = CHAR8_FROM_PA (LOG_BUFFER_FROM_ALI (NewLoggerInfo));
+          TargetLog                      = CHAR8_FROM_PA (LOG_BUFFER_FROM_ALI (NewLoggerInfo));
 
           if (LoggerInfo->LogCurrentOffset > 0) {
             CopyMem (
@@ -205,9 +205,9 @@ InitializeDebugAgent (
               );
           }
 
-          NewLoggerInfo->LogBufferSize  = (EFI_PAGE_SIZE * FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
-          NewLoggerInfo->LogCurrentOffset     = LoggerInfo->LogCurrentOffset;
-          NewLoggerInfo->InPermanentRAM = TRUE;
+          NewLoggerInfo->LogBufferSize    = (EFI_PAGE_SIZE * FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
+          NewLoggerInfo->LogCurrentOffset = LoggerInfo->LogCurrentOffset;
+          NewLoggerInfo->InPermanentRAM   = TRUE;
 
           PeiServices                   = GetPeiServicesTablePointer ();
           PeiCoreInstance               = PEI_CORE_INSTANCE_FROM_PS_THIS (PeiServices);

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -218,9 +218,9 @@ InternalTestLoggerWrite (
     );
 
   LoggerInfo->LogCurrentOffset = LoggerInfo->LogCurrentOffset + (UINT32)EntrySize;
-  Entry                  = (ADVANCED_LOGGER_MESSAGE_ENTRY *)PTR_FROM_PA (CurrentBuffer);
-  if ((Entry != (ADVANCED_LOGGER_MESSAGE_ENTRY *)ALIGN_POINTER (Entry, 8)) ||                  // Insure pointer is on boundary
-      (Entry <  (ADVANCED_LOGGER_MESSAGE_ENTRY *)PTR_FROM_PA (LOG_BUFFER_FROM_ALI (LoggerInfo))) ||       // and within the log region
+  Entry                        = (ADVANCED_LOGGER_MESSAGE_ENTRY *)PTR_FROM_PA (CurrentBuffer);
+  if ((Entry != (ADVANCED_LOGGER_MESSAGE_ENTRY *)ALIGN_POINTER (Entry, 8)) ||                       // Insure pointer is on boundary
+      (Entry <  (ADVANCED_LOGGER_MESSAGE_ENTRY *)PTR_FROM_PA (LOG_BUFFER_FROM_ALI (LoggerInfo))) || // and within the log region
       (Entry >  (ADVANCED_LOGGER_MESSAGE_ENTRY *)PTR_FROM_PA ((UINT8 *)LoggerInfo + TOTAL_LOG_SIZE_WITH_ALI (LoggerInfo))))
   {
     UT_ASSERT_TRUE (FALSE);
@@ -265,9 +265,9 @@ InternalTestLoggerWriteV2 (
     );
 
   LoggerInfo->LogCurrentOffset = LoggerInfo->LogCurrentOffset + (UINT32)EntrySize;
-  Entry                  = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)PTR_FROM_PA (CurrentBuffer);
-  if ((Entry != (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)ALIGN_POINTER (Entry, 8)) ||                  // Insure pointer is on boundary
-      (Entry <  (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)PTR_FROM_PA (LOG_BUFFER_FROM_ALI (LoggerInfo))) ||       // and within the log region
+  Entry                        = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)PTR_FROM_PA (CurrentBuffer);
+  if ((Entry != (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)ALIGN_POINTER (Entry, 8)) ||                       // Insure pointer is on boundary
+      (Entry <  (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)PTR_FROM_PA (LOG_BUFFER_FROM_ALI (LoggerInfo))) || // and within the log region
       (Entry >  (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)PTR_FROM_PA ((UINT8 *)LoggerInfo + TOTAL_LOG_SIZE_WITH_ALI (LoggerInfo))))
   {
     UT_ASSERT_TRUE (FALSE);
@@ -403,16 +403,17 @@ InitializeInMemoryLog (
 
   #define IN_MEMORY_PAGES  32// 1 MB test memory log
 
-  mLoggerInfo     = AllocatePages (IN_MEMORY_PAGES);
+  mLoggerInfo = AllocatePages (IN_MEMORY_PAGES);
   if (mLoggerInfo == NULL) {
     UT_ASSERT_TRUE (FALSE);
   }
-  mLoggerInfo->Signature = ADVANCED_LOGGER_SIGNATURE;
-  mLoggerInfo->GoneVirtual = FALSE;
-  mLoggerInfo->AtRuntime = FALSE;
-  mLoggerInfo->LogBufferSize = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
-  mLoggerInfo->LogBufferOffset = sizeof (*mLoggerInfo);
-  mLoggerInfo->LogCurrentOffset    = mLoggerInfo->LogBufferOffset;
+
+  mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->GoneVirtual      = FALSE;
+  mLoggerInfo->AtRuntime        = FALSE;
+  mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
+  mLoggerInfo->LogBufferOffset  = sizeof (*mLoggerInfo);
+  mLoggerInfo->LogCurrentOffset = mLoggerInfo->LogBufferOffset;
 
   for (i = 0; i < ARRAY_SIZE (InternalMemoryLog); i++) {
     UnitTestStatus = InternalTestLoggerWrite (
@@ -451,16 +452,17 @@ InitializeInMemoryLogV2 (
   }
 
   // Repopulate the content with v2 messages
-  mLoggerInfo     = AllocatePages (IN_MEMORY_PAGES);
+  mLoggerInfo = AllocatePages (IN_MEMORY_PAGES);
   if (mLoggerInfo == NULL) {
     UT_ASSERT_TRUE (FALSE);
   }
-  mLoggerInfo->Signature = ADVANCED_LOGGER_SIGNATURE;
-  mLoggerInfo->GoneVirtual = FALSE;
-  mLoggerInfo->AtRuntime = FALSE; 
-  mLoggerInfo->LogBufferSize = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
-  mLoggerInfo->LogBufferOffset = sizeof (*mLoggerInfo);
-  mLoggerInfo->LogCurrentOffset    = mLoggerInfo->LogBufferOffset;
+
+  mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->GoneVirtual      = FALSE;
+  mLoggerInfo->AtRuntime        = FALSE;
+  mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
+  mLoggerInfo->LogBufferOffset  = sizeof (*mLoggerInfo);
+  mLoggerInfo->LogCurrentOffset = mLoggerInfo->LogBufferOffset;
 
   ZeroMem (&mMessageEntry, sizeof (mMessageEntry));
 
@@ -500,16 +502,17 @@ InitializeInMemoryLogV2Hybrid (
     mLoggerInfo = NULL;
   }
 
-  mLoggerInfo     = AllocatePages (IN_MEMORY_PAGES);
+  mLoggerInfo = AllocatePages (IN_MEMORY_PAGES);
   if (mLoggerInfo == NULL) {
     UT_ASSERT_TRUE (FALSE);
   }
-  mLoggerInfo->Signature = ADVANCED_LOGGER_SIGNATURE;
-  mLoggerInfo->GoneVirtual = FALSE;
-  mLoggerInfo->AtRuntime = FALSE; 
-  mLoggerInfo->LogBufferSize = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
-  mLoggerInfo->LogBufferOffset = sizeof (*mLoggerInfo);
-  mLoggerInfo->LogCurrentOffset    = mLoggerInfo->LogBufferOffset;
+
+  mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->GoneVirtual      = FALSE;
+  mLoggerInfo->AtRuntime        = FALSE;
+  mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
+  mLoggerInfo->LogBufferOffset  = sizeof (*mLoggerInfo);
+  mLoggerInfo->LogCurrentOffset = mLoggerInfo->LogBufferOffset;
 
   ZeroMem (&mMessageEntry, sizeof (mMessageEntry));
 


### PR DESCRIPTION
## Description

AdvLoggerPkg.dsc was not setup to run CI for AARCH64 and as a result the ARM64 parts of this pkg were broken. This commit fixes the various build and CI breaks and enables CI for AARCH64 in AdvLoggerPkg.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

AARCH64 CI now passes.

## Integration Instructions

N/A.