### PR TITLE
AdvLoggerPkg: Clarify BaseArm instance of AdvLoggerLib

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -1,7 +1,7 @@
 /** @file
-  MM_CORE Arm implementation of Advanced Logger Library.
+  Standalone MM Arm implementation of Advanced Logger Library.
 
-  Copyright (c) Microsoft Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -14,11 +14,11 @@
   FILE_GUID                      = 916f2e2d-1f55-4ca4-b229-18487e94c747
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = AdvancedLoggerLib
+  LIBRARY_CLASS                  = AdvancedLoggerLib | MM_STANDALONE
   PI_SPECIFICATION_VERSION       = 0x00010032
 
 #
-#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#  VALID_ARCHITECTURES           = AARCH64
 #
 
 [Sources]


### PR DESCRIPTION
## Description

The BaseArm instance of AdvLoggerLib has drifted in usage over time from being a BASE instance to an MM_STANDALONE instance. This patch updates comments (and a license while we are there) to indicate usage and restricts its usage to MM_STANDALONE.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI.

## Integration Instructions

N/A.
