### PR TITLE
HidPkg/UefiHidDxeV2: Skip field process if the same usage of the field already added

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -108,6 +108,12 @@ impl PointerHidHandler {
 
             for field in &report.fields {
                 if let ReportField::Variable(field) = field {
+                    if self.supported_usages.contains(&field.usage) {
+                        // already processed this usage, skip.
+                        // As we only support single touch.
+                        continue;
+                    }
+
                     match field.usage.into() {
                         GENERIC_DESKTOP_X => {
                             let field_handler =


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/mu_plus/issues/698

The current implementation of UefiHidDxeV2 processes all fields in the input report using a single `current_state` variable, which merges multiple touch states and leads to unexpected behavior in the downstream absolute pointer driver. 

To ensure proper functionality, we need to skip processing any field if its usage has already been added to the supported list. Without this check, multi-touch reports may cause the touch input to malfunction.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested with a multi-touch input report. UefiHidDxeV2 was able to correctly parse and handle the first touch collection as expected.

## Integration Instructions

N/A
