### PR TITLE
PagingAuditTestApp: Increase Static Buffer Size

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -32,7 +32,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/DebugImageInfoTable.h>
 #include <Guid/MemoryAttributesTable.h>
 
-#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x1000
+#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x10000
 #define    MEM_INFO_DATABASE_MAX_STRING_SIZE  0x400
 #define    MAX_STRING_SIZE                    0x1000
 


### PR DESCRIPTION
## Description

mu_tiano_platform's pipelines have begun to fail because a static buffer in the paging audit test app has filled up. This commit increase the size from 4k to 64k.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Running the test app. Unable to repro locally, so will update mu_tiano_platforms after this gets checked in and ensure pipelines succeed.

## Integration Instructions

N/A.
