### PR TITLE
Fix the system boot to a boot manager menu after priority boot option returns with a status of EFI_SUCCESS

### DIFF
--- a/MsCorePkg/Library/PlatformBootManagerLib/MsPlatform.c
+++ b/MsCorePkg/Library/PlatformBootManagerLib/MsPlatform.c
@@ -128,7 +128,6 @@ PlatformBootManagerPriorityBoot (
   )
 {
   EFI_BOOT_MANAGER_LOAD_OPTION  BootOption;
-  EFI_BOOT_MANAGER_LOAD_OPTION  BootManagerMenu;
   EFI_STATUS                    Status = EFI_SUCCESS;
 
   Status = DeviceBootManagerPriorityBoot (&BootOption);
@@ -154,24 +153,12 @@ PlatformBootManagerPriorityBoot (
   }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[Bds] VOL/+ or VOL/- detected, and unable to boot. Code=%r\n", Status));
+    DEBUG ((DEBUG_ERROR, "[Bds] Boot priority override detected, and unable to boot. Code=%r\n", Status));
   } else {
     // Attempt the priority boot option.
     EfiBootManagerBoot (&BootOption);
     Status = BootOption.Status;
     EfiBootManagerFreeLoadOption (&BootOption);
-
-    //
-    // If the priority boot option returns with a status of EFI_SUCCESS, and platform firmware supports boot manager
-    // menu the boot manager will stop processing boot options here and present a boot manager menu to the user.
-    //
-    if (Status == EFI_SUCCESS) {
-      Status = EfiBootManagerGetBootManagerMenu (&BootManagerMenu);
-      if (!EFI_ERROR (Status)) {
-        EfiBootManagerBoot (&BootManagerMenu);
-        EfiBootManagerFreeLoadOption (&BootManagerMenu);
-      }
-    }
   }
 
   return;


### PR DESCRIPTION

## Description
It will present a boot manager menu to the user after priority boot option returns with a status of EFI_SUCCESS.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

IPMI boot to USB shell, exit on shell, it not present a boot manager menu.

## Integration Instructions

N/A
