### PR TITLE
AdvancedLogDumper: Fixed application logic to not bail all the time

### DIFF
--- a/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
+++ b/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
@@ -29,7 +29,7 @@ EntryPoint (
   )
 {
   gAdvLogHiiHandle = InitializeHiiPackage (ImageHandle);
-  if (gAdvLogHiiHandle) {
+  if (gAdvLogHiiHandle == NULL) {
     return EFI_ABORTED;
   }
 


### PR DESCRIPTION
## Description

The current logic will bail if the HII calls are successful. This change fixes it.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on proprietary hardware platform and fixed the issue.

## Integration Instructions

N/A