### PR TITLE
[CHERRY-PICK][release/202405] Rust 1.85 update [Rebase & FF]

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v12.0.2
+      ref: refs/tags/v15.0.1
 
 parameters:
 - name: do_ci_build
@@ -82,7 +82,7 @@ parameters:
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:d1e4ff1
+    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:68fa63a
     ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
     do_ci_build: ${{ parameters.do_ci_build }}
@@ -105,7 +105,7 @@ jobs:
 
     container:
 
-      image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:d1e4ff1
+      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:68fa63a
       options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -175,7 +175,7 @@ jobs:
           return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
-        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.9"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.24"
 
         response = get_response_with_retries(api_url)
         if response.status_code == 200:
@@ -214,7 +214,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.11
+      uses: robinraju/release-downloader@v1.12
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -23,4 +23,4 @@ jobs:
       contents: read
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.1

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.1

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,4 +28,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.1

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -32,5 +32,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.1
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.1

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v12.0.2
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ members = [
 
 # Add packages that generate libraries here
 [workspace.dependencies]
+mu_rust_helpers = { version = "3" }
 RustAdvancedLoggerDxe = {path = "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe"}
 RustBootServicesAllocatorDxe = {path = "MsCorePkg/Crates/RustBootServicesAllocatorDxe"}
 HidIo = {path = "HidPkg/Crates/HidIo"}
-hidparser = {git = "https://github.com/microsoft/mu_rust_hid.git", branch = "main"}
+hidparser = {version = "1"}
 HiiKeyboardLayout = {path = "HidPkg/Crates/HiiKeyboardLayout"}
 
 memoffset = "0.9.0"
@@ -23,5 +24,5 @@ num-traits = { version = "0.2", default-features = false}
 num-derive = { version = "0.4", default-features = false}
 r-efi = "5.0.0"
 rustversion = "1.0.14"
-spin = "0.9.8"
-scroll = { version = "0.12", default-features = false, features = ["derive"]}
+spin = "0.10.0"
+scroll = { version = "0.13", default-features = false, features = ["derive"]}

--- a/HidPkg/UefiHidDxe/src/keyboard.rs
+++ b/HidPkg/UefiHidDxe/src/keyboard.rs
@@ -846,7 +846,7 @@ extern "efiapi" fn simple_text_in_ex_register_key_notify(
     let key_data = OrdKeyData(*unsafe { key_data_ptr.as_mut().expect("Bad key_data_ptr") });
 
     for (handle, entry) in &keyboard_context.handler.notification_callbacks {
-        if entry.0 == key_data && entry.1 == key_notification_function {
+        if entry.0 == key_data && core::ptr::fn_addr_eq(entry.1, key_notification_function) {
             //if callback already exists, just return current handle
             unsafe { notify_handle.write(*handle as *mut c_void) };
             return efi::Status::SUCCESS;

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 HidIo = {workspace=true}
 hidparser = {workspace=true}
 HiiKeyboardLayout = {workspace=true}
+mu_rust_helpers = {workspace=true}
 r-efi = {workspace=true}
 rustversion = {workspace=true}
 RustAdvancedLoggerDxe = {workspace=true}

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "UefiHidDxeV2"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Microsoft"]
 
 [lib]

--- a/HidPkg/UefiHidDxeV2/src/driver_binding.rs
+++ b/HidPkg/UefiHidDxeV2/src/driver_binding.rs
@@ -99,11 +99,7 @@ impl UefiDriverBinding {
             efi::NATIVE_INTERFACE,
             uefi_driver_binding_mgr_ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(uefi_driver_binding_mgr_ptr)
-        }
+        if status.is_error() { Err(status) } else { Ok(uefi_driver_binding_mgr_ptr) }
     }
 
     /// Uninstalls the binding from the UEFI core.
@@ -111,17 +107,13 @@ impl UefiDriverBinding {
     /// uefi_binding must be the same pointer returned from [`Self::install`].
     pub unsafe fn uninstall(uefi_binding: *mut UefiDriverBinding) -> Result<Self, efi::Status> {
         let ptr = uefi_binding;
-        let binding = Box::from_raw(uefi_binding);
+        let binding = unsafe { Box::from_raw(uefi_binding) };
         let status = binding.boot_services.uninstall_protocol_interface(
             binding.uefi_binding.driver_binding_handle,
             &protocols::driver_binding::PROTOCOL_GUID as *const efi::Guid as *mut efi::Guid,
             ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(*binding)
-        }
+        if status.is_error() { Err(status) } else { Ok(*binding) }
     }
 
     // Driver Binding Supported FFI function
@@ -171,6 +163,9 @@ impl UefiDriverBinding {
 #[cfg(test)]
 mod test {
 
+    use core::ffi::c_void;
+    use core::ptr;
+
     use super::{MockDriverBinding, UefiDriverBinding};
     use crate::boot_services::MockUefiBootServices;
     use r_efi::{efi, protocols};
@@ -191,9 +186,34 @@ mod test {
         let handle = 0x1234 as efi::Handle;
         let driver_binding = UefiDriverBinding::new(boot_services, Box::new(binding), handle);
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);
@@ -262,9 +282,34 @@ mod test {
 
         let driver_binding = unsafe { UefiDriverBinding::uninstall(binding_ptr) }.unwrap();
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);

--- a/HidPkg/UefiHidDxeV2/src/hid.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid.rs
@@ -47,7 +47,7 @@ use core::ffi::c_void;
 #[cfg(test)]
 use mockall::automock;
 use r_efi::efi;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/hid_io.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid_io.rs
@@ -19,7 +19,7 @@ use r_efi::efi;
 
 use hid_io::protocol::HidReportType;
 use hidparser::ReportDescriptor;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::boot_services::UefiBootServices;
 
@@ -98,13 +98,7 @@ impl UefiHidIo {
     ) -> Result<Self, efi::Status> {
         let mut hid_io_ptr: *mut hid_io::protocol::Protocol = ptr::null_mut();
 
-        let attributes = {
-            if owned {
-                efi::OPEN_PROTOCOL_BY_DRIVER
-            } else {
-                efi::OPEN_PROTOCOL_GET_PROTOCOL
-            }
-        };
+        let attributes = { if owned { efi::OPEN_PROTOCOL_BY_DRIVER } else { efi::OPEN_PROTOCOL_GET_PROTOCOL } };
 
         let status = boot_services.open_protocol(
             controller,
@@ -328,7 +322,10 @@ mod test {
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
             assert_ne!(context, ptr::null_mut());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
 
             callback(TEST_REPORT0.len() as u16, TEST_REPORT0.as_ptr() as *mut c_void, context);
 
@@ -340,7 +337,10 @@ mod test {
             callback: hid_io::protocol::HidIoReportCallback,
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
             efi::Status::SUCCESS
         }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -24,10 +24,11 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, hii, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ArrayField, ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
+use mu_rust_helpers::function;
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN, debugln};
 
 use crate::{
     boot_services::UefiBootServices,
@@ -338,10 +339,10 @@ impl KeyboardHidHandler {
         );
         if status.is_error() {
             debugln!(
-        DEBUG_ERROR,
-        "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
-        status
-      );
+                DEBUG_ERROR,
+                "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
+                status
+            );
             Err(status)?;
         }
 
@@ -455,7 +456,7 @@ impl KeyboardHidHandler {
     ) -> usize {
         let key_data = OrdKeyData(key_data);
         for (handle, entry) in &self.notification_callbacks {
-            if entry.0 == key_data && entry.1 == key_notification_function {
+            if entry.0 == key_data && ptr::fn_addr_eq(entry.1, key_notification_function) {
                 //this callback already exists for this key, so return the current handle.
                 return *handle;
             }
@@ -734,16 +735,17 @@ extern "efiapi" fn on_layout_update(_event: efi::Event, context: *mut c_void) {
 #[cfg(test)]
 mod test {
 
-    use core::{ffi::c_void, mem::MaybeUninit, slice::from_raw_parts_mut};
+    use core::{ffi::c_void, mem::MaybeUninit, ptr, slice::from_raw_parts_mut};
 
     use hii_keyboard_layout::HiiKeyboardLayout;
     use r_efi::{efi, hii, protocols};
     use scroll::Pwrite;
+    use std::sync::Mutex;
 
     use crate::{
         boot_services::MockUefiBootServices,
         hid_io::{HidReportReceiver, MockHidIo},
-        keyboard::{key_queue::OrdKeyData, on_layout_update, KeyboardHidHandler, LayoutChangeContext},
+        keyboard::{KeyboardHidHandler, LayoutChangeContext, key_queue::OrdKeyData, on_layout_update},
     };
 
     static BOOT_KEYBOARD_REPORT_DESCRIPTOR: &[u8] = &[
@@ -1001,18 +1003,22 @@ mod test {
         const TEST_KEYBOARD_GUID: efi::Guid =
             efi::Guid::from_fields(0xf1796c10, 0xdafb, 0x4989, 0xa0, 0x82, &[0x75, 0xe9, 0x65, 0x76, 0xbe, 0x52]);
 
-        static mut TEST_KEYBOARD_LAYOUT: HiiKeyboardLayout =
-            HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() };
-        unsafe {
-            //make a test keyboard layout that is different than the default.
-            TEST_KEYBOARD_LAYOUT = hii_keyboard_layout::get_default_keyboard_layout();
-            TEST_KEYBOARD_LAYOUT.guid = TEST_KEYBOARD_GUID;
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].description = "Test Keyboard Layout".to_string();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].language = "ts-TS".to_string();
-        }
+        static TEST_KEYBOARD_LAYOUT: Mutex<HiiKeyboardLayout> =
+            Mutex::new(HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() });
+
+        //make a test keyboard layout that is different than the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys = hii_keyboard_layout::get_default_keyboard_layout().keys.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions =
+            hii_keyboard_layout::get_default_keyboard_layout().descriptions.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = hii_keyboard_layout::DEFAULT_KEYBOARD_LAYOUT_GUID;
+
+        // modify the default layout to make sure it is not the same as the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = TEST_KEYBOARD_GUID;
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].description = "Test Keyboard Layout".to_string();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].language = "ts-TS".to_string();
 
         extern "efiapi" fn get_keyboard_layout(
             _this: *const protocols::hii_database::Protocol,
@@ -1021,7 +1027,9 @@ mod test {
             keyboard_layout_ptr: *mut protocols::hii_database::KeyboardLayout,
         ) -> efi::Status {
             let mut keyboard_layout_buffer = vec![0u8; 4096];
-            let buffer_size = keyboard_layout_buffer.pwrite(unsafe { &TEST_KEYBOARD_LAYOUT }, 0).unwrap();
+            let buffer_size = keyboard_layout_buffer
+                .pwrite(&unsafe { (*ptr::addr_of!(TEST_KEYBOARD_LAYOUT)).lock().unwrap().clone() }, 0)
+                .unwrap();
             keyboard_layout_buffer.resize(buffer_size, 0);
             unsafe {
                 if keyboard_layout_length.read() < buffer_size as u16 {
@@ -1279,15 +1287,31 @@ mod test {
         assert_eq!(keyboard_handler.notification_callbacks.len(), 4);
         key_data.key.unicode_char = 'a' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&1).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&1).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&1).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'b' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&2).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&2).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&2).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'c' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&3).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&3).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&3).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         assert_eq!(keyboard_handler.notification_callbacks.get(&4).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&4).unwrap().1 == mock_key_notify_callback2);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&4).unwrap().1,
+            mock_key_notify_callback2
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
 
         //press and release 'c' key
         let report: &[u8] = &[0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00];

--- a/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
@@ -20,7 +20,7 @@ use r_efi::{
     efi,
     protocols::{self, hii_database::*, simple_text_input::InputKey, simple_text_input_ex::*},
 };
-use rust_advanced_logger_dxe::{debugln, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_WARN, debugln};
 
 use crate::RUNTIME_SERVICES;
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -11,7 +11,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/main.rs
+++ b/HidPkg/UefiHidDxeV2/src/main.rs
@@ -20,16 +20,16 @@ mod uefi_entry {
 
     use r_efi::{efi, system};
 
-    use rust_advanced_logger_dxe::{debugln, init_debug, DEBUG_ERROR};
+    use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln, init_debug};
     use rust_boot_services_allocator_dxe::GLOBAL_ALLOCATOR;
     use uefi_hid_dxe_v2::{
+        BOOT_SERVICES, RUNTIME_SERVICES,
         boot_services::UefiBootServices,
         driver_binding::UefiDriverBinding,
         hid::{HidFactory, HidReceiverFactory},
         hid_io::{HidReportReceiver, UefiHidIoFactory},
         keyboard::KeyboardHidHandler,
         pointer::PointerHidHandler,
-        BOOT_SERVICES, RUNTIME_SERVICES,
     };
 
     struct UefiReceivers {
@@ -48,7 +48,7 @@ mod uefi_entry {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "efiapi" fn efi_main(
         image_handle: efi::Handle,
         system_table: *const system::SystemTable,

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -19,10 +19,11 @@ use alloc::{
 use r_efi::{efi, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
-use rust_advanced_logger_dxe::{debugln, function, DEBUG_ERROR, DEBUG_VERBOSE};
+use mu_rust_helpers::function;
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, debugln};
 
 use self::absolute_pointer::PointerContext;
 use crate::{
@@ -175,11 +176,7 @@ impl PointerHidHandler {
                 self.input_reports.insert(report_data.report_id, report_data);
             }
         }
-        if !self.input_reports.is_empty() {
-            Ok(())
-        } else {
-            Err(efi::Status::UNSUPPORTED)
-        }
+        if !self.input_reports.is_empty() { Ok(()) } else { Err(efi::Status::UNSUPPORTED) }
     }
 
     // Helper routine that handles projecting relative and absolute axis reports onto the fixed

--- a/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
@@ -13,9 +13,9 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, protocols};
 
 use hidparser::report_data_types::Usage;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN, debugln};
 
-use super::{PointerHidHandler, BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN};
+use super::{BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN, PointerHidHandler};
 use crate::boot_services::UefiBootServices;
 
 // FFI context
@@ -351,7 +351,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -429,7 +437,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -514,7 +530,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.85.0"
 
 [tool]
 cargo-make = "0.37.9"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 channel = "1.85.0"
 
 [tool]
-cargo-make = "0.37.9"
-cargo-tarpaulin = "0.31.2"
+cargo-make = "0.37.24"
+cargo-tarpaulin = "0.31.5"


### PR DESCRIPTION
## Description

Merge conflicts were present when the backporting workflow attempted to automatically cherry-pick the changes that went from `dev/202405` in https://github.com/microsoft/mu_plus/pull/709 into `release/202405`. This change manually cherry-picks that series into `release/202405`.

The changes made to address dependencies for the cherry-pick to update `HidPkg` to use Rust 1.85 are made in this commit:

> HidPkg: Rust changes for 1.85 cherry-pick
> 
> The upcoming cherry-pick needs some changes specific to the
> release/202405 branch to be made for the changes to apply.
> 
> This commit makes those changes.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- CI

## Integration Instructions

- N/A