### PR TITLE
[Merge && FF] CI: Limit CI runs to AARCH64, IA32, X64

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -15,7 +15,7 @@
 ##
 
 variables:
-- group: architectures-arm-64-x86-64
+- group: architectures-arm64-x86-64
 - group: tool-chain-ubuntu-gcc
 - group: coverage
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/GoogleTest/AdvancedLoggerDxeLibGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Dxe/GoogleTest/AdvancedLoggerDxeLibGoogleTest.cpp
@@ -39,19 +39,19 @@ protected:
   EFI_GUID gMockAdvLoggerProtocolGuid =
   { 0x434f695c, 0xef26, 0x4a12, { 0x9e, 0xba, 0xdd, 0xef, 0x00, 0x97, 0x49, 0x7c }
   };
+  CHAR8 OutputBuf[100];
 
   void
   SetUp (
     ) override
   {
-    CHAR8  OutputBuf[] = "MyUnitTestLog";
-
     NumberOfBytes          = sizeof (OutputBuf);
     Buffer                 = OutputBuf;
     DebugLevel             = DEBUG_ERROR;
     mInitialized           = FALSE;
     gALProtocol->Signature = ADVANCED_LOGGER_PROTOCOL_SIGNATURE;
     gALProtocol->Version   = ADVANCED_LOGGER_PROTOCOL_VERSION;
+    snprintf (Buffer, sizeof (OutputBuf), "MyUnitTestLog");
   }
 };
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
@@ -57,13 +57,12 @@ protected:
   ADVANCED_LOGGER_INFO testLoggerInfo;
   // StrictMock<MockHobLib> gHobLib;
   // StrictMock<MockAdvancedLoggerHdwPortLib> gALHdwPortLib;
+  CHAR8 OutputBuf[100];
 
   void
   SetUp (
     ) override
   {
-    CHAR8  OutputBuf[] = "MyUnitTestLog";
-
     NumberOfBytes                   = sizeof (OutputBuf);
     Buffer                          = OutputBuf;
     DebugLevel                      = DEBUG_ERROR;
@@ -74,6 +73,7 @@ protected:
     testLoggerInfo.LogBufferOffset  = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     testLoggerInfo.LogCurrentOffset = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     mLoggerInfo                     = NULL;
+    snprintf (Buffer, sizeof (OutputBuf), "MyUnitTestLog");
   }
 };
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei/GoogleTest/AdvancedLoggerPeiLibGoogleTest.cpp
@@ -32,19 +32,19 @@ protected:
   UINTN Instance;
   CHAR8 *Buffer;
   UINTN NumberOfBytes;
+  CHAR8 OutputBuf[100];
 
   void
   SetUp (
     ) override
   {
-    CHAR8  OutputBuf[] = "MyUnitTestLog";
-
     NumberOfBytes     = sizeof (OutputBuf);
     Buffer            = OutputBuf;
     DebugLevel        = DEBUG_ERROR;
     Instance          = 0;
     gALPpi->Signature = ADVANCED_LOGGER_PPI_SIGNATURE;
     gALPpi->Version   = ADVANCED_LOGGER_PPI_VERSION;
+    snprintf (Buffer, sizeof (OutputBuf), "MyUnitTestLog");
   }
 };
 

--- a/MsCorePkg/Library/MuArmGicExLib/AArch64/MuArmGicEx.S
+++ b/MsCorePkg/Library/MuArmGicExLib/AArch64/MuArmGicEx.S
@@ -6,7 +6,7 @@
 #
 #
 
-#include <AsmMacroIoLibV8.h>
+#include <AsmMacroLib.h>
 
 #if !defined(__clang__)
 

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-#include <Chipset/AArch64.h>
+#include <AArch64/AArch64.h>
 #include <AsmMacroLib.h>
 #include <IndustryStandard/ArmStdSmc.h>
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.22.5
+edk2-pytool-library==0.23.1
 edk2-pytool-extensions==0.28.5
 antlr4-python3-runtime==4.13.2
 regex==2024.11.6


### PR DESCRIPTION
## Description
Remove ARM as a target for CI runs.

Only target AARCH64, IA32, X64 for GCC CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local CI builds. 

## Integration Instructions
Not Applicable since it is a CI change. 