### PR TITLE
UefiTestingPkg: Remove UnallocatedMemoryIsRP test.

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/README.md
+++ b/UefiTestingPkg/AuditTests/PagingAudit/README.md
@@ -55,9 +55,7 @@ results will be saved to an XML file in the same file system as the app (or the 
 available writable simple file system):
 
 - **NoReadWriteExecute:** Checks if the page/translation table has any readable, writable,
-and executable regions.  
-- **UnallocatedMemoryIsRP:** Checks that all EfiConventionalMemory is EFI_MEMORY_RP or
-is not mapped.  
+and executable regions.
 - **IsMemoryAttributeProtocolPresent:** Checks if the EFI Memory Attribute Protocol
 is installed.  
 - **NullPageIsRp:** Checks if page 0 is EFI_MEMORY_RP or is not mapped.  

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -893,61 +893,6 @@ NoReadWriteExecute (
 }
 
 /**
-  Checks that EfiConventionalMemory is EFI_MEMORY_RP or
-  is not mapped.
-
-  @param[in] Context            Unit test context
-
-  @retval UNIT_TEST_PASSED      The unit test passed
-  @retval other                 The unit test failed
-**/
-UNIT_TEST_STATUS
-EFIAPI
-UnallocatedMemoryIsRP (
-  IN UNIT_TEST_CONTEXT  Context
-  )
-{
-  BOOLEAN                TestFailure;
-  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
-  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
-
-  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
-
-  UT_ASSERT_NOT_EFI_ERROR (ValidatePageTableMapSize ());
-  UT_ASSERT_NOT_EFI_ERROR (ValidateEfiMemoryMapSize ());
-  UT_ASSERT_NOT_EFI_ERROR (PopulateEfiMemoryMap ());
-  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
-
-  TestFailure = FALSE;
-
-  EfiMemoryMapEntry = mEfiMemoryMap;
-  EfiMemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)mEfiMemoryMap + mEfiMemoryMapSize);
-
-  while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
-    if (EfiMemoryMapEntry->Type == EfiConventionalMemory) {
-      if (!ValidateRegionAttributes (
-             &mMap,
-             EfiMemoryMapEntry->PhysicalStart,
-             (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE),
-             EFI_MEMORY_RP,
-             TRUE,
-             TRUE,
-             TRUE
-             ))
-      {
-        TestFailure = TRUE;
-      }
-    }
-
-    EfiMemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (EfiMemoryMapEntry, mEfiMemoryMapDescriptorSize);
-  }
-
-  UT_ASSERT_FALSE (TestFailure);
-
-  return UNIT_TEST_PASSED;
-}
-
-/**
   Checks if the EFI Memory Attribute Protocol is Present.
 
   @param[in] Context            Unit test context
@@ -1435,7 +1380,6 @@ DxePagingAuditTestAppEntryPoint (
     }
 
     AddTestCase (Misc, "No pages are  readable, writable, and executable", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, NULL, GeneralTestCleanup, NULL);
-    AddTestCase (Misc, "Unallocated memory is EFI_MEMORY_RP", "Security.Misc.UnallocatedMemoryIsRP", UnallocatedMemoryIsRP, NULL, GeneralTestCleanup, NULL);
     AddTestCase (Misc, "Memory Attribute Protocol is present", "Security.Misc.IsMemoryAttributeProtocolPresent", IsMemoryAttributeProtocolPresent, NULL, NULL, NULL);
     AddTestCase (Misc, "NULL page is EFI_MEMORY_RP", "Security.Misc.NullPageIsRp", NullPageIsRp, NULL, GeneralTestCleanup, NULL);
     AddTestCase (Misc, "MMIO Regions are EFI_MEMORY_XP", "Security.Misc.MmioIsXp", MmioIsXp, NULL, GeneralTestCleanup, NULL);


### PR DESCRIPTION

## Description

Removing the UnallocatedMemoryIsRP test to allow
for EfiConventionalMemory to be in a state other
than Read Protected or Unmapped.

Unallocated memory still needs to follow the
no Read/Write/Executable protections, but should
still be left mapped.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
QemuSbsa  running DxePagingAuditTest prior to removal of the test failed with specific regions
being left mapped, but as Nx.
After changes, DxePagingAuditTest Reported a pass

## Integration Instructions
No integration necessary.