### PR TITLE
[CherryPick] Build Hid rust module with 1.85 compiler

### DIFF
--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "UefiHidDxeV2"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Microsoft"]
 
 [lib]

--- a/HidPkg/UefiHidDxeV2/src/driver_binding.rs
+++ b/HidPkg/UefiHidDxeV2/src/driver_binding.rs
@@ -99,11 +99,7 @@ impl UefiDriverBinding {
             efi::NATIVE_INTERFACE,
             uefi_driver_binding_mgr_ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(uefi_driver_binding_mgr_ptr)
-        }
+        if status.is_error() { Err(status) } else { Ok(uefi_driver_binding_mgr_ptr) }
     }
 
     /// Uninstalls the binding from the UEFI core.
@@ -111,17 +107,13 @@ impl UefiDriverBinding {
     /// uefi_binding must be the same pointer returned from [`Self::install`].
     pub unsafe fn uninstall(uefi_binding: *mut UefiDriverBinding) -> Result<Self, efi::Status> {
         let ptr = uefi_binding;
-        let binding = Box::from_raw(uefi_binding);
+        let binding = unsafe { Box::from_raw(uefi_binding) };
         let status = binding.boot_services.uninstall_protocol_interface(
             binding.uefi_binding.driver_binding_handle,
             &protocols::driver_binding::PROTOCOL_GUID as *const efi::Guid as *mut efi::Guid,
             ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(*binding)
-        }
+        if status.is_error() { Err(status) } else { Ok(*binding) }
     }
 
     // Driver Binding Supported FFI function
@@ -171,6 +163,9 @@ impl UefiDriverBinding {
 #[cfg(test)]
 mod test {
 
+    use core::ffi::c_void;
+    use core::ptr;
+
     use super::{MockDriverBinding, UefiDriverBinding};
     use crate::boot_services::MockUefiBootServices;
     use r_efi::{efi, protocols};
@@ -191,9 +186,34 @@ mod test {
         let handle = 0x1234 as efi::Handle;
         let driver_binding = UefiDriverBinding::new(boot_services, Box::new(binding), handle);
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);
@@ -262,9 +282,34 @@ mod test {
 
         let driver_binding = unsafe { UefiDriverBinding::uninstall(binding_ptr) }.unwrap();
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);

--- a/HidPkg/UefiHidDxeV2/src/hid.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid.rs
@@ -47,7 +47,7 @@ use core::ffi::c_void;
 #[cfg(test)]
 use mockall::automock;
 use r_efi::efi;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/hid_io.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid_io.rs
@@ -19,7 +19,7 @@ use r_efi::efi;
 
 use hid_io::protocol::HidReportType;
 use hidparser::ReportDescriptor;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::boot_services::UefiBootServices;
 
@@ -98,13 +98,7 @@ impl UefiHidIo {
     ) -> Result<Self, efi::Status> {
         let mut hid_io_ptr: *mut hid_io::protocol::Protocol = ptr::null_mut();
 
-        let attributes = {
-            if owned {
-                efi::OPEN_PROTOCOL_BY_DRIVER
-            } else {
-                efi::OPEN_PROTOCOL_GET_PROTOCOL
-            }
-        };
+        let attributes = { if owned { efi::OPEN_PROTOCOL_BY_DRIVER } else { efi::OPEN_PROTOCOL_GET_PROTOCOL } };
 
         let status = boot_services.open_protocol(
             controller,
@@ -328,7 +322,10 @@ mod test {
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
             assert_ne!(context, ptr::null_mut());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
 
             callback(TEST_REPORT0.len() as u16, TEST_REPORT0.as_ptr() as *mut c_void, context);
 
@@ -340,7 +337,10 @@ mod test {
             callback: hid_io::protocol::HidIoReportCallback,
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
             efi::Status::SUCCESS
         }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -24,11 +24,11 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, hii, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ArrayField, ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
 use mu_rust_helpers::function;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN, debugln};
 
 use crate::{
     boot_services::UefiBootServices,
@@ -339,10 +339,10 @@ impl KeyboardHidHandler {
         );
         if status.is_error() {
             debugln!(
-        DEBUG_ERROR,
-        "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
-        status
-      );
+                DEBUG_ERROR,
+                "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
+                status
+            );
             Err(status)?;
         }
 
@@ -456,7 +456,7 @@ impl KeyboardHidHandler {
     ) -> usize {
         let key_data = OrdKeyData(key_data);
         for (handle, entry) in &self.notification_callbacks {
-            if entry.0 == key_data && entry.1 == key_notification_function {
+            if entry.0 == key_data && ptr::fn_addr_eq(entry.1, key_notification_function) {
                 //this callback already exists for this key, so return the current handle.
                 return *handle;
             }
@@ -740,11 +740,12 @@ mod test {
     use hii_keyboard_layout::HiiKeyboardLayout;
     use r_efi::{efi, hii, protocols};
     use scroll::Pwrite;
+    use std::sync::Mutex;
 
     use crate::{
         boot_services::MockUefiBootServices,
         hid_io::{HidReportReceiver, MockHidIo},
-        keyboard::{key_queue::OrdKeyData, on_layout_update, KeyboardHidHandler, LayoutChangeContext},
+        keyboard::{KeyboardHidHandler, LayoutChangeContext, key_queue::OrdKeyData, on_layout_update},
     };
 
     static BOOT_KEYBOARD_REPORT_DESCRIPTOR: &[u8] = &[
@@ -1002,18 +1003,22 @@ mod test {
         const TEST_KEYBOARD_GUID: efi::Guid =
             efi::Guid::from_fields(0xf1796c10, 0xdafb, 0x4989, 0xa0, 0x82, &[0x75, 0xe9, 0x65, 0x76, 0xbe, 0x52]);
 
-        static mut TEST_KEYBOARD_LAYOUT: HiiKeyboardLayout =
-            HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() };
-        unsafe {
-            //make a test keyboard layout that is different than the default.
-            TEST_KEYBOARD_LAYOUT = hii_keyboard_layout::get_default_keyboard_layout();
-            TEST_KEYBOARD_LAYOUT.guid = TEST_KEYBOARD_GUID;
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].description = "Test Keyboard Layout".to_string();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].language = "ts-TS".to_string();
-        }
+        static TEST_KEYBOARD_LAYOUT: Mutex<HiiKeyboardLayout> =
+            Mutex::new(HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() });
+
+        //make a test keyboard layout that is different than the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys = hii_keyboard_layout::get_default_keyboard_layout().keys.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions =
+            hii_keyboard_layout::get_default_keyboard_layout().descriptions.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = hii_keyboard_layout::DEFAULT_KEYBOARD_LAYOUT_GUID;
+
+        // modify the default layout to make sure it is not the same as the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = TEST_KEYBOARD_GUID;
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].description = "Test Keyboard Layout".to_string();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].language = "ts-TS".to_string();
 
         extern "efiapi" fn get_keyboard_layout(
             _this: *const protocols::hii_database::Protocol,
@@ -1022,8 +1027,9 @@ mod test {
             keyboard_layout_ptr: *mut protocols::hii_database::KeyboardLayout,
         ) -> efi::Status {
             let mut keyboard_layout_buffer = vec![0u8; 4096];
-            let buffer_size =
-                keyboard_layout_buffer.pwrite(&unsafe { (*ptr::addr_of!(TEST_KEYBOARD_LAYOUT)).clone() }, 0).unwrap();
+            let buffer_size = keyboard_layout_buffer
+                .pwrite(&unsafe { (*ptr::addr_of!(TEST_KEYBOARD_LAYOUT)).lock().unwrap().clone() }, 0)
+                .unwrap();
             keyboard_layout_buffer.resize(buffer_size, 0);
             unsafe {
                 if keyboard_layout_length.read() < buffer_size as u16 {
@@ -1281,15 +1287,31 @@ mod test {
         assert_eq!(keyboard_handler.notification_callbacks.len(), 4);
         key_data.key.unicode_char = 'a' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&1).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&1).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&1).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'b' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&2).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&2).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&2).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'c' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&3).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&3).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&3).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         assert_eq!(keyboard_handler.notification_callbacks.get(&4).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&4).unwrap().1 == mock_key_notify_callback2);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&4).unwrap().1,
