### PR TITLE
[Cherry-pick] Remove override tag for display engine

### DIFF
--- a/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
+++ b/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
@@ -7,9 +7,6 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | 95f81e8ce741d001db004b3e4e23c3ee | 2025-05-27T14-42-25 | 281ea9326bd55d467527b79d80a7e1664a10fb6c
-
-
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = DisplayEngine


### PR DESCRIPTION
This module is being carried as an override for years.

But really, we have not had any plan to upstream it to EDK2. Additionally, the driver has minimal commonality with the upstream version. This change is to break the bond with EDK2 version so that we save the hassle to deal with override tags.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

This is not a functional test.

N/A

(cherry picked from commit 61efde0633b7eae121babb3336b21aee121f569b)