### PR TITLE
Support die offsets for GIC functions

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -276,7 +276,7 @@ SetupInterruptStatus (
   IN  UINTN  CpuIndex
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS                 Status;
   EFI_PROCESSOR_INFORMATION  CpuInfo;
 
   if (mCommonBuffer[CpuIndex].CpuArchBuffer == NULL) {
@@ -308,9 +308,11 @@ SetupInterruptStatus (
     return Status;
   }
 
-  ArmGicEnableInterrupt ((UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
-                         (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
-                         PcdGet32 (PcdGicSgiIntId));
+  ArmGicEnableInterrupt (
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+    PcdGet32 (PcdGicSgiIntId)
+    );
 
   ArmEnableInterrupts ();
 
@@ -330,7 +332,7 @@ RestoreInterruptStatus (
   IN  UINTN  CpuIndex
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS                 Status;
   EFI_PROCESSOR_INFORMATION  CpuInfo;
 
   // Disable gic cpu interface
@@ -344,9 +346,11 @@ RestoreInterruptStatus (
     return Status;
   }
 
-  ArmGicDisableInterrupt ((UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
-                          (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
-                          PcdGet32 (PcdGicSgiIntId));
+  ArmGicDisableInterrupt (
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+    PcdGet32 (PcdGicSgiIntId)
+    );
 
   return EFI_SUCCESS;
 }

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -277,6 +277,7 @@ SetupInterruptStatus (
   )
 {
   EFI_STATUS  Status;
+  EFI_PROCESSOR_INFORMATION  CpuInfo;
 
   if (mCommonBuffer[CpuIndex].CpuArchBuffer == NULL) {
     return EFI_NOT_READY;
@@ -300,7 +301,16 @@ SetupInterruptStatus (
   ArmGicEnableInterruptInterface (PcdGet64 (PcdGicInterruptInterfaceBase));
 
   // Enable the intended interrupt source
-  ArmGicEnableInterrupt ((UINT32)PcdGet64 (PcdGicDistributorBase), (UINT32)PcdGet64 (PcdGicRedistributorsBase), PcdGet32 (PcdGicSgiIntId));
+  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __FUNCTION__, CpuIndex, Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  ArmGicEnableInterrupt ((UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+                         (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+                         PcdGet32 (PcdGicSgiIntId));
 
   ArmEnableInterrupts ();
 
@@ -320,11 +330,23 @@ RestoreInterruptStatus (
   IN  UINTN  CpuIndex
   )
 {
+  EFI_STATUS  Status;
+  EFI_PROCESSOR_INFORMATION  CpuInfo;
+
   // Disable gic cpu interface
   ArmGicDisableInterruptInterface (PcdGet64 (PcdGicInterruptInterfaceBase));
 
   // Disable the intended interrupt source
-  ArmGicDisableInterrupt ((UINT32)PcdGet64 (PcdGicDistributorBase), (UINT32)PcdGet64 (PcdGicRedistributorsBase), PcdGet32 (PcdGicSgiIntId));
+  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __FUNCTION__, CpuIndex, Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  ArmGicDisableInterrupt ((UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+                          (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64(PcdPlatformGICOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+                          PcdGet32 (PcdGicSgiIntId));
 
   return EFI_SUCCESS;
 }

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -798,7 +798,7 @@ MpManagementEntryPoint (
                   &mMpManagement
                   );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Error: Failed to fetch processor information.\n"));
+    DEBUG ((DEBUG_ERROR, "Error: Failed to Install Protocol Interface.\n"));
     goto Done;
   }
 

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
@@ -62,6 +62,7 @@
   gArmTokenSpaceGuid.PcdGicRedistributorsBase
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
   gArmTokenSpaceGuid.PcdGicSgiIntId
+  gUefiTestingPkgTokenSpaceGuid.PcdPlatformGICOffset
 
 [Pcd.AARCH64]
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum

--- a/UefiTestingPkg/UefiTestingPkg.dec
+++ b/UefiTestingPkg/UefiTestingPkg.dec
@@ -50,3 +50,7 @@
 
   ## Power state used for suspending a secondary core to C3 state
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformC3PowerState|0x1010022|UINT64|0x00000003
+
+  ## Platforms with multiple die(s) can have same GIC base address but with an added offset address for each die.
+  ## This offset address values can be added to base GIC address to reach die-specific address.
+  gUefiTestingPkgTokenSpaceGuid.PcdPlatformGICOffset|0x0|UINT64|0x00000004


### PR DESCRIPTION
## Description
Platforms with multiple die(s) can have a die offset address added to common GIC address to reach die-specific GIC address. Hence, adding support to get die information from MpServices and use a platform specific PCD to calculate die offset address which is then added to base GIC addresses. 

The existing implementation will remain unchanged since PcdPlatformGICOffset is set to 0 by default. Platforms can override this value to its specific need. 

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on MSFT platform

## Integration Instructions

N/A
