### PR TITLE
Remove override tag for display engine

### DIFF
--- a/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
+++ b/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
@@ -6,9 +6,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
-
-#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | cd71a33f6ecb1ac9282762f821f317bb | 2025-05-27T13-30-17 | 0ef61161fce7097c6cd0b054b2d321dd5640cc92
-
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = DisplayEngine


### PR DESCRIPTION
## Description

This module is being carried as an override for years.

But really, we have not had any plan to upstream it to EDK2. Additionally, the driver has minimal commonality with the upstream version. This change is to break the bond with EDK2 version so that we save the hassle to deal with override tags.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This is not a functional test.

## Integration Instructions

N/