### PR TITLE
AdvLoggerPkg: Fix timestamp consistency in LineParserTestApp

### DIFF
--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -58,47 +58,47 @@ CHAR8  *InternalMemoryLog[] = {
 // The following text represents the output lines from the line parser given the above input
 
 /* spell-checker: disable */
-CHAR8  Line00[] = "09:06:45.012 : [INFO] First normal test line\n";
-CHAR8  Line01[] = "09:06:45.012 : [ERR ] The QueryMode() function returns information for an available graphics mod\n";
-CHAR8  Line02[] = "09:06:45.012 : [ERR ] e that the graphics device and the set of active video output devices supp\n";
-CHAR8  Line03[] = "09:06:45.012 : [ERR ] orts.\n";
-CHAR8  Line04[] = "09:06:45.012 : [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
-CHAR8  Line05[] = "09:06:45.012 : [ERR ]  is returned.\n";
-CHAR8  Line06[] = "09:06:45.012 : [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
-CHAR8  Line07[] = "09:06:45.012 : [INFO] OTOCOL.\n";
-CHAR8  Line08[] = "09:06:45.012 : [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
-CHAR8  Line09[] = "09:06:45.012 : [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
-CHAR8  Line10[] = "09:06:45.012 : [ERR ] \n";
-CHAR8  Line11[] = "09:06:45.012 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line12[] = "09:06:45.012 : [INFO] ents a single video output device, then the set of modes returned by this \n";
-CHAR8  Line13[] = "09:06:45.012 : [ERR ] service is the subset of modes supported by both the graphics controller a\n";
-CHAR8  Line14[] = "09:06:45.012 : [ERR ] nd the video output device.\n";
-CHAR8  Line15[] = "09:06:45.012 : [ERR ] \n";
-CHAR8  Line16[] = "09:06:45.012 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line17[] = "09:06:45.012 : [ERR ] ents a combination of video output devices, then the set of modes returned\n";
-CHAR8  Line18[] = "09:06:45.012 : [INFO]  by this service is the subset of modes supported by the graphics controll\n";
-CHAR8  Line19[] = "09:06:45.012 : [ERR ] er and all of the video output devices represented by the handle.\n";
+CHAR8  Line00[] = "09:06:45.011 : [INFO] First normal test line\n";
+CHAR8  Line01[] = "09:06:45.011 : [ERR ] The QueryMode() function returns information for an available graphics mod\n";
+CHAR8  Line02[] = "09:06:45.011 : [ERR ] e that the graphics device and the set of active video output devices supp\n";
+CHAR8  Line03[] = "09:06:45.011 : [ERR ] orts.\n";
+CHAR8  Line04[] = "09:06:45.011 : [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
+CHAR8  Line05[] = "09:06:45.011 : [ERR ]  is returned.\n";
+CHAR8  Line06[] = "09:06:45.011 : [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
+CHAR8  Line07[] = "09:06:45.011 : [INFO] OTOCOL.\n";
+CHAR8  Line08[] = "09:06:45.011 : [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
+CHAR8  Line09[] = "09:06:45.011 : [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
+CHAR8  Line10[] = "09:06:45.011 : [ERR ] \n";
+CHAR8  Line11[] = "09:06:45.011 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line12[] = "09:06:45.011 : [INFO] ents a single video output device, then the set of modes returned by this \n";
+CHAR8  Line13[] = "09:06:45.011 : [ERR ] service is the subset of modes supported by both the graphics controller a\n";
+CHAR8  Line14[] = "09:06:45.011 : [ERR ] nd the video output device.\n";
+CHAR8  Line15[] = "09:06:45.011 : [ERR ] \n";
+CHAR8  Line16[] = "09:06:45.011 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line17[] = "09:06:45.011 : [ERR ] ents a combination of video output devices, then the set of modes returned\n";
+CHAR8  Line18[] = "09:06:45.011 : [INFO]  by this service is the subset of modes supported by the graphics controll\n";
+CHAR8  Line19[] = "09:06:45.011 : [ERR ] er and all of the video output devices represented by the handle.\n";
 
-CHAR8  Line00V2[] = "09:06:45.012 : [DXE  ] [INFO] First normal test line\n";
-CHAR8  Line01V2[] = "09:06:45.012 : [DXE  ] [ERR ] The QueryMode() function returns information for an available graphics mod\n";
-CHAR8  Line02V2[] = "09:06:45.012 : [DXE  ] [ERR ] e that the graphics device and the set of active video output devices supp\n";
-CHAR8  Line03V2[] = "09:06:45.012 : [DXE  ] [ERR ] orts.\n";
-CHAR8  Line04V2[] = "09:06:45.012 : [DXE  ] [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
-CHAR8  Line05V2[] = "09:06:45.012 : [DXE  ] [ERR ]  is returned.\n";
-CHAR8  Line06V2[] = "09:06:45.012 : [DXE  ] [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
-CHAR8  Line07V2[] = "09:06:45.012 : [DXE  ] [INFO] OTOCOL.\n";
-CHAR8  Line08V2[] = "09:06:45.012 : [DXE  ] [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
-CHAR8  Line09V2[] = "09:06:45.012 : [DXE  ] [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
-CHAR8  Line10V2[] = "09:06:45.012 : [DXE  ] [ERR ] \n";
-CHAR8  Line11V2[] = "09:06:45.012 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line12V2[] = "09:06:45.012 : [DXE  ] [INFO] ents a single video output device, then the set of modes returned by this \n";
-CHAR8  Line13V2[] = "09:06:45.012 : [DXE  ] [ERR ] service is the subset of modes supported by both the graphics controller a\n";
-CHAR8  Line14V2[] = "09:06:45.012 : [DXE  ] [ERR ] nd the video output device.\n";
-CHAR8  Line15V2[] = "09:06:45.012 : [DXE  ] [ERR ] \n";
-CHAR8  Line16V2[] = "09:06:45.012 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line17V2[] = "09:06:45.012 : [DXE  ] [ERR ] ents a combination of video output devices, then the set of modes returned\n";
-CHAR8  Line18V2[] = "09:06:45.012 : [DXE  ] [INFO]  by this service is the subset of modes supported by the graphics controll\n";
-CHAR8  Line19V2[] = "09:06:45.012 : [DXE  ] [ERR ] er and all of the video output devices represented by the handle.\n";
+CHAR8  Line00V2[] = "09:06:45.011 : [DXE  ] [INFO] First normal test line\n";
+CHAR8  Line01V2[] = "09:06:45.011 : [DXE  ] [ERR ] The QueryMode() function returns information for an available graphics mod\n";
+CHAR8  Line02V2[] = "09:06:45.011 : [DXE  ] [ERR ] e that the graphics device and the set of active video output devices supp\n";
+CHAR8  Line03V2[] = "09:06:45.011 : [DXE  ] [ERR ] orts.\n";
+CHAR8  Line04V2[] = "09:06:45.011 : [DXE  ] [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
+CHAR8  Line05V2[] = "09:06:45.011 : [DXE  ] [ERR ]  is returned.\n";
+CHAR8  Line06V2[] = "09:06:45.011 : [DXE  ] [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
+CHAR8  Line07V2[] = "09:06:45.011 : [DXE  ] [INFO] OTOCOL.\n";
+CHAR8  Line08V2[] = "09:06:45.011 : [DXE  ] [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
+CHAR8  Line09V2[] = "09:06:45.011 : [DXE  ] [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
+CHAR8  Line10V2[] = "09:06:45.011 : [DXE  ] [ERR ] \n";
+CHAR8  Line11V2[] = "09:06:45.011 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line12V2[] = "09:06:45.011 : [DXE  ] [INFO] ents a single video output device, then the set of modes returned by this \n";
+CHAR8  Line13V2[] = "09:06:45.011 : [DXE  ] [ERR ] service is the subset of modes supported by both the graphics controller a\n";
+CHAR8  Line14V2[] = "09:06:45.011 : [DXE  ] [ERR ] nd the video output device.\n";
+CHAR8  Line15V2[] = "09:06:45.011 : [DXE  ] [ERR ] \n";
+CHAR8  Line16V2[] = "09:06:45.011 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line17V2[] = "09:06:45.011 : [DXE  ] [ERR ] ents a combination of video output devices, then the set of modes returned\n";
+CHAR8  Line18V2[] = "09:06:45.011 : [DXE  ] [INFO]  by this service is the subset of modes supported by the graphics controll\n";
+CHAR8  Line19V2[] = "09:06:45.011 : [DXE  ] [ERR ] er and all of the video output devices represented by the handle.\n";
 
 /* spell-checker: enable */
 
@@ -137,7 +137,6 @@ InternalGetPerformanceCounter (
   )
 {
   UINT64           TimeInMs;
-  UINT64           TimeInNs;
   UINT64           Frequency;
   UINT32           Remainder = 0;
   STATIC   UINT64  Ticks     = 0;
@@ -183,10 +182,8 @@ InternalGetPerformanceCounter (
   //
   // Do multiply first, then divide, to keep as many bits as possible
   //
-  Ticks    = DivU64x32Remainder (MultU64x64 (TimeInMs, Frequency), 1000u, &Remainder) + Remainder;
-  TimeInNs = GetTimeInNanoSecond (Ticks);
 
-  UT_ASSERT_TRUE (TimeInMs == (TimeInNs / 1000000u));
+  Ticks = DivU64x32Remainder (MultU64x64 (TimeInMs, Frequency), 1000u, &Remainder);
 
   return Ticks;
 }


### PR DESCRIPTION
## Description

LineParserTestApp makes use of InternalGetPerformanceCounter for generating timestamps. The value returned is a fixed value, but additional testing was being performed on the conversion of the time, to make it correspond to what was actually possible based on the performance counter's frequency.

This started failing when when optimized, causing UT_ASSERT_TRUE to fail. When UT_ASSERT_TRUE fails, it returned UNIT_TEST_ERROR_TEST_FAILED, instead of the expected UINT64 value that the InternalGetPerformanceCounter was expected, causing a cascade of failures.

Remove the check on the conversion of the test's build defined value for timestamp. Updated the expected strings to use the timestamp value as calculated from the conversion from timestampe to ticks (note the 11 vs the 12).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Ran mu_tiano_platform testing and verifying that Audit Tests pass with changes.

## Integration Instructions
No Integration necessary.