### PR TITLE
Improve USB HID error scenario handling

### DIFF
--- a/HidPkg/UsbHidDxe/UsbHidDxe.c
+++ b/HidPkg/UsbHidDxe/UsbHidDxe.c
@@ -455,7 +455,9 @@ DelayedRecoveryHandler (
                                OnReportInterruptComplete,
                                UsbHidDev
                                );
-  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "USB [%a] failed to re-submit async transfer: %r\n", __func__, Status));
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This converts an assert to an error message on failure to re-submit the async interrupt for USB HID devices. In some scenarios (such a device removal), this assert was triggering even though failure to re-submit the async interrupt is expected (because the device is no longer present.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

No longer observe spurious asserts on unplug of USB devices. 

## Integration Instructions

N/A