### PR TITLE
XmlSupportPkg: Remove FreePool during reporting of unit tests results.

### DIFF
--- a/XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.c
+++ b/XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.c
@@ -222,8 +222,6 @@ OutputUnitTestFrameworkReport (
     }
 
     SuiteNode = New_TestSuiteNodeInList (Doc, SuiteName, SuitePackage, Id);
-    FreePool (SuiteName);
-    FreePool (SuitePackage);
     if (SuiteNode == NULL) {
       DEBUG ((DEBUG_ERROR, "%a Failed to create new test suite\n", __FUNCTION__));
       Status = EFI_DEVICE_ERROR;
@@ -262,18 +260,6 @@ OutputUnitTestFrameworkReport (
 
       // TODO:  need to handle timing.  Right now its hard coded to 1 second.
       New_TestCaseInSuite (SuiteNode, Name, ClassName, 1, Log, FailureMsg, GetStringForFailureType (Test->UT.FailureType), Skipped);
-
-      if (Name != NULL) {
-        FreePool (Name);
-      }
-
-      if (Log != NULL) {
-        FreePool (Log);
-      }
-
-      if (ClassName != NULL) {
-        FreePool (ClassName);
-      }
     } // End Test iteration
 
     Status = AddTestSuiteStats (SuiteNode, TotalTests, TotalFailures, TotalSkips, TotalErrors);


### PR DESCRIPTION
## Description
When test cases are added to the test framework, the data is expected to be torn down through the FreeUnitTestFramework call.

UnitTestResultReportLib was freeing memory allocated, owned and managed by the UnitTestLib. This resulted in memory for the entries being unmapped, and when the FreeUnitTestFramework was called later, the unmaped memory resulted in an exception.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Q35 running unit tests resulted in hangs.
After resolving this, the hangs went away.

## Integration Instructions
No integration necessary.