### PR TITLE
AdvLoggerPkg/AdvancedLoggerDxeLibGoogleTest: Link GoogleTest

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/GoogleTest/AdvancedLoggerDxeLibGoogleTest.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/GoogleTest/AdvancedLoggerDxeLibGoogleTest.inf
@@ -33,6 +33,7 @@
 [LibraryClasses]
   BaseLib
   DebugLib
+  GoogleTestLib
   UnitTestLib
   UefiBootServicesTableLib
 


### PR DESCRIPTION
## Description

The GoogleTest library class is not specified in the inf file so this leads to its code not being linked.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Compile and run unit test on QemuSbsaPkg

## Integration Instructions

- N/A