### PR TITLE
MsGraphicsPkg/QrEncoderLib: Prevent memcpy being used on VS22 (17.14.2)

### DIFF
--- a/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
+++ b/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
@@ -372,12 +372,10 @@ PolynomialDivision (
 
   // MU_CHANGE [END] - CodeQL change
 
-  for (i = 0; i < DividendCount; i++) {
-    TempRemainder[i] = Dividend[i];
-  }
+  CopyMem (TempRemainder, Dividend, DividendCount);
 
   if (gFlags & QR_FLAGS_DEBUG_POLYDIVIDE) {
-    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", i));
+    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", DividendCount));
     for (j = 0; j < sizeofnumbers; j++) {
       DEBUG ((DEBUG_INFO, " %3d,", TempRemainder[j]));
     }


### PR DESCRIPTION
## Description

This code can be optimized to `memcpy`. So, explicitly use `CopyMem` to prevent that from happening.

This PR adds the commit to the release branch as well.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- Before and after with VS22 17.14.2.

## Integration Instructions

- N/A