### PR TITLE
Run CI using release branches of dependent repos

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -194,22 +194,22 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Silicon/Arm/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_silicon_arm_tiano.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Silicon/Intel/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_silicon_intel_tiano.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Common/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_tiano_plus.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             }
         ]
 


### PR DESCRIPTION
## Description

Run CI using release branches of dependent repos.

Release branch of mu_tiano_plus needs to depend on release branches of other repos.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local CI run.

## Integration Instructions
Not integration necessary