### PR TITLE
Add MsBootHttp4 MsBootHttp6 boot sequence

### DIFF
--- a/PcBdsPkg/Include/Library/MsBootPolicyLib.h
+++ b/PcBdsPkg/Include/Library/MsBootPolicyLib.h
@@ -27,7 +27,9 @@ typedef enum {
   MsBootNVME,       /// Nvme boot devices
   MsBootODD,        /// Optical Disk drive devices
   MsBootSD,         /// Sd/Emmc type devices
-  MsBootRAMDISK     /// Ram Disk devices
+  MsBootRAMDISK,    /// Ram Disk devices
+  MsBootHttp4,      /// Boot devices that support IPV4 Http
+  MsBootHttp6       /// Boot devices supporting IPV6 Http
 } BOOT_SEQUENCE;
 
 /**


### PR DESCRIPTION
## Description

This change adds MsBootHttp4 MsBootHttp6 so that platform can choose boot device with ipv4/v6 http device.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on SUT and it can boot to http ip v4 and http ipv6 device.

## Integration Instructions

None