### PR TITLE
Fix MfciPolicy.py syntax error

### DIFF
--- a/MfciPkg/Application/MfciPolicy/MfciPolicy.py
+++ b/MfciPkg/Application/MfciPolicy/MfciPolicy.py
@@ -84,7 +84,7 @@ def get_system_info():
             if Variable == "NextMfciPolicyNonce" or Variable == "CurrentMfciPolicyNonce":
                 print(f" {Variable} = {hex(int.from_bytes(data, byteorder='little', signed=False))}")
             else:
-                print(f" {Variable} = \"{data.decode("utf16")[0:-1]}\"")
+                print(f" {Variable} = '{data.decode('utf16')[0:-1]}'")
     return
 
 


### PR DESCRIPTION
## Description

Fix a syntax error in MfciPolicy.py while using pyinstaller to generate executable file.
![image](https://github.com/user-attachments/assets/2c3fec6b-1732-4860-b52b-c86740cbfb2e)


For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified the MfciPolicy.exe can be generated by pyinstaller successfully.
Verified the system info can be dumped as below
![image](https://github.com/user-attachments/assets/0ef74028-28c0-4408-8b8a-b88b4ff5dedb)


## Integration Instructions

N/A