+            mock_key_notify_callback2
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
 
         //press and release 'c' key
         let report: &[u8] = &[0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00];

--- a/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
@@ -20,7 +20,7 @@ use r_efi::{
     efi,
     protocols::{self, hii_database::*, simple_text_input::InputKey, simple_text_input_ex::*},
 };
-use rust_advanced_logger_dxe::{debugln, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_WARN, debugln};
 
 use crate::RUNTIME_SERVICES;
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -11,7 +11,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/main.rs
+++ b/HidPkg/UefiHidDxeV2/src/main.rs
@@ -20,16 +20,16 @@ mod uefi_entry {
 
     use r_efi::{efi, system};
 
-    use rust_advanced_logger_dxe::{debugln, init_debug, DEBUG_ERROR};
+    use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln, init_debug};
     use rust_boot_services_allocator_dxe::GLOBAL_ALLOCATOR;
     use uefi_hid_dxe_v2::{
+        BOOT_SERVICES, RUNTIME_SERVICES,
         boot_services::UefiBootServices,
         driver_binding::UefiDriverBinding,
         hid::{HidFactory, HidReceiverFactory},
         hid_io::{HidReportReceiver, UefiHidIoFactory},
         keyboard::KeyboardHidHandler,
         pointer::PointerHidHandler,
-        BOOT_SERVICES, RUNTIME_SERVICES,
     };
 
     struct UefiReceivers {
@@ -48,7 +48,7 @@ mod uefi_entry {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "efiapi" fn efi_main(
         image_handle: efi::Handle,
         system_table: *const system::SystemTable,

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -19,11 +19,11 @@ use alloc::{
 use r_efi::{efi, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
 use mu_rust_helpers::function;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, debugln};
 
 use self::absolute_pointer::PointerContext;
 use crate::{
@@ -176,11 +176,7 @@ impl PointerHidHandler {
                 self.input_reports.insert(report_data.report_id, report_data);
             }
         }
-        if !self.input_reports.is_empty() {
-            Ok(())
-        } else {
-            Err(efi::Status::UNSUPPORTED)
-        }
+        if !self.input_reports.is_empty() { Ok(()) } else { Err(efi::Status::UNSUPPORTED) }
     }
 
     // Helper routine that handles projecting relative and absolute axis reports onto the fixed

--- a/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
@@ -13,9 +13,9 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, protocols};
 
 use hidparser::report_data_types::Usage;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN, debugln};
 
-use super::{PointerHidHandler, BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN};
+use super::{BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN, PointerHidHandler};
 use crate::boot_services::UefiBootServices;
 
 // FFI context
@@ -351,7 +351,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -429,7 +437,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -514,7 +530,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;


### PR DESCRIPTION
## Description

Cherry Picked from https://github.com/microsoft/mu_plus/pull/695

This change moved the rust module to build with 1.85. As requirement tightens, the rust code and tests were updated to work with the new requirements.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This change was tested on physical platform.

## Integration Instructions

N/A
