### PR TITLE
.github: Update backport workflow to use GitHub App token authentication

### DIFF
--- a/.github/workflows/backport-to-release-branch.yml
+++ b/.github/workflows/backport-to-release-branch.yml
@@ -33,11 +33,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.MU_ACCESS_APP_ID }}
+        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.CHERRY_PICK_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Determine Contribution Info
       id: backport_info
@@ -229,5 +236,5 @@ jobs:
         -H "Content-Type: application/json" \
         -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$PR_BRANCH\",\"base\":\"$BASE_BRANCH\",\"labels\":[\"type:release-merge-conflict\"]}"
       env:
-        CHERRY_PICK_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        CHERRY_PICK_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Description

Authenticate using an app derived token.

I'm using this to verify token derivation works with the new GitHub app installation. If this works, I will be moving all non-default GitHub token usage in Mu repos to be through the GitHub app and make upstream changes to token usage in mu_devops.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- On side branch. Now testing on dev/202405 branch.

## Integration Instructions

N/A