### PR TITLE
MsGraphicsPkg/DisplayEngineDxe: Remove override hash

### DIFF
--- a/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
+++ b/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
@@ -7,9 +7,6 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | a3e75c5e3cb70580751814df534c1755 | 2023-10-26T19-21-17 | e77aa3b4b2bb9854c8ec3ec931b97428fe86315e
-
-
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = DisplayEngine


### PR DESCRIPTION
## Description

The override hash would need to be updated for the 2311 Mu Basecore file.

For the change to `DisplayEngineDxe` in https://github.com/microsoft/mu_basecore/pull/1410.

This change removes the hash to match what is done in later (the 2502) release branch.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- `stuart_ci_build -c .\.pytool\CISettings.py -p MsGraphicsPkg -a X64 -t DEBUG TOOL_CHAIN_TAG=VS2022`

## Integration Instructions

- Ensure `MU_BASECORE` is updated to the latest current commit in `release/202311` (`5976d7d9c3950d1c2977295ae480eb3a9b40f17a`).