### PR TITLE
Reset the keyboard to default state during initialization

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -524,6 +524,9 @@ impl HidReportReceiver for KeyboardHidHandler {
     fn initialize(&mut self, controller: efi::Handle, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
         let descriptor = hid_io.get_report_descriptor()?;
         self.process_descriptor(descriptor)?;
+        // Set the key toggle state here so that the subsequent reset() can send the LED state to the device.
+        self.set_key_toggle_state(protocols::simple_text_input_ex::CAPS_LOCK_ACTIVE);
+        self.reset(hid_io, true)?;
         self.install_protocol_interfaces(controller)?;
         self.initialize_keyboard_layout()?;
         Ok(())

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -822,6 +822,7 @@ mod test {
         let boot_services = create_fake_static_boot_service();
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&MOUSE_REPORT_DESCRIPTOR).unwrap()));
@@ -843,6 +844,7 @@ mod test {
 
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -866,6 +868,7 @@ mod test {
 
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -1091,6 +1094,7 @@ mod test {
         unsafe { HANDLER = &mut keyboard_handler as *mut KeyboardHidHandler };
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -1161,6 +1165,7 @@ mod test {
 
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -1225,6 +1230,7 @@ mod test {
 
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -467,6 +467,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -607,6 +608,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -596,6 +596,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -775,6 +776,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -840,6 +842,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));
@@ -978,6 +981,7 @@ mod test {
         let mut keyboard_handler = KeyboardHidHandler::new(boot_services, 1 as efi::Handle);
 
         let mut hid_io = MockHidIo::new();
+        hid_io.expect_set_output_report().returning(|_, _| Ok(()));
         hid_io
             .expect_get_report_descriptor()
             .returning(|| Ok(hidparser::parse_report_descriptor(&BOOT_KEYBOARD_REPORT_DESCRIPTOR).unwrap()));


### PR DESCRIPTION
## Description

Fixes #633

Reset the keyboard to default state during initialization in order to make sure the LED status on keyboard is determined.  

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on Surface Laptop and Surface Pro, all keyboard LEDs are turned off when booting to the UEFI front page. 
No regressions observed.

## Integration Instructions

N/A