### PR TITLE
[CHERRY-PICK][2311] Prevent memcpy intrinsics in VS22 (17.14.2) [Rebase & FF] 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -199,12 +199,16 @@ jobs:
           print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
 
 
-    - name: Attempt to Load cargo-make From Cache
+    # - name: Attempt to Load cargo-make From Cache
+    #   id: cargo_make_cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+    #     key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+
+    - name: Force cargo-make cache miss
       id: cargo_make_cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
-        key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+      run: echo "cache-hit=false" >> $GITHUB_OUTPUT
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'

--- a/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
+++ b/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
@@ -372,12 +372,10 @@ PolynomialDivision (
 
   // MU_CHANGE [END] - CodeQL change
 
-  for (i = 0; i < DividendCount; i++) {
-    TempRemainder[i] = Dividend[i];
-  }
+  CopyMem (TempRemainder, Dividend, DividendCount);
 
   if (gFlags & QR_FLAGS_DEBUG_POLYDIVIDE) {
-    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", i));
+    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", DividendCount));
     for (j = 0; j < sizeofnumbers; j++) {
       DEBUG ((DEBUG_INFO, " %3d,", TempRemainder[j]));
     }


### PR DESCRIPTION
## Description

Cherry-picks changes to 202311 to build with recent Visual Studio 2022 releases and to allow the CodeQL workflow to succeed.

- [[CHERRY-PICK] MsGraphicsPkg/QrEncoderLib: Prevent memcpy being used on VS22 (17.14.2)](https://github.com/microsoft/mu_plus/commit/a854d25d1215b85b5e3f4b5bf4e6162f2f2bd637)
- [[CHERRY-PICK] codeql.yml: Always download cargo make](https://github.com/microsoft/mu_plus/commit/18d124bbec185f3618d159cafda26fdd428ae377)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- VS22 build

## Integration Instructions

- N/A