### PR TITLE
[CHERRY-PICK] Support die offsets for GIC functions (#717)

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -267,6 +267,14 @@ RestoreBspStates (
   The main goal is to enable the AP to accept software generated
   interrupts sent from BSP.
 
+  PcdGicPerPackageOffset usage assumptions::
+  1. Each GIC is tied to ExtendedInformation.Location2.Package field of EFI_PROCESSOR_INFORMATION which is expected
+  to have die location of individual cores
+  2. The GIC address are linearly spaced out, meaning, if GIC address in Die0 is x, then
+  GIC address for Die 1 : ((offset*1) + x) and
+  GIC address for Die 2 : ((offset*2) + x) and so on.
+  If these assumption don't apply to your platform, redeclaration of the PCD can break functionality
+
   @param  CpuIndex      The number of intended CPU to be setup.
 
   @return EFI_SUCCESS   The routine always succeeds.
@@ -276,7 +284,8 @@ SetupInterruptStatus (
   IN  UINTN  CpuIndex
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS                 Status;
+  EFI_PROCESSOR_INFORMATION  CpuInfo;
 
   if (mCommonBuffer[CpuIndex].CpuArchBuffer == NULL) {
     return EFI_NOT_READY;
@@ -300,7 +309,18 @@ SetupInterruptStatus (
   ArmGicEnableInterruptInterface (PcdGet64 (PcdGicInterruptInterfaceBase));
 
   // Enable the intended interrupt source
-  ArmGicEnableInterrupt ((UINT32)PcdGet64 (PcdGicDistributorBase), (UINT32)PcdGet64 (PcdGicRedistributorsBase), PcdGet32 (PcdGicSgiIntId));
+  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __func__, CpuIndex, Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  ArmGicEnableInterrupt (
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdGicPerPackageOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdGicPerPackageOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+    PcdGet32 (PcdGicSgiIntId)
+    );
 
   ArmEnableInterrupts ();
 
@@ -311,6 +331,14 @@ SetupInterruptStatus (
   This routine will restore the AP specific interrupt states after
   the entire AP routine is about to be completed.
 
+  PcdGicPerPackageOffset usage assumptions::
+  1. Each GIC is tied to ExtendedInformation.Location2.Package field of EFI_PROCESSOR_INFORMATION which is expected
+  to have die location of individual cores
+  2. The GIC address are linearly spaced out, meaning, if GIC address in Die0 is x, then
+  GIC address for Die 1 : ((offset*1) + x) and
+  GIC address for Die 2 : ((offset*2) + x) and so on.
+  If these assumption don't apply to your platform, redeclaration of the PCD can break functionality
+
   @param  CpuIndex      The number of intended CPU to be setup.
 
   @return EFI_SUCCESS   The routine always succeeds.
@@ -320,11 +348,25 @@ RestoreInterruptStatus (
   IN  UINTN  CpuIndex
   )
 {
+  EFI_STATUS                 Status;
+  EFI_PROCESSOR_INFORMATION  CpuInfo;
+
   // Disable gic cpu interface
   ArmGicDisableInterruptInterface (PcdGet64 (PcdGicInterruptInterfaceBase));
 
   // Disable the intended interrupt source
-  ArmGicDisableInterrupt ((UINT32)PcdGet64 (PcdGicDistributorBase), (UINT32)PcdGet64 (PcdGicRedistributorsBase), PcdGet32 (PcdGicSgiIntId));
+  Status = mMpServices->GetProcessorInfo (mMpServices, CPU_V2_EXTENDED_TOPOLOGY | CpuIndex, &CpuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a Cannot get information for specified processor (%d) - %r\n", __func__, CpuIndex, Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  ArmGicDisableInterrupt (
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdGicPerPackageOffset)) + PcdGet64 (PcdGicDistributorBase)), \
+    (UINT64)((CpuInfo.ExtendedInformation.Location2.Package * PcdGet64 (PcdGicPerPackageOffset)) + PcdGet64 (PcdGicRedistributorsBase)), \
+    PcdGet32 (PcdGicSgiIntId)
+    );
 
   return EFI_SUCCESS;
 }

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
@@ -62,6 +62,7 @@
   gArmTokenSpaceGuid.PcdGicRedistributorsBase
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
   gArmTokenSpaceGuid.PcdGicSgiIntId
+    gUefiTestingPkgTokenSpaceGuid.PcdGicPerPackageOffset
 
 [Pcd.AARCH64]
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum

--- a/UefiTestingPkg/UefiTestingPkg.dec
+++ b/UefiTestingPkg/UefiTestingPkg.dec
@@ -50,3 +50,14 @@
 
   ## Power state used for suspending a secondary core to C3 state
   gUefiTestingPkgTokenSpaceGuid.PcdPlatformC3PowerState|0x1010022|UINT64|0x00000003
+
+  ## Platforms with multiple die(s) can have same GIC base address but with an added offset address for each die.
+  ## This offset address values can be added to base GIC address to reach die-specific GIC address.
+  ## Assumptions:
+  ## 1. Each GIC is tied to ExtendedInformation.Location2.Package field of EFI_PROCESSOR_INFORMATION which is expected
+  ## to have die location of individual cores
+  ## 2. The GIC address are linearly spaced out, meaning, if GIC address in Die0 is x, then
+  ## GIC address for Die 1 : ((offset*1) + x) and
+  ## GIC address for Die 2 : ((offset*2) + x) and so on.
+  ## If these assumption don't apply to your platform, redeclaration of the PCD can break functionality
+  gUefiTestingPkgTokenSpaceGuid.PcdGicPerPackageOffset|0x0|UINT64|0x00000004


### PR DESCRIPTION
## Description

Platforms with multiple die(s) can have a die offset address added to common GIC address to reach die-specific GIC address. Hence, adding support to get die information from MpServices and use a platform specific PCD to calculate die offset address which is then added to base GIC addresses.

The existing implementation will remain unchanged since PcdPlatformGICOffset is set to 0 by default. Platforms can override this value to its specific need.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on MSFT platform, booting to UEFI shell.

## Integration Instructions

N/A
