### PR TITLE
Use Mu Rust Helpers function!() Macro [Rebase & FF]

### DIFF
--- a/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
+++ b/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe/src/lib.rs
@@ -246,19 +246,6 @@ macro_rules! debugln {
     ($level:expr, $fmt:expr, $($arg:tt)*) => ($crate::debug!($level, concat!($fmt, "\n"), $($arg)*));
 }
 
-/// Yields a &'static str that is the name of the containing function.
-#[macro_export]
-macro_rules! function {
-    () => {{
-        fn f() {}
-        fn type_name_of<T>(_: T) -> &'static str {
-            core::any::type_name::<T>()
-        }
-        let name = type_name_of(f);
-        name.strip_suffix("::f").unwrap()
-    }};
-}
-
 #[cfg(test)]
 mod tests {
     extern crate std;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ RustBootServicesAllocatorDxe = {path = "MsCorePkg/Crates/RustBootServicesAllocat
 HidIo = {path = "HidPkg/Crates/HidIo"}
 hidparser = {git = "https://github.com/microsoft/mu_rust_hid.git", branch = "main"}
 HiiKeyboardLayout = {path = "HidPkg/Crates/HiiKeyboardLayout"}
-mu_rust_helpers = { git = "https://github.com/microsoft/mu_rust_helpers.git", tag = "v1.0.0" }
-boot_services = { git = "https://github.com/microsoft/mu_rust_helpers.git", tag = "v1.0.1" }
+mu_rust_helpers = { git = "https://github.com/microsoft/mu_rust_helpers.git", tag = "v1.1.0" }
+boot_services = { git = "https://github.com/microsoft/mu_rust_helpers.git", tag = "v1.1.0" }
 
 memoffset = "0.9.0"
 num-traits = { version = "0.2", default-features = false}

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 HidIo = {workspace=true}
 hidparser = {workspace=true}
 HiiKeyboardLayout = {workspace=true}
+mu_rust_helpers = {workspace=true}
 r-efi = {workspace=true}
 rustversion = {workspace=true}
 RustAdvancedLoggerDxe = {workspace=true}

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -27,7 +27,8 @@ use hidparser::{
     report_data_types::{ReportId, Usage},
     ArrayField, ReportDescriptor, ReportField, VariableField,
 };
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
+use mu_rust_helpers::function;
+use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -22,7 +22,8 @@ use hidparser::{
     report_data_types::{ReportId, Usage},
     ReportDescriptor, ReportField, VariableField,
 };
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE};
+use mu_rust_helpers::function;
+use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE};
 
 use self::absolute_pointer::PointerContext;
 use crate::{


### PR DESCRIPTION
## Description

---

**HidPkg: Use function!() macro from mu_rust_helpers**

function!() has been moved to mu_rust_helpers to make it more broadly
accessible. Update references to use the macro from the latest
mu_rust_helpers (v1.1.0) release.

---

**AdvLoggerPkg: Drop function!() macro**

The macro is now available in mu_rust_helpers v1.1.0 release so drop
the implementation here.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Cargo build, test, fmt, clippy

## Integration Instructions

- This crate now depends on `mu_rust_helpers` v1.1.0