### PR TITLE
SimpleWindowManagerDxe: Check absolute pointer mode to prevent division by zero

### DIFF
--- a/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
+++ b/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
@@ -953,6 +953,11 @@ CheckWatchListCallback (
         //
         AbsolutePointerMaxX = pList->AbsolutePointer->Mode->AbsoluteMaxX;
         AbsolutePointerMaxY = pList->AbsolutePointer->Mode->AbsoluteMaxY;
+        if ((AbsolutePointerMaxX == 0) || (AbsolutePointerMaxY == 0)) {
+          // Incorrect Absolute Pointer Mode, skip this pointer event
+          //
+          continue;
+        }
 
         // Get screen coordinate space maximums.
         //


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/mu_plus/issues/650

Touch screen may report an incorrect HID report, with AbsoluteMaxX or AbsoluteMaxY set to 0, causing SimpleWindowManagerDxe to hang due to division by zero. 
This PR adds a check of absolute pointer mode to avoid division by zero. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Ran a stress test on the failing device, and the issue no longer reproduces

## Integration Instructions

N/A