### PR TITLE
Remove comparison on the timestamp portion for LineParser test app

### DIFF
--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -578,7 +578,8 @@ BasicTests (
   UT_ASSERT_MEM_EQUAL (
     &(mMessageEntry.Message[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
     &(Btc->ExpectedLine[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
-    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_SIZE);
+    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_SIZE
+    );
 
   return UNIT_TEST_PASSED;
 }

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -27,6 +27,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UNIT_TEST_APP_NAME     "LineParser Library test cases"
 #define UNIT_TEST_APP_VERSION  "1.0"
 
+#define ADV_LOG_TIME_STAMP_RESULT     "hh:mm:ss:ttt : "
+
 // The following text represents the file logger stream of text as individual DEBUG
 // statements.
 
@@ -564,15 +566,18 @@ BasicTests (
   UT_LOG_INFO ("\nExpected Length=%d\n", AsciiStrLen (Btc->ExpectedLine));
   UT_LOG_INFO ("\n = %a =\n", Btc->ExpectedLine);
 
-  if (mMessageEntry.MessageLen != AsciiStrLen (Btc->ExpectedLine)) {
+  // if (mMessageEntry.MessageLen != AsciiStrLen (Btc->ExpectedLine)) {
     DUMP_HEX (DEBUG_ERROR, 0, mMessageEntry.Message, mMessageEntry.MessageLen, "Actual   - ");
     DUMP_HEX (DEBUG_ERROR, 0, Btc->ExpectedLine, AsciiStrLen (Btc->ExpectedLine), "Expected - ");
-  }
+  // }
 
   UT_ASSERT_EQUAL (mMessageEntry.MessageLen, AsciiStrLen (Btc->ExpectedLine));
 
   // The following also verifies that the string is NULL terminated.
-  UT_ASSERT_MEM_EQUAL (mMessageEntry.Message, Btc->ExpectedLine, mMessageEntry.MessageLen + sizeof (CHAR8));
+  UT_ASSERT_MEM_EQUAL (
+    &(mMessageEntry.Message[sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1]),
+    &(Btc->ExpectedLine[sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1]),
+    mMessageEntry.MessageLen + sizeof (CHAR8) - (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1));
 
   return UNIT_TEST_PASSED;
 }

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -27,7 +27,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UNIT_TEST_APP_NAME     "LineParser Library test cases"
 #define UNIT_TEST_APP_VERSION  "1.0"
 
-#define ADV_LOG_TIME_STAMP_RESULT     "hh:mm:ss:ttt : "
+#define ADV_LOG_TIME_STAMP_RESULT       "hh:mm:ss:ttt : "
+#define ADV_LOG_TIME_STAMP_RESULT_SIZE  (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
 
 // The following text represents the file logger stream of text as individual DEBUG
 // statements.
@@ -566,18 +567,18 @@ BasicTests (
   UT_LOG_INFO ("\nExpected Length=%d\n", AsciiStrLen (Btc->ExpectedLine));
   UT_LOG_INFO ("\n = %a =\n", Btc->ExpectedLine);
 
-  // if (mMessageEntry.MessageLen != AsciiStrLen (Btc->ExpectedLine)) {
+  if (mMessageEntry.MessageLen != AsciiStrLen (Btc->ExpectedLine)) {
     DUMP_HEX (DEBUG_ERROR, 0, mMessageEntry.Message, mMessageEntry.MessageLen, "Actual   - ");
     DUMP_HEX (DEBUG_ERROR, 0, Btc->ExpectedLine, AsciiStrLen (Btc->ExpectedLine), "Expected - ");
-  // }
+  }
 
   UT_ASSERT_EQUAL (mMessageEntry.MessageLen, AsciiStrLen (Btc->ExpectedLine));
 
   // The following also verifies that the string is NULL terminated.
   UT_ASSERT_MEM_EQUAL (
-    &(mMessageEntry.Message[sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1]),
-    &(Btc->ExpectedLine[sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1]),
-    mMessageEntry.MessageLen + sizeof (CHAR8) - (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1));
+    &(mMessageEntry.Message[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
+    &(Btc->ExpectedLine[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
+    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_SIZE);
 
   return UNIT_TEST_PASSED;
 }

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -27,8 +27,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UNIT_TEST_APP_NAME     "LineParser Library test cases"
 #define UNIT_TEST_APP_VERSION  "1.0"
 
-#define ADV_LOG_TIME_STAMP_RESULT       "hh:mm:ss:ttt : "
-#define ADV_LOG_TIME_STAMP_RESULT_LEN   (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
+#define ADV_LOG_TIME_STAMP_RESULT      "hh:mm:ss:ttt : "
+#define ADV_LOG_TIME_STAMP_RESULT_LEN  (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
 
 // The following text represents the file logger stream of text as individual DEBUG
 // statements.

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -28,7 +28,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UNIT_TEST_APP_VERSION  "1.0"
 
 #define ADV_LOG_TIME_STAMP_RESULT       "hh:mm:ss:ttt : "
-#define ADV_LOG_TIME_STAMP_RESULT_SIZE  (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
+#define ADV_LOG_TIME_STAMP_RESULT_LEN   (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
 
 // The following text represents the file logger stream of text as individual DEBUG
 // statements.
@@ -576,9 +576,9 @@ BasicTests (
 
   // The following also verifies that the string is NULL terminated.
   UT_ASSERT_MEM_EQUAL (
-    &(mMessageEntry.Message[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
-    &(Btc->ExpectedLine[ADV_LOG_TIME_STAMP_RESULT_SIZE]),
-    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_SIZE
+    &(mMessageEntry.Message[ADV_LOG_TIME_STAMP_RESULT_LEN]),
+    &(Btc->ExpectedLine[ADV_LOG_TIME_STAMP_RESULT_LEN]),
+    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_LEN
     );
 
   return UNIT_TEST_PASSED;


### PR DESCRIPTION
## Description

Somehow the latest basecore has changed how the rollover of a timestamp is handled, which caused an earlier mitigation in vain.

This change dumps the comparison for that prefix because the exact time comparison is not the point of this test.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Test passed locally on QEMU SBSA

## Integration Instructions

N/A