### PR TITLE
[DO NOT MERGE] [PROTOTYPE] Stabilizing PCR4 Measurements

### DIFF
--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
@@ -2584,22 +2584,6 @@ OnReadyToBoot (
       DEBUG ((DEBUG_ERROR, "Boot Variables not Measured. Error!\n"));
     }
 
-    if (PcdGetBool (TcgMeasureBootStringsInPcr4)) {
-      // MsChange for some platform uefi compat
-      //
-      // 1. This is the first boot attempt.
-      //
-      Status = TcgMeasureAction (
-                 4,
-                 EFI_CALLING_EFI_APPLICATION
-                 );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
-      }
-    } else {
-      DEBUG ((DEBUG_WARN, "Tcg2Dxe PCD set to skip Measure Boot String in PCR4\n"));
-    }
-
     //
     // 2. Draw a line between pre-boot env and entering post-boot env.
     // PCR[7] is already done.
@@ -2622,35 +2606,6 @@ OnReadyToBoot (
     //
     // 5. Read & Measure variable. BootOrder already measured.
     //
-  } else {
-    if (PcdGetBool (TcgMeasureBootStringsInPcr4)) {
-      // MsChange for hyperv uefi compat
-      //
-      // 6. Not first attempt, meaning a return from last attempt
-      //
-      Status = TcgMeasureAction (
-                 4,
-                 EFI_RETURNING_FROM_EFI_APPLICATION
-                 );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
-      }
-
-      //
-      // 7. Next boot attempt, measure "Calling EFI Application from Boot Option" again
-      // TCG PC Client PFP spec Section 2.4.4.5 Step 4
-      //
-      Status = TcgMeasureAction (
-                 4,
-                 EFI_CALLING_EFI_APPLICATION
-                 );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
-      }
-    } else {
-      // MS_CHANGE
-      DEBUG ((DEBUG_WARN, "Tcg2Dxe PCD set to skip Measure Boot String in PCR4\n"));
-    }
   }
 
   DEBUG ((EFI_D_INFO, "TPM2 Tcg2Dxe Measure Data when ReadyToBoot\n"));

--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
@@ -117,7 +117,6 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLaml                        ## PRODUCES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLasa                        ## PRODUCES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision               ## CONSUMES
-  gEfiSecurityPkgTokenSpaceGuid.TcgMeasureBootStringsInPcr4                 ## CONSUMES # MU_CHANGE
 
 [Depex]
   # According to PcdTpm2AcpiTableRev definition in SecurityPkg.dec


### PR DESCRIPTION
## Description

This is an effort to stabilize PCR4 measurements.

There are a few known issues with PCR4 measurements that need to be addressed.

Applications that originate from a measured FV and are an extension of the BDS environment should not signal ready to boot nor be measured into PCR4.
File paths that do not exist should not be loaded thus should not signal ready to boot nor should they be measured into PCR4.
Applications that originate from a measured FV should not be measured into PCR4 
(https://github.com/microsoft/mu_tiano_plus/pull/330)

- [X] Impacts functionality?
- [X] Impacts security?
- [X] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Various Boot Paths

## Integration Instructions

TODO