### PR TITLE
Fix an issue where an uninitialized pointer was used if an EFI system partition was not present in the system.

### DIFF
--- a/MsCorePkg/Library/DxeCapsulePersistenceLib/CapsulePersistence.c
+++ b/MsCorePkg/Library/DxeCapsulePersistenceLib/CapsulePersistence.c
@@ -149,6 +149,7 @@ OpenVolumeSFS (
   Status = UefiGetSfsProtocolHandle (&SfsProtocol);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to find Simple Filesystem Protocol: %r \n", __FUNCTION__, Status));
+    return Status;
   }
 
   // Open the volume/partition.


### PR DESCRIPTION

## Description

If no EFI system partition was present in the system, then UefiGetSfsProtocolHandle() would return an error status. A message was printed, however execution would proceed and call the uninitialized pointer. This patch causes a return of the failed status instead of proceeding in this case.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Confirmed that with this patch the code correctly returns an error aborting the capsule update rather than crashing due to a call through bad pointer. 

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
