### PR TITLE
Fix infinite loop issue in UsbGetFullHidDescriptor

### DIFF
--- a/HidPkg/UsbHidDxe/UsbHidDxe.c
+++ b/HidPkg/UsbHidDxe/UsbHidDxe.c
@@ -697,6 +697,12 @@ UsbGetFullHidDescriptor (
       }
     }
 
+    // Check if the descriptor length is 0
+    if (DescriptorHeader->Len == 0) {
+      DEBUG ((DEBUG_ERROR, "[%a] Descriptor length is 0\n", __FUNCTION__));
+      break;
+    }
+
     // move to next descriptor
     DescriptorCursor += DescriptorHeader->Len;
     DescriptorHeader  = (USB_DESC_HEAD *)((UINT8 *)DescriptorBuffer + DescriptorCursor);

--- a/HidPkg/UsbHidDxe/UsbHidDxe.c
+++ b/HidPkg/UsbHidDxe/UsbHidDxe.c
@@ -699,7 +699,7 @@ UsbGetFullHidDescriptor (
 
     // Check if the descriptor length is 0
     if (DescriptorHeader->Len == 0) {
-      DEBUG ((DEBUG_ERROR, "[%a] Descriptor length is 0\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "[%a] Descriptor length is 0\n", __func__));
       break;
     }
 


### PR DESCRIPTION
## Description

UsbGetFullHidDescriptor does not check the Descriptor header length and this might result in an infinite loop if a bad descriptor is passed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on Surface devices

## Integration Instructions

N/A