### PR TITLE
DecodeUefiLog separate by size feature

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -1038,7 +1038,7 @@ def main():
     parser.add_argument("-s",  "--StartLine", dest="StartLine", default=0, type=int,
                         help="Print starting at StartLine")
     parser.add_argument("-size",  "--FileSize", dest="FileSize", default=0, type=int,
-                        help="Output Separate LogFile by KB Size")
+                        help="[-o option] Output Separate LogFile by KB Size")
 
     options = parser.parse_args()
 
@@ -1090,6 +1090,8 @@ def main():
 
                 OutFile.close()
                 print(f"{CountOfLines} lines written to {SeparatedFilePath}")
+        elif options.FileSize != 0:
+            print("Warning: No OutFilePath found. -size is OutFile option.")
 
     except Exception:
         print("Error processing log output.")
@@ -1109,7 +1111,10 @@ def main():
 
     InFile.close()
 
-    print("Log complete")
+    if options.OutFilePath is None and options.RawFilePath is None:
+        print("No output FilePath found.")
+    else:
+        print("Log complete")
 
 
 # --------------------------------------------------------------------------- #

--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -1065,7 +1065,7 @@ def main():
             else:
                 SeparatedFilePath:str = options.OutFilePath
                 FilePathPart = os.path.splitext(SeparatedFilePath)
-                MaxSize = options.FileSize * 1000
+                MaxSize = options.FileSize * 1024
                 CurrentFileSize = 0
                 SeparateFileIndex = 1
                 CountOfLines = 0
@@ -1073,7 +1073,7 @@ def main():
                 OutFile = open(SeparatedFilePath, "w", newline=None)
 
                 for LineIndex in lines:
-                    CurrentLineSize = len(LineIndex.encode('utf-8'))
+                    CurrentLineSize = len(LineIndex.encode('utf-8')) + 1
                     if CurrentFileSize + CurrentLineSize > MaxSize:
                         OutFile.close()
                         print(f"{CountOfLines} lines written to {SeparatedFilePath}")

--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -1066,14 +1066,16 @@ def main():
                 SeparatedFilePath:str = options.OutFilePath
                 FilePathPart = os.path.splitext(SeparatedFilePath)
                 MaxSize = options.FileSize * 1024
-                CurrentFileSize = 0
-                SeparateFileIndex = 1
-                CountOfLines = 0
-                SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
-                OutFile = open(SeparatedFilePath, "w", newline=None)
 
-                for LineIndex in lines:
-                    CurrentLineSize = len(LineIndex.encode('utf-8')) + 1
+                for LineIndex, LineStr in enumerate(lines):
+                    if LineIndex == 0:
+                        CurrentFileSize = 0
+                        SeparateFileIndex = 1
+                        CountOfLines = 0
+                        SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
+                        OutFile = open(SeparatedFilePath, "w", newline=None)
+
+                    CurrentLineSize = len(LineStr.encode('utf-8')) + 1
                     if CurrentFileSize + CurrentLineSize > MaxSize:
                         OutFile.close()
                         print(f"{CountOfLines} lines written to {SeparatedFilePath}")
@@ -1081,10 +1083,10 @@ def main():
                         SeparateFileIndex += 1
                         SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
                         OutFile = open(SeparatedFilePath, "w", newline=None)
-                        OutFile.writelines(LineIndex)
+                        OutFile.writelines(LineStr)
                         CurrentFileSize = CurrentLineSize
                     else:
-                        OutFile.writelines(LineIndex)
+                        OutFile.writelines(LineStr)
                         CountOfLines += 1
                         CurrentFileSize += CurrentLineSize
 

--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -10,6 +10,7 @@ import argparse
 import tempfile
 import traceback
 import copy
+import os
 
 from win32com.shell import shell
 from edk2toollib.os.uefivariablesupport import UefiVariable
@@ -1036,6 +1037,8 @@ def main():
                         help="Path to binary Output LogFile")
     parser.add_argument("-s",  "--StartLine", dest="StartLine", default=0, type=int,
                         help="Print starting at StartLine")
+    parser.add_argument("-size",  "--FileSize", dest="FileSize", default=0, type=int,
+                        help="Output Separate LogFile by KB Size")
 
     options = parser.parse_args()
 
@@ -1053,11 +1056,40 @@ def main():
         lines = advlog.ProcessMessages(InFile, options.StartLine)
 
         if options.OutFilePath is not None:
-            OutFile = open(options.OutFilePath, "w", newline=None)
-            OutFile.writelines(lines)
-            OutFile.close()
-            CountOfLines = len(lines)
-            print(f"{CountOfLines} lines written to {options.OutFilePath}")
+            if options.FileSize == 0:
+                OutFile = open(options.OutFilePath, "w", newline=None)
+                OutFile.writelines(lines)
+                OutFile.close()
+                CountOfLines = len(lines)
+                print(f"{CountOfLines} lines written to {options.OutFilePath}")
+            else:
+                SeparatedFilePath:str = options.OutFilePath
+                FilePathPart = os.path.splitext(SeparatedFilePath)
+                MaxSize = options.FileSize * 1000
+                CurrentFileSize = 0
+                SeparateFileIndex = 1
+                CountOfLines = 0
+                SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
+                OutFile = open(SeparatedFilePath, "w", newline=None)
+
+                for LineIndex in lines:
+                    CurrentLineSize = len(LineIndex.encode('utf-8'))
+                    if CurrentFileSize + CurrentLineSize > MaxSize:
+                        OutFile.close()
+                        print(f"{CountOfLines} lines written to {SeparatedFilePath}")
+                        CountOfLines = 1
+                        SeparateFileIndex += 1
+                        SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
+                        OutFile = open(SeparatedFilePath, "w", newline=None)
+                        OutFile.writelines(LineIndex)
+                        CurrentFileSize = CurrentLineSize
+                    else:
+                        OutFile.writelines(LineIndex)
+                        CountOfLines += 1
+                        CurrentFileSize += CurrentLineSize
+
+                OutFile.close()
+                print(f"{CountOfLines} lines written to {SeparatedFilePath}")
 
     except Exception:
         print("Error processing log output.")

--- a/AdvLoggerPkg/Application/DecodeUefiLog/ReadMe.md
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/ReadMe.md
@@ -39,6 +39,12 @@ Decode a raw file into a text file:
   DecodeUefiLog -l RawLog.bin -o NewLogFIle.txt
 ```
 
+Decode lines and separate to multiple files by Kb size -size:
+
+```.sh
+  DecodeUefiLog -size 30 -o NewLogFile.txt
+```
+
 ---
 
 ## Copyright

--- a/AdvLoggerPkg/Application/DecodeUefiLog/ReadMe.md
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/ReadMe.md
@@ -39,7 +39,7 @@ Decode a raw file into a text file:
   DecodeUefiLog -l RawLog.bin -o NewLogFIle.txt
 ```
 
-Decode lines and separate to multiple files by Kb size -size:
+[-o Option] Decode lines and separate to multiple files by Kb size -size:
 
 ```.sh
   DecodeUefiLog -size 30 -o NewLogFile.txt


### PR DESCRIPTION
## Description

DecodeUefiLog separate by size feature

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [X] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Test DecodeUefiLog with "-size" command and check output file size and contents.
![螢幕擷取畫面 2025-02-18 145746](https://github.com/user-attachments/assets/aa74553b-7314-4d22-9108-241d27fb8998)
![螢幕擷取畫面 2025-02-18 145833](https://github.com/user-attachments/assets/a015ac8b-3817-46cd-82a6-4022326b3ecc)

## Integration Instructions

N/A
