### PR TITLE
GopOverrideDxe: prevent single-protocol handle from being freed

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -82,7 +82,7 @@ parameters:
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:b089181
+    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:4d8e1b7
     ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
     do_ci_build: ${{ parameters.do_ci_build }}
@@ -105,7 +105,7 @@ jobs:
 
     container:
 
-      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:b089181
+      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:4d8e1b7
       options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
 
     steps:

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v15.0.2
+      ref: refs/tags/v15.0.3
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v15.0.1
+      ref: refs/tags/v15.0.2
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v14.0.1
+      ref: refs/tags/v15.0.1
 
 parameters:
 - name: do_ci_build
@@ -82,7 +82,7 @@ parameters:
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:4d8e1b7
+    linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:68fa63a
     ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
     do_ci_build: ${{ parameters.do_ci_build }}
@@ -105,7 +105,7 @@ jobs:
 
     container:
 
-      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:4d8e1b7
+      image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:68fa63a
       options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
 
     steps:

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v13.0.3
+      ref: refs/tags/v14.0.1
 
 parameters:
 - name: do_ci_build

--- a/.github/release-draft-config-n-1-dev.yml
+++ b/.github/release-draft-config-n-1-dev.yml
@@ -20,7 +20,7 @@
 name-template: 'dev-v$RESOLVED_VERSION'
 tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/dev/202311
+commitish: refs/heads/dev/202405
 filter-by-commitish: true
 
 template: |

--- a/.github/release-draft-config-n-1.yml
+++ b/.github/release-draft-config-n-1.yml
@@ -20,7 +20,7 @@
 name-template: 'dev-v$RESOLVED_VERSION'
 tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/dev/202311
+commitish: refs/heads/dev/202405
 filter-by-commitish: true
 include-labels: ["type:backport"]
 

--- a/.github/release-draft-config-n-dev.yml
+++ b/.github/release-draft-config-n-dev.yml
@@ -20,7 +20,7 @@
 name-template: 'dev-v$RESOLVED_VERSION'
 tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/dev/202405
+commitish: refs/heads/dev/202502
 filter-by-commitish: true
 
 template: |

--- a/.github/release-draft-config-n.yml
+++ b/.github/release-draft-config-n.yml
@@ -20,7 +20,7 @@
 name-template: 'dev-v$RESOLVED_VERSION'
 tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/dev/202405
+commitish: refs/heads/dev/202502
 filter-by-commitish: true
 include-labels: ["type:backport"]
 

--- a/.github/workflows/backport-to-release-branch.yml
+++ b/.github/workflows/backport-to-release-branch.yml
@@ -148,7 +148,7 @@ jobs:
           core.setOutput('pr_number', prNumber);
           core.setOutput('backport_needed', 'true');
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
     - name: Checkout a Local ${{ steps.backport_info.outputs.target_branch_name }} Branch (Destination Branch)
       if: steps.backport_check.outputs.backport_needed == 'true'

--- a/.github/workflows/backport-to-release-branch.yml
+++ b/.github/workflows/backport-to-release-branch.yml
@@ -1,5 +1,12 @@
 # This workflow moves marked commits from a development branch to a release branch.
 #
+# This workflow requires a GitHub App with the following permissions:
+# - Read and write access to repository contents
+# - Read and write access to pull requests
+#
+# The GitHub App ID and private key should be stored in the repository as a variable named `MU_ACCESS_APP_ID` and a
+# secret named `MU_ACCESS_APP_PRIVATE_KEY` respectively.
+#
 # Each commit in the development branch is cherry-picked to the release branch if the commit originates from a merged
 # PR that is marked for backport.
 #
@@ -25,6 +32,7 @@ name: Backport Commits to Release Branch
 on:
   push:
     branches:
+      - dev/202502
       - dev/202405
 
 jobs:
@@ -33,11 +41,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.MU_ACCESS_APP_ID }}
+        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.CHERRY_PICK_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Determine Contribution Info
       id: backport_info
@@ -229,5 +244,5 @@ jobs:
         -H "Content-Type: application/json" \
         -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$PR_BRANCH\",\"base\":\"$BASE_BRANCH\",\"labels\":[\"type:release-merge-conflict\"]}"
       env:
-        CHERRY_PICK_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        CHERRY_PICK_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -207,12 +207,16 @@ jobs:
           print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
 
 
-    - name: Attempt to Load cargo-make From Cache
+    # - name: Attempt to Load cargo-make From Cache
+    #   id: cargo_make_cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+    #     key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+
+    - name: Force cargo-make cache miss
       id: cargo_make_cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
-        key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+      run: echo "cache-hit=false" >> $GITHUB_OUTPUT
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,8 @@ jobs:
   gather_packages:
     name: Gather Repo Packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       packages: ${{ steps.generate_matrix.outputs.packages }}
 
@@ -165,38 +167,44 @@ jobs:
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         import os
         import requests
         import sys
         import time
 
-        def get_response_with_retries(url, retries=5, wait_time=10):
+        def get_response_with_retries(url, headers, retries=5, wait_time=10):
           for attempt in range(retries):
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             if response.status_code == 200:
               return response
-            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed. Retrying in {wait_time} seconds...")
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed ({response.status_code}). Retrying in {wait_time} seconds...")
             time.sleep(wait_time)
           return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.24"
+        headers = {
+          "Authorization": f"Bearer {os.environ['AUTH_TOKEN']}",
+          "Accept": "application/vnd.github.v3+json"
+        }
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           build_release_id = response.json()["id"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make release ID! ({response.status_code})")
           sys.exit(1)
 
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make! ({response.status_code})")
           sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'
@@ -207,6 +215,8 @@ jobs:
           print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
 
 
+    # Temporarily disable caching cargo-make as it stopped working in some repos recently
+    # and need to be investigated
     # - name: Attempt to Load cargo-make From Cache
     #   id: cargo_make_cache
     #   uses: actions/cache@v4

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -23,4 +23,4 @@ jobs:
       contents: read
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.2

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -19,8 +19,5 @@ on:
 jobs:
   apply:
 
-    permissions:
-      contents: read
-      issues: write
-
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.3
+    secrets: inherit

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -23,4 +23,4 @@ jobs:
       contents: read
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v15.0.1

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -23,4 +23,4 @@ jobs:
       contents: read
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v14.0.1

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -21,7 +21,7 @@ on:
     types:
       - edited
       - opened
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.2

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -21,7 +21,7 @@ on:
     types:
       - edited
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened
@@ -31,9 +31,5 @@ on:
 
 jobs:
   apply:
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.3
+    secrets: inherit

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v15.0.1

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v14.0.1

--- a/.github/workflows/label-issues/regex-pull-requests.yml
+++ b/.github/workflows/label-issues/regex-pull-requests.yml
@@ -10,24 +10,45 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # For more information, see:
-# https://github.com/github/issue-labeler
+# https://github.com/srvaroa/labeler
 
 # Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+version: 1
+issues: False
 
-type:backport:
-  - '\s*-\s*\[\s*[x|X]\s*\] Backport to release branch\?'
+labels:
+  - label: type:backport
+    type: "pull_request"
+    body: '\s*\[\s*(x|X){1}\s*\]\s*Backport to release branch\?'
 
-impact:breaking-change:
-  - '\s*-\s*\[\s*[x|X]\s*\] Breaking change\?'
+  - label: type:backport
+    type: "pull_request"
+    authors: ["mu-automation[bot]"]
+    branch : "repo-sync/mu_devops/default"  
+    base-branch: "dev/20[0-9]{4}"
 
-type:documentation:
-  - '\s*-\s*\[\s*[x|X]\s*\] Includes documentation\?'
+  - label: type:backport
+    type: "pull_request"
+    authors: ["dependabot[bot]"]
+    branch : "dependabot/*"
+    base-branch: "dev/20[0-9]{4}"
 
-impact:non-functional:
-  - '\s*-\s*\[\s*(?![x|X])\s*\] Impacts functionality\?'
+  - label: impact:breaking-change
+    type: "pull_request"
+    body: '\s*\[\s*(x|X){1}\s*\]\s*Breaking\s*change\?'
 
-impact:security:
-  - '\s*-\s*\[\s*[x|X]\s*\] Impacts security\?'
+  - label: type:documentation
+    type: "pull_request"
+    body: '\s*\[\s*(x|X){1}\s*\]\s*Includes\s*documentation\?'
 
-impact:testing:
-  - '\s*-\s*\[\s*[x|X]\s*\] Includes tests\?'
+  - label: impact:non-functional
+    type: "pull_request"
+    body: '\s*\[\s*\]\s*Impacts\s*functionality\?'
+
+  - label: impact:security
+    type: "pull_request"
+    body: '\s*\[\s*(x|X){1}\s*\]\s*Impacts\s*security\?'
+
+  - label: impact:testing
+    type: "pull_request"
+    body: '\[\s*(x|X){1}\s*\]\s*Includes\s*tests\?'

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -25,7 +25,5 @@ on:
 jobs:
   sync:
 
-    permissions:
-      issues: write
-
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.3
+    secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,4 +28,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.2

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,4 +28,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v15.0.1

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,4 +28,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v14.0.1

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened
@@ -24,11 +24,15 @@ jobs:
   validate_pr:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='
             query($name: String!, $owner: String!, $pr_number: Int!) {
@@ -45,7 +49,7 @@ jobs:
           fi
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -35,5 +35,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.2
     secrets: inherit

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -31,9 +31,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    permissions:
-      contents: write
-      pull-requests: write
-
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.3
     secrets: inherit

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,7 +23,7 @@ name: Update Release Draft
 on:
   workflow_run:
     workflows: ["Backport Commits to Release Branch"]
-    branches: [dev/202405]
+    branches: [dev/202502]
     types:
       - completed
 
@@ -35,5 +35,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v14.0.1
     secrets: inherit

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -35,5 +35,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.1
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -25,17 +25,21 @@ jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
 
-    permissions:
-      pull-requests: write
-      issues: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Prune Won't Fix Pull Requests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \
@@ -50,7 +54,7 @@ jobs:
 
       - name: Prune Won't Fix Issues
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,8 +25,5 @@ on:
 jobs:
   check:
 
-    permissions:
-      issues: write
-      pull-requests: write
-
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.3
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
       issues: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v14.0.1

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,7 +20,5 @@ on:
 jobs:
   triage:
 
-    permissions:
-      issues: write
-
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.2
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.3
+    secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.1
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.2

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v14.0.1
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v15.0.1

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       issues: write
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v14.0.1

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -194,22 +194,22 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             {
                 "Path": "MU_BASECORE",
                 "Url": "https://github.com/microsoft/mu_basecore.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Silicon/Arm/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_silicon_arm_tiano.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Silicon/Intel/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_silicon_intel_tiano.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             },
             {
                 "Path": "Common/MU_TIANO",
                 "Url": "https://github.com/Microsoft/mu_tiano_plus.git",
-                "Branch": "dev/202502"
+                "Branch": "release/202502"
             }
         ]
 

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -27,6 +27,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UNIT_TEST_APP_NAME     "LineParser Library test cases"
 #define UNIT_TEST_APP_VERSION  "1.0"
 
+#define ADV_LOG_TIME_STAMP_RESULT      "hh:mm:ss:ttt : "
+#define ADV_LOG_TIME_STAMP_RESULT_LEN  (sizeof (ADV_LOG_TIME_STAMP_RESULT) - 1)
+
 // The following text represents the file logger stream of text as individual DEBUG
 // statements.
 
@@ -572,7 +575,11 @@ BasicTests (
   UT_ASSERT_EQUAL (mMessageEntry.MessageLen, AsciiStrLen (Btc->ExpectedLine));
 
   // The following also verifies that the string is NULL terminated.
-  UT_ASSERT_MEM_EQUAL (mMessageEntry.Message, Btc->ExpectedLine, mMessageEntry.MessageLen + sizeof (CHAR8));
+  UT_ASSERT_MEM_EQUAL (
+    &(mMessageEntry.Message[ADV_LOG_TIME_STAMP_RESULT_LEN]),
+    &(Btc->ExpectedLine[ADV_LOG_TIME_STAMP_RESULT_LEN]),
+    mMessageEntry.MessageLen + sizeof (CHAR8) - ADV_LOG_TIME_STAMP_RESULT_LEN
+    );
 
   return UNIT_TEST_PASSED;
 }

--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -58,47 +58,47 @@ CHAR8  *InternalMemoryLog[] = {
 // The following text represents the output lines from the line parser given the above input
 
 /* spell-checker: disable */
-CHAR8  Line00[] = "09:06:45.012 : [INFO] First normal test line\n";
-CHAR8  Line01[] = "09:06:45.012 : [ERR ] The QueryMode() function returns information for an available graphics mod\n";
-CHAR8  Line02[] = "09:06:45.012 : [ERR ] e that the graphics device and the set of active video output devices supp\n";
-CHAR8  Line03[] = "09:06:45.012 : [ERR ] orts.\n";
-CHAR8  Line04[] = "09:06:45.012 : [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
-CHAR8  Line05[] = "09:06:45.012 : [ERR ]  is returned.\n";
-CHAR8  Line06[] = "09:06:45.012 : [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
-CHAR8  Line07[] = "09:06:45.012 : [INFO] OTOCOL.\n";
-CHAR8  Line08[] = "09:06:45.012 : [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
-CHAR8  Line09[] = "09:06:45.012 : [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
-CHAR8  Line10[] = "09:06:45.012 : [ERR ] \n";
-CHAR8  Line11[] = "09:06:45.012 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line12[] = "09:06:45.012 : [INFO] ents a single video output device, then the set of modes returned by this \n";
-CHAR8  Line13[] = "09:06:45.012 : [ERR ] service is the subset of modes supported by both the graphics controller a\n";
-CHAR8  Line14[] = "09:06:45.012 : [ERR ] nd the video output device.\n";
-CHAR8  Line15[] = "09:06:45.012 : [ERR ] \n";
-CHAR8  Line16[] = "09:06:45.012 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line17[] = "09:06:45.012 : [ERR ] ents a combination of video output devices, then the set of modes returned\n";
-CHAR8  Line18[] = "09:06:45.012 : [INFO]  by this service is the subset of modes supported by the graphics controll\n";
-CHAR8  Line19[] = "09:06:45.012 : [ERR ] er and all of the video output devices represented by the handle.\n";
+CHAR8  Line00[] = "09:06:45.011 : [INFO] First normal test line\n";
+CHAR8  Line01[] = "09:06:45.011 : [ERR ] The QueryMode() function returns information for an available graphics mod\n";
+CHAR8  Line02[] = "09:06:45.011 : [ERR ] e that the graphics device and the set of active video output devices supp\n";
+CHAR8  Line03[] = "09:06:45.011 : [ERR ] orts.\n";
+CHAR8  Line04[] = "09:06:45.011 : [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
+CHAR8  Line05[] = "09:06:45.011 : [ERR ]  is returned.\n";
+CHAR8  Line06[] = "09:06:45.011 : [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
+CHAR8  Line07[] = "09:06:45.011 : [INFO] OTOCOL.\n";
+CHAR8  Line08[] = "09:06:45.011 : [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
+CHAR8  Line09[] = "09:06:45.011 : [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
+CHAR8  Line10[] = "09:06:45.011 : [ERR ] \n";
+CHAR8  Line11[] = "09:06:45.011 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line12[] = "09:06:45.011 : [INFO] ents a single video output device, then the set of modes returned by this \n";
+CHAR8  Line13[] = "09:06:45.011 : [ERR ] service is the subset of modes supported by both the graphics controller a\n";
+CHAR8  Line14[] = "09:06:45.011 : [ERR ] nd the video output device.\n";
+CHAR8  Line15[] = "09:06:45.011 : [ERR ] \n";
+CHAR8  Line16[] = "09:06:45.011 : [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line17[] = "09:06:45.011 : [ERR ] ents a combination of video output devices, then the set of modes returned\n";
+CHAR8  Line18[] = "09:06:45.011 : [INFO]  by this service is the subset of modes supported by the graphics controll\n";
+CHAR8  Line19[] = "09:06:45.011 : [ERR ] er and all of the video output devices represented by the handle.\n";
 
-CHAR8  Line00V2[] = "09:06:45.012 : [DXE  ] [INFO] First normal test line\n";
-CHAR8  Line01V2[] = "09:06:45.012 : [DXE  ] [ERR ] The QueryMode() function returns information for an available graphics mod\n";
-CHAR8  Line02V2[] = "09:06:45.012 : [DXE  ] [ERR ] e that the graphics device and the set of active video output devices supp\n";
-CHAR8  Line03V2[] = "09:06:45.012 : [DXE  ] [ERR ] orts.\n";
-CHAR8  Line04V2[] = "09:06:45.012 : [DXE  ] [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
-CHAR8  Line05V2[] = "09:06:45.012 : [DXE  ] [ERR ]  is returned.\n";
-CHAR8  Line06V2[] = "09:06:45.012 : [DXE  ] [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
-CHAR8  Line07V2[] = "09:06:45.012 : [DXE  ] [INFO] OTOCOL.\n";
-CHAR8  Line08V2[] = "09:06:45.012 : [DXE  ] [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
-CHAR8  Line09V2[] = "09:06:45.012 : [DXE  ] [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
-CHAR8  Line10V2[] = "09:06:45.012 : [DXE  ] [ERR ] \n";
-CHAR8  Line11V2[] = "09:06:45.012 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line12V2[] = "09:06:45.012 : [DXE  ] [INFO] ents a single video output device, then the set of modes returned by this \n";
-CHAR8  Line13V2[] = "09:06:45.012 : [DXE  ] [ERR ] service is the subset of modes supported by both the graphics controller a\n";
-CHAR8  Line14V2[] = "09:06:45.012 : [DXE  ] [ERR ] nd the video output device.\n";
-CHAR8  Line15V2[] = "09:06:45.012 : [DXE  ] [ERR ] \n";
-CHAR8  Line16V2[] = "09:06:45.012 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
-CHAR8  Line17V2[] = "09:06:45.012 : [DXE  ] [ERR ] ents a combination of video output devices, then the set of modes returned\n";
-CHAR8  Line18V2[] = "09:06:45.012 : [DXE  ] [INFO]  by this service is the subset of modes supported by the graphics controll\n";
-CHAR8  Line19V2[] = "09:06:45.012 : [DXE  ] [ERR ] er and all of the video output devices represented by the handle.\n";
+CHAR8  Line00V2[] = "09:06:45.011 : [DXE  ] [INFO] First normal test line\n";
+CHAR8  Line01V2[] = "09:06:45.011 : [DXE  ] [ERR ] The QueryMode() function returns information for an available graphics mod\n";
+CHAR8  Line02V2[] = "09:06:45.011 : [DXE  ] [ERR ] e that the graphics device and the set of active video output devices supp\n";
+CHAR8  Line03V2[] = "09:06:45.011 : [DXE  ] [ERR ] orts.\n";
+CHAR8  Line04V2[] = "09:06:45.011 : [DXE  ] [ERR ] If ModeNumber is not between 0 and MaxMode - 1, then EFI_INVALID_PARAMETER\n";
+CHAR8  Line05V2[] = "09:06:45.011 : [DXE  ] [ERR ]  is returned.\n";
+CHAR8  Line06V2[] = "09:06:45.011 : [DXE  ] [INFO] MaxMode is available from the Mode structure of the EFI_GRAPHICS_OUTPUT_PR\n";
+CHAR8  Line07V2[] = "09:06:45.011 : [DXE  ] [INFO] OTOCOL.\n";
+CHAR8  Line08V2[] = "09:06:45.011 : [DXE  ] [ERR ] The size of the Info structure should never be assumed and the value of Si\n";
+CHAR8  Line09V2[] = "09:06:45.011 : [DXE  ] [ERR ] zeOfInfo is the only valid way to know the size of Info.\n";
+CHAR8  Line10V2[] = "09:06:45.011 : [DXE  ] [ERR ] \n";
+CHAR8  Line11V2[] = "09:06:45.011 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line12V2[] = "09:06:45.011 : [DXE  ] [INFO] ents a single video output device, then the set of modes returned by this \n";
+CHAR8  Line13V2[] = "09:06:45.011 : [DXE  ] [ERR ] service is the subset of modes supported by both the graphics controller a\n";
+CHAR8  Line14V2[] = "09:06:45.011 : [DXE  ] [ERR ] nd the video output device.\n";
+CHAR8  Line15V2[] = "09:06:45.011 : [DXE  ] [ERR ] \n";
+CHAR8  Line16V2[] = "09:06:45.011 : [DXE  ] [ERR ] If the EFI_GRAPHICS_OUTPUT_PROTOCOL is installed on the handle that repres\n";
+CHAR8  Line17V2[] = "09:06:45.011 : [DXE  ] [ERR ] ents a combination of video output devices, then the set of modes returned\n";
+CHAR8  Line18V2[] = "09:06:45.011 : [DXE  ] [INFO]  by this service is the subset of modes supported by the graphics controll\n";
+CHAR8  Line19V2[] = "09:06:45.011 : [DXE  ] [ERR ] er and all of the video output devices represented by the handle.\n";
 
 /* spell-checker: enable */
 
@@ -137,7 +137,6 @@ InternalGetPerformanceCounter (
   )
 {
   UINT64           TimeInMs;
-  UINT64           TimeInNs;
   UINT64           Frequency;
   UINT32           Remainder = 0;
   STATIC   UINT64  Ticks     = 0;
@@ -183,10 +182,8 @@ InternalGetPerformanceCounter (
   //
   // Do multiply first, then divide, to keep as many bits as possible
   //
-  Ticks    = DivU64x32Remainder (MultU64x64 (TimeInMs, Frequency), 1000u, &Remainder) + Remainder;
-  TimeInNs = GetTimeInNanoSecond (Ticks);
 
-  UT_ASSERT_TRUE (TimeInMs == (TimeInNs / 1000000u));
+  Ticks = DivU64x32Remainder (MultU64x64 (TimeInMs, Frequency), 1000u, &Remainder);
 
   return Ticks;
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ num-derive = { version = "0.4", default-features = false}
 r-efi = "5.0.0"
 rustversion = "1.0.14"
 spin = "0.10.0"
-scroll = { version = "0.12", default-features = false, features = ["derive"]}
+scroll = { version = "0.13", default-features = false, features = ["derive"]}

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "UefiHidDxeV2"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Microsoft"]
 
 [lib]

--- a/HidPkg/UefiHidDxeV2/src/driver_binding.rs
+++ b/HidPkg/UefiHidDxeV2/src/driver_binding.rs
@@ -99,11 +99,7 @@ impl UefiDriverBinding {
             efi::NATIVE_INTERFACE,
             uefi_driver_binding_mgr_ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(uefi_driver_binding_mgr_ptr)
-        }
+        if status.is_error() { Err(status) } else { Ok(uefi_driver_binding_mgr_ptr) }
     }
 
     /// Uninstalls the binding from the UEFI core.
@@ -111,17 +107,13 @@ impl UefiDriverBinding {
     /// uefi_binding must be the same pointer returned from [`Self::install`].
     pub unsafe fn uninstall(uefi_binding: *mut UefiDriverBinding) -> Result<Self, efi::Status> {
         let ptr = uefi_binding;
-        let binding = Box::from_raw(uefi_binding);
+        let binding = unsafe { Box::from_raw(uefi_binding) };
         let status = binding.boot_services.uninstall_protocol_interface(
             binding.uefi_binding.driver_binding_handle,
             &protocols::driver_binding::PROTOCOL_GUID as *const efi::Guid as *mut efi::Guid,
             ptr as *mut c_void,
         );
-        if status.is_error() {
-            Err(status)
-        } else {
-            Ok(*binding)
-        }
+        if status.is_error() { Err(status) } else { Ok(*binding) }
     }
 
     // Driver Binding Supported FFI function
@@ -171,6 +163,9 @@ impl UefiDriverBinding {
 #[cfg(test)]
 mod test {
 
+    use core::ffi::c_void;
+    use core::ptr;
+
     use super::{MockDriverBinding, UefiDriverBinding};
     use crate::boot_services::MockUefiBootServices;
     use r_efi::{efi, protocols};
@@ -191,9 +186,34 @@ mod test {
         let handle = 0x1234 as efi::Handle;
         let driver_binding = UefiDriverBinding::new(boot_services, Box::new(binding), handle);
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);
@@ -262,9 +282,34 @@ mod test {
 
         let driver_binding = unsafe { UefiDriverBinding::uninstall(binding_ptr) }.unwrap();
 
-        assert!(driver_binding.uefi_binding.supported == UefiDriverBinding::driver_binding_supported);
-        assert!(driver_binding.uefi_binding.start == UefiDriverBinding::driver_binding_start);
-        assert!(driver_binding.uefi_binding.stop == UefiDriverBinding::driver_binding_stop);
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.supported,
+            UefiDriverBinding::driver_binding_supported
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.start,
+            UefiDriverBinding::driver_binding_start
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    *mut protocols::device_path::Protocol,
+                ) -> efi::Status
+        ));
+        assert!(ptr::fn_addr_eq(
+            driver_binding.uefi_binding.stop,
+            UefiDriverBinding::driver_binding_stop
+                as extern "efiapi" fn(
+                    *mut protocols::driver_binding::Protocol,
+                    *mut c_void,
+                    usize,
+                    *mut *mut c_void,
+                ) -> efi::Status
+        ));
         assert_eq!(driver_binding.uefi_binding.version, 1);
         assert_eq!(driver_binding.uefi_binding.image_handle, handle);
         assert_eq!(driver_binding.uefi_binding.driver_binding_handle, handle);

--- a/HidPkg/UefiHidDxeV2/src/hid.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid.rs
@@ -47,7 +47,7 @@ use core::ffi::c_void;
 #[cfg(test)]
 use mockall::automock;
 use r_efi::efi;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/hid_io.rs
+++ b/HidPkg/UefiHidDxeV2/src/hid_io.rs
@@ -19,7 +19,7 @@ use r_efi::efi;
 
 use hid_io::protocol::HidReportType;
 use hidparser::ReportDescriptor;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::boot_services::UefiBootServices;
 
@@ -98,13 +98,7 @@ impl UefiHidIo {
     ) -> Result<Self, efi::Status> {
         let mut hid_io_ptr: *mut hid_io::protocol::Protocol = ptr::null_mut();
 
-        let attributes = {
-            if owned {
-                efi::OPEN_PROTOCOL_BY_DRIVER
-            } else {
-                efi::OPEN_PROTOCOL_GET_PROTOCOL
-            }
-        };
+        let attributes = { if owned { efi::OPEN_PROTOCOL_BY_DRIVER } else { efi::OPEN_PROTOCOL_GET_PROTOCOL } };
 
         let status = boot_services.open_protocol(
             controller,
@@ -328,7 +322,10 @@ mod test {
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
             assert_ne!(context, ptr::null_mut());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
 
             callback(TEST_REPORT0.len() as u16, TEST_REPORT0.as_ptr() as *mut c_void, context);
 
@@ -340,7 +337,10 @@ mod test {
             callback: hid_io::protocol::HidIoReportCallback,
         ) -> efi::Status {
             assert_ne!(this, ptr::null());
-            assert!(callback == UefiHidIo::report_callback);
+            assert!(ptr::fn_addr_eq(
+                callback,
+                UefiHidIo::report_callback as extern "efiapi" fn(u16, *mut c_void, *mut c_void)
+            ));
             efi::Status::SUCCESS
         }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -24,11 +24,11 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, hii, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ArrayField, ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
 use mu_rust_helpers::function;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN, debugln};
 
 use crate::{
     boot_services::UefiBootServices,
@@ -339,10 +339,10 @@ impl KeyboardHidHandler {
         );
         if status.is_error() {
             debugln!(
-        DEBUG_ERROR,
-        "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
-        status
-      );
+                DEBUG_ERROR,
+                "keyboard::install_default_layout: Could not locate hii_database protocol to install keyboard layout: {:x?}",
+                status
+            );
             Err(status)?;
         }
 
@@ -456,7 +456,7 @@ impl KeyboardHidHandler {
     ) -> usize {
         let key_data = OrdKeyData(key_data);
         for (handle, entry) in &self.notification_callbacks {
-            if entry.0 == key_data && entry.1 == key_notification_function {
+            if entry.0 == key_data && ptr::fn_addr_eq(entry.1, key_notification_function) {
                 //this callback already exists for this key, so return the current handle.
                 return *handle;
             }
@@ -740,11 +740,12 @@ mod test {
     use hii_keyboard_layout::HiiKeyboardLayout;
     use r_efi::{efi, hii, protocols};
     use scroll::Pwrite;
+    use std::sync::Mutex;
 
     use crate::{
         boot_services::MockUefiBootServices,
         hid_io::{HidReportReceiver, MockHidIo},
-        keyboard::{key_queue::OrdKeyData, on_layout_update, KeyboardHidHandler, LayoutChangeContext},
+        keyboard::{KeyboardHidHandler, LayoutChangeContext, key_queue::OrdKeyData, on_layout_update},
     };
 
     static BOOT_KEYBOARD_REPORT_DESCRIPTOR: &[u8] = &[
@@ -1002,18 +1003,22 @@ mod test {
         const TEST_KEYBOARD_GUID: efi::Guid =
             efi::Guid::from_fields(0xf1796c10, 0xdafb, 0x4989, 0xa0, 0x82, &[0x75, 0xe9, 0x65, 0x76, 0xbe, 0x52]);
 
-        static mut TEST_KEYBOARD_LAYOUT: HiiKeyboardLayout =
-            HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() };
-        unsafe {
-            //make a test keyboard layout that is different than the default.
-            TEST_KEYBOARD_LAYOUT = hii_keyboard_layout::get_default_keyboard_layout();
-            TEST_KEYBOARD_LAYOUT.guid = TEST_KEYBOARD_GUID;
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.keys.pop();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].description = "Test Keyboard Layout".to_string();
-            TEST_KEYBOARD_LAYOUT.descriptions[0].language = "ts-TS".to_string();
-        }
+        static TEST_KEYBOARD_LAYOUT: Mutex<HiiKeyboardLayout> =
+            Mutex::new(HiiKeyboardLayout { keys: Vec::new(), guid: TEST_KEYBOARD_GUID, descriptions: Vec::new() });
+
+        //make a test keyboard layout that is different than the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys = hii_keyboard_layout::get_default_keyboard_layout().keys.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions =
+            hii_keyboard_layout::get_default_keyboard_layout().descriptions.clone();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = hii_keyboard_layout::DEFAULT_KEYBOARD_LAYOUT_GUID;
+
+        // modify the default layout to make sure it is not the same as the default.
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().guid = TEST_KEYBOARD_GUID;
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().keys.pop();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].description = "Test Keyboard Layout".to_string();
+        TEST_KEYBOARD_LAYOUT.lock().unwrap().descriptions[0].language = "ts-TS".to_string();
 
         extern "efiapi" fn get_keyboard_layout(
             _this: *const protocols::hii_database::Protocol,
@@ -1022,8 +1027,9 @@ mod test {
             keyboard_layout_ptr: *mut protocols::hii_database::KeyboardLayout,
         ) -> efi::Status {
             let mut keyboard_layout_buffer = vec![0u8; 4096];
-            let buffer_size =
-                keyboard_layout_buffer.pwrite(&unsafe { (*ptr::addr_of!(TEST_KEYBOARD_LAYOUT)).clone() }, 0).unwrap();
+            let buffer_size = keyboard_layout_buffer
+                .pwrite(&unsafe { (*ptr::addr_of!(TEST_KEYBOARD_LAYOUT)).lock().unwrap().clone() }, 0)
+                .unwrap();
             keyboard_layout_buffer.resize(buffer_size, 0);
             unsafe {
                 if keyboard_layout_length.read() < buffer_size as u16 {
@@ -1281,15 +1287,31 @@ mod test {
         assert_eq!(keyboard_handler.notification_callbacks.len(), 4);
         key_data.key.unicode_char = 'a' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&1).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&1).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&1).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'b' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&2).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&2).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&2).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         key_data.key.unicode_char = 'c' as u16;
         assert_eq!(keyboard_handler.notification_callbacks.get(&3).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&3).unwrap().1 == mock_key_notify_callback);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&3).unwrap().1,
+            mock_key_notify_callback
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
         assert_eq!(keyboard_handler.notification_callbacks.get(&4).unwrap().0, OrdKeyData(key_data));
-        assert!(keyboard_handler.notification_callbacks.get(&4).unwrap().1 == mock_key_notify_callback2);
+        assert!(ptr::fn_addr_eq(
+            keyboard_handler.notification_callbacks.get(&4).unwrap().1,
+            mock_key_notify_callback2
+                as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
+        ));
 
         //press and release 'c' key
         let report: &[u8] = &[0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00];

--- a/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
@@ -20,7 +20,7 @@ use r_efi::{
     efi,
     protocols::{self, hii_database::*, simple_text_input::InputKey, simple_text_input_ex::*},
 };
-use rust_advanced_logger_dxe::{debugln, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_WARN, debugln};
 
 use crate::RUNTIME_SERVICES;
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -11,7 +11,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln};
 
 use crate::{
     boot_services::UefiBootServices,

--- a/HidPkg/UefiHidDxeV2/src/main.rs
+++ b/HidPkg/UefiHidDxeV2/src/main.rs
@@ -20,16 +20,16 @@ mod uefi_entry {
 
     use r_efi::{efi, system};
 
-    use rust_advanced_logger_dxe::{debugln, init_debug, DEBUG_ERROR};
+    use rust_advanced_logger_dxe::{DEBUG_ERROR, debugln, init_debug};
     use rust_boot_services_allocator_dxe::GLOBAL_ALLOCATOR;
     use uefi_hid_dxe_v2::{
+        BOOT_SERVICES, RUNTIME_SERVICES,
         boot_services::UefiBootServices,
         driver_binding::UefiDriverBinding,
         hid::{HidFactory, HidReceiverFactory},
         hid_io::{HidReportReceiver, UefiHidIoFactory},
         keyboard::KeyboardHidHandler,
         pointer::PointerHidHandler,
-        BOOT_SERVICES, RUNTIME_SERVICES,
     };
 
     struct UefiReceivers {
@@ -48,7 +48,7 @@ mod uefi_entry {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "efiapi" fn efi_main(
         image_handle: efi::Handle,
         system_table: *const system::SystemTable,

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -19,11 +19,11 @@ use alloc::{
 use r_efi::{efi, protocols};
 
 use hidparser::{
-    report_data_types::{ReportId, Usage},
     ReportDescriptor, ReportField, VariableField,
+    report_data_types::{ReportId, Usage},
 };
 use mu_rust_helpers::function;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_VERBOSE};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, debugln};
 
 use self::absolute_pointer::PointerContext;
 use crate::{
@@ -176,11 +176,7 @@ impl PointerHidHandler {
                 self.input_reports.insert(report_data.report_id, report_data);
             }
         }
-        if !self.input_reports.is_empty() {
-            Ok(())
-        } else {
-            Err(efi::Status::UNSUPPORTED)
-        }
+        if !self.input_reports.is_empty() { Ok(()) } else { Err(efi::Status::UNSUPPORTED) }
     }
 
     // Helper routine that handles projecting relative and absolute axis reports onto the fixed

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -40,6 +40,7 @@ const BUTTON_MIN: u32 = 0x00090001;
 const BUTTON_MAX: u32 = 0x00090020; //Per spec, the Absolute Pointer protocol supports a 32-bit button state field.
 const DIGITIZER_SWITCH_MIN: u32 = 0x000d0042;
 const DIGITIZER_SWITCH_MAX: u32 = 0x000d0046;
+const DIGITIZER_CONTACT_COUNT: u32 = 0x000d0054;
 
 // number of points on the X/Y axis for this implementation.
 const AXIS_RESOLUTION: u64 = 1024;
@@ -60,6 +61,16 @@ struct PointerReportData {
     relevant_fields: Vec<ReportFieldWithHandler>,
 }
 
+// Defines counters for determining how many pointers need to be handled
+#[derive(Debug, Default, Clone)]
+struct UsageUpdateCounter {
+    x: u8,
+    y: u8,
+    z: u8,
+    button: u8,
+    switch: u8,
+}
+
 /// Pointer HID Handler
 pub struct PointerHidHandler {
     boot_services: &'static dyn UefiBootServices,
@@ -70,6 +81,7 @@ pub struct PointerHidHandler {
     report_id_present: bool,
     state_changed: bool,
     current_state: protocols::absolute_pointer::State,
+    contact_count: u8,
 }
 
 impl PointerHidHandler {
@@ -84,6 +96,7 @@ impl PointerHidHandler {
             report_id_present: false,
             state_changed: false,
             current_state: Default::default(),
+            contact_count: 0xFF, // If HID device's report doesn't contain the contact count usage(ex: mouse), leave it as 0xFF
         };
         handler.reset_state();
         handler
@@ -109,35 +122,50 @@ impl PointerHidHandler {
             for field in &report.fields {
                 if let ReportField::Variable(field) = field {
                     match field.usage.into() {
+                        DIGITIZER_CONTACT_COUNT => {
+                            let field_handler = ReportFieldWithHandler {
+                                field: field.clone(),
+                                report_handler: Self::contact_count_handler,
+                            };
+                            // Always check the Contact Count(if exist) first before handling any input pointer data
+                            report_data.relevant_fields.insert(0, field_handler);
+                            self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
+                        }
                         GENERIC_DESKTOP_X => {
                             let field_handler =
                                 ReportFieldWithHandler { field: field.clone(), report_handler: Self::x_axis_handler };
                             report_data.relevant_fields.push(field_handler);
                             self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
                         }
                         GENERIC_DESKTOP_Y => {
                             let field_handler =
                                 ReportFieldWithHandler { field: field.clone(), report_handler: Self::y_axis_handler };
                             report_data.relevant_fields.push(field_handler);
                             self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
                         }
                         GENERIC_DESKTOP_Z | GENERIC_DESKTOP_WHEEL => {
                             let field_handler =
                                 ReportFieldWithHandler { field: field.clone(), report_handler: Self::z_axis_handler };
                             report_data.relevant_fields.push(field_handler);
                             self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
                         }
                         BUTTON_MIN..=BUTTON_MAX => {
                             let field_handler =
                                 ReportFieldWithHandler { field: field.clone(), report_handler: Self::button_handler };
                             report_data.relevant_fields.push(field_handler);
                             self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
                         }
                         DIGITIZER_SWITCH_MIN..=DIGITIZER_SWITCH_MAX => {
                             let field_handler =
                                 ReportFieldWithHandler { field: field.clone(), report_handler: Self::button_handler };
                             report_data.relevant_fields.push(field_handler);
                             self.supported_usages.insert(field.usage);
+                            debugln!(DEBUG_VERBOSE, "usage 0x{:X} inserted", field.usage.id());
                         }
                         _ => (), //other usages irrelevant
                     }
@@ -233,12 +261,21 @@ impl PointerHidHandler {
         }
     }
 
+    // Get the contact count
+    fn contact_count_handler(&mut self, field: VariableField, report: &[u8]) {
+        if let Some(contact_count) = field.field_value(report) {
+            debugln!(DEBUG_VERBOSE, "contact_count: {}", contact_count);
+            self.contact_count = contact_count as u8;
+        }
+    }
+
     fn reset_state(&mut self) {
         self.current_state = Default::default();
         // initialize pointer to center of screen
         self.current_state.current_x = CENTER;
         self.current_state.current_y = CENTER;
         self.state_changed = false;
+        self.contact_count = 0xFF;
     }
 }
 
@@ -272,6 +309,9 @@ impl HidReportReceiver for PointerHidHandler {
             }
 
             if let Some(report_data) = self.input_reports.get(&report_id).cloned() {
+                // reset all counters of contact count for a new input report
+                let mut counters = UsageUpdateCounter::default();
+
                 if report.len() != report_data.report_size {
                     //Some devices report extra bytes in their reports. Warn about this, but try and process anyway.
                     debugln!(
@@ -289,7 +329,48 @@ impl HidReportReceiver for PointerHidHandler {
 
                 // hand the report data to the handler for each relevant field for field-specific processing.
                 for field in report_data.relevant_fields {
-                    (field.report_handler)(self, field.field, report);
+                    match field.field.usage.into() {
+                        DIGITIZER_CONTACT_COUNT => {
+                            debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                            (field.report_handler)(self, field.field, report);
+                        }
+                        GENERIC_DESKTOP_X => {
+                            if counters.x < self.contact_count {
+                                debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                                (field.report_handler)(self, field.field, report);
+                                counters.x += 1;
+                            }
+                        }
+                        GENERIC_DESKTOP_Y => {
+                            if counters.y < self.contact_count {
+                                debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                                (field.report_handler)(self, field.field, report);
+                                counters.y += 1;
+                            }
+                        }
+                        GENERIC_DESKTOP_Z | GENERIC_DESKTOP_WHEEL => {
+                            if counters.z < self.contact_count {
+                                debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                                (field.report_handler)(self, field.field, report);
+                                counters.z += 1;
+                            }
+                        }
+                        BUTTON_MIN..=BUTTON_MAX => {
+                            if counters.button < self.contact_count {
+                                debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                                (field.report_handler)(self, field.field, report);
+                                counters.button += 1;
+                            }
+                        }
+                        DIGITIZER_SWITCH_MIN..=DIGITIZER_SWITCH_MAX => {
+                            if counters.switch < self.contact_count {
+                                debugln!(DEBUG_VERBOSE, "handler for usage 0x{:X}", field.field.usage.id());
+                                (field.report_handler)(self, field.field, report);
+                                counters.switch += 1;
+                            }
+                        }
+                        _ => (), //other usages irrelevant
+                    }
                 }
             }
         }

--- a/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
@@ -13,9 +13,9 @@ use core::{ffi::c_void, ptr};
 use r_efi::{efi, protocols};
 
 use hidparser::report_data_types::Usage;
-use rust_advanced_logger_dxe::{debugln, DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN};
+use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_INFO, DEBUG_WARN, debugln};
 
-use super::{PointerHidHandler, BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN};
+use super::{BUTTON_MAX, BUTTON_MIN, DIGITIZER_SWITCH_MAX, DIGITIZER_SWITCH_MIN, PointerHidHandler};
 use crate::boot_services::UefiBootServices;
 
 // FFI context
@@ -351,7 +351,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -429,7 +437,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;
@@ -514,7 +530,15 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            assert!(wait_for_ptr == Some(PointerContext::wait_for_pointer));
+            if wait_for_ptr.is_none() {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
+            } else {
+                assert!(ptr::fn_addr_eq(
+                    wait_for_ptr.unwrap(),
+                    PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
+                ));
+            }
             assert_ne!(context, ptr::null_mut());
             unsafe {
                 EVENT_CONTEXT = context;

--- a/MfciPkg/Private/Library/MfciPolicyParsingLib/MfciPolicyParsingLib.c
+++ b/MfciPkg/Private/Library/MfciPolicyParsingLib/MfciPolicyParsingLib.c
@@ -355,21 +355,26 @@ FindRule (
   OUT        POLICY_VALUE_HEADER  **Value
   )
 {
-  UINT16  RulesCount       = Policy->RulesCount;
-  UINTN   RulesSize        = RulesCount * sizeof (RULE);
-  UINTN   ValueTableOffset = sizeof (MfciPolicyBlob) + RulesSize;
-  CHAR16  LocalString[POLICY_STRING_MAX_LENGTH];
-  CHAR16  *SubKeyExpected;
-  CHAR16  *ValueNameExpected;
+  EFI_STATUS  Status;
+  UINT16      RulesCount       = Policy->RulesCount;
+  UINTN       RulesSize        = RulesCount * sizeof (RULE);
+  UINTN       ValueTableOffset = sizeof (MfciPolicyBlob) + RulesSize;
+  CHAR16      LocalString[POLICY_STRING_MAX_LENGTH];
+  CHAR16      *SubKeyExpected;
+  CHAR16      *ValueNameExpected;
 
   if ((Policy == NULL) || (MfciPolicyName == NULL) || (Value == NULL)) {
     DEBUG ((DEBUG_ERROR, "Policy is NULL, Name is NULL, or Value is NULL\n"));
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "Searching for: '%s'\n", MfciPolicyName));
+  Status = StrCpyS (LocalString, sizeof (LocalString), MfciPolicyName);
+  if (EFI_ERROR (Status)) {
+    return EFI_COMPROMISED_DATA;
+  }
 
-  StrCpyS (LocalString, sizeof (LocalString), MfciPolicyName);
+  DEBUG ((DEBUG_VERBOSE, "Searching for: '%s'\n", LocalString));
+
   SplitPolicyName (LocalString, &SubKeyExpected, &ValueNameExpected);
   DEBUG ((DEBUG_VERBOSE, "Split SubKeyName '%s' & ValueName '%s'\n", SubKeyExpected, ValueNameExpected));
 
@@ -378,17 +383,16 @@ FindRule (
 
   for (UINT16 i = 0; i < RulesCount; i++) {
     RULE  *Rule = &Rules[i];
-    DEBUG ((DEBUG_VERBOSE, "Rule #: %d  Rule* 0x%p\n", i, Rule));
+    DEBUG ((DEBUG_VERBOSE, "Rule #: %u  Rule* 0x%p\n", i, Rule));
 
     if (Rule->RootKey != UEFI_POLICIES_ROOT_KEY) {
-      DEBUG ((DEBUG_ERROR, "Incorrect Root Key found: %x\n", Rule->RootKey));
+      DEBUG ((DEBUG_ERROR, "Incorrect Root Key found: 0x%x\n", Rule->RootKey));
       continue;
     }
 
     POLICY_STRING  *PolicyString = (POLICY_STRING *)(ValueTable + Rule->OffsetToSubKeyName);
     CONST CHAR16   *SubKeyName   = PolicyString->String;
     CONST UINT16   SubKeyLength  = PolicyString->StringLength / sizeof (CHAR16);
-    DEBUG ((DEBUG_VERBOSE, "SubKeyLength and Name are %d and '%s'\n", SubKeyLength, SubKeyName));
     if (0 != StrnCmp (SubKeyExpected, SubKeyName, SubKeyLength)) {
       continue;
     }

--- a/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
+++ b/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
@@ -7,7 +7,7 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | dc0c8c4002e568b56b511922443545f8 | 2025-02-12T04-14-49 | 81e778fe4164c0d1bd06614ba6acf28799457f4f
+#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | cd71a33f6ecb1ac9282762f821f317bb | 2025-05-27T13-30-17 | 0ef61161fce7097c6cd0b054b2d321dd5640cc92
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
+++ b/MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
@@ -6,9 +6,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
-
-#Override : 00000002 | MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf | cd71a33f6ecb1ac9282762f821f317bb | 2025-05-27T13-30-17 | 0ef61161fce7097c6cd0b054b2d321dd5640cc92
-
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = DisplayEngine

--- a/MsGraphicsPkg/GopOverrideDxe/GopOverrideDxe.c
+++ b/MsGraphicsPkg/GopOverrideDxe/GopOverrideDxe.c
@@ -79,20 +79,6 @@ GopRegisteredCallback (
   }
 
   //
-  // Uninstall Graphics Output Protocol on this handle.
-  //
-  Status = gBS->UninstallMultipleProtocolInterfaces (
-                  Handles[0],
-                  &gEfiGraphicsOutputProtocolGuid,
-                  (VOID *)pGop,
-                  NULL
-                  );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to uninstall %g protocol - code=%r\n", &gEfiGraphicsOutputProtocolGuid, Status));
-    goto Exit;
-  }
-
-  //
   // Now, install Graphics Output Override Protocol on this handle.
   //
   Status = gBS->InstallProtocolInterface (
@@ -103,6 +89,20 @@ GopRegisteredCallback (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to install %g protocol - code=%r\n", mMsGopOverrideProtocolGuid, Status));
+    goto Exit;
+  }
+
+  //
+  // Uninstall Graphics Output Protocol on this handle.
+  //
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  Handles[0],
+                  &gEfiGraphicsOutputProtocolGuid,
+                  (VOID *)pGop,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to uninstall %g protocol - code=%r\n", &gEfiGraphicsOutputProtocolGuid, Status));
     goto Exit;
   }
 

--- a/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
+++ b/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
@@ -372,12 +372,10 @@ PolynomialDivision (
 
   // MU_CHANGE [END] - CodeQL change
 
-  for (i = 0; i < DividendCount; i++) {
-    TempRemainder[i] = Dividend[i];
-  }
+  CopyMem (TempRemainder, Dividend, DividendCount);
 
   if (gFlags & QR_FLAGS_DEBUG_POLYDIVIDE) {
-    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", i));
+    DEBUG ((DEBUG_INFO, "MsgPly %3d   ", DividendCount));
     for (j = 0; j < sizeofnumbers; j++) {
       DEBUG ((DEBUG_INFO, " %3d,", TempRemainder[j]));
     }

--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
@@ -54,6 +54,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 // MU_CHANGE [BEGIN] - TPM Replay Feature
 
+#include <Library/Tpm2DebugLib.h> // MU_CHANGE - Use Tpm2DebugLib
 #include <TpmReplayConfig.h>
 
 TPM_REPLAY_CONFIG  mTpmReplayConfig;
@@ -155,26 +156,28 @@ MeasurePeImageAndExtend (
   OUT TPML_DIGEST_VALUES    *DigestList
   );
 
-/**
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
 
-  This function dump raw data.
+//   This function dump raw data.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+//   @param  Data  raw data
+//   @param  Size  raw data size
 
-**/
-VOID
-InternalDumpData (
-  IN UINT8  *Data,
-  IN UINTN  Size
-  )
-{
-  UINTN  Index;
+// **/
+// VOID
+// InternalDumpData (
+//   IN UINT8  *Data,
+//   IN UINTN  Size
+//   )
+// {
+//   UINTN  Index;
 
-  for (Index = 0; Index < Size; Index++) {
-    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
-  }
-}
+//   for (Index = 0; Index < Size; Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
+//   }
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
 
@@ -252,40 +255,42 @@ InitNoActionEvent (
   WriteUnaligned32 ((UINT32 *)DigestBuffer, EventSize);
 }
 
-/**
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
 
-  This function dump raw data with colume format.
+//   This function dump raw data with colume format.
 
-  @param  Data  raw data
-  @param  Size  raw data size
+//   @param  Data  raw data
+//   @param  Size  raw data size
 
-**/
-VOID
-InternalDumpHex (
-  IN UINT8  *Data,
-  IN UINTN  Size
-  )
-{
-  UINTN  Index;
-  UINTN  Count;
-  UINTN  Left;
+// **/
+// VOID
+// InternalDumpHex (
+//   IN UINT8  *Data,
+//   IN UINTN  Size
+//   )
+// {
+//   UINTN  Index;
+//   UINTN  Count;
+//   UINTN  Left;
 
-  #define COLUME_SIZE  (16 * 2)
+//   #define COLUME_SIZE  (16 * 2)
 
-  Count = Size / COLUME_SIZE;
-  Left  = Size % COLUME_SIZE;
-  for (Index = 0; Index < Count; Index++) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
-    DEBUG ((DEBUG_INFO, "\n"));
-  }
+//   Count = Size / COLUME_SIZE;
+//   Left  = Size % COLUME_SIZE;
+//   for (Index = 0; Index < Count; Index++) {
+//     DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+//     InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
+//     DEBUG ((DEBUG_INFO, "\n"));
+//   }
 
-  if (Left != 0) {
-    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
-    InternalDumpData (Data + Index * COLUME_SIZE, Left);
-    DEBUG ((DEBUG_INFO, "\n"));
-  }
-}
+//   if (Left != 0) {
+//     DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+//     InternalDumpData (Data + Index * COLUME_SIZE, Left);
+//     DEBUG ((DEBUG_INFO, "\n"));
+//   }
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   Get All processors EFI_CPU_LOCATION in system. LocationBuf is allocated inside the function
@@ -431,78 +436,80 @@ Tcg2GetCapability (
   return EFI_SUCCESS;
 }
 
-/**
-  This function dump PCR event.
+// MU_CHANGE BEGIN: Move to Tpm2DebugLib
+// /**
+//   This function dump PCR event.
 
-  @param[in]  EventHdr     TCG PCR event structure.
-**/
-VOID
-DumpEvent (
-  IN TCG_PCR_EVENT_HDR  *EventHdr
-  )
-{
-  UINTN  Index;
+//   @param[in]  EventHdr     TCG PCR event structure.
+// **/
+// VOID
+// DumpEvent (
+//   IN TCG_PCR_EVENT_HDR  *EventHdr
+//   )
+// {
+//   UINTN  Index;
 
-  DEBUG ((DEBUG_INFO, "  Event:\n"));
-  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
-  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
-  DEBUG ((DEBUG_INFO, "    Digest    - "));
-  for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
-    DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
-  }
+//   DEBUG ((DEBUG_INFO, "  Event:\n"));
+//   DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
+//   DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
+//   DEBUG ((DEBUG_INFO, "    Digest    - "));
+//   for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
-  InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
-}
+//   DEBUG ((DEBUG_INFO, "\n"));
+//   DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
+//   InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
+// }
 
-/**
-  This function dump TCG_EfiSpecIDEventStruct.
+// /**
+//   This function dump TCG_EfiSpecIDEventStruct.
 
-  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
-**/
-VOID
-DumpTcgEfiSpecIdEventStruct (
-  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
-  )
-{
-  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
-  UINTN                            Index;
-  UINT8                            *VendorInfoSize;
-  UINT8                            *VendorInfo;
-  UINT32                           NumberOfAlgorithms;
+//   @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+// **/
+// VOID
+// DumpTcgEfiSpecIdEventStruct (
+//   IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+//   )
+// {
+//   TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+//   UINTN                            Index;
+//   UINT8                            *VendorInfoSize;
+//   UINT8                            *VendorInfo;
+//   UINT32                           NumberOfAlgorithms;
 
-  DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
-  DEBUG ((DEBUG_INFO, "    signature          - '"));
-  for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
-    DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
-  }
+//   DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
+//   DEBUG ((DEBUG_INFO, "    signature          - '"));
+//   for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
+//     DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "'\n"));
-  DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
-  DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
-  DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
+//   DEBUG ((DEBUG_INFO, "'\n"));
+//   DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
+//   DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
+//   DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
 
-  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
-  DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
+//   CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+//   DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
 
-  DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
-  for (Index = 0; Index < NumberOfAlgorithms; Index++) {
-    DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
-    DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
-    DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
-  }
+//   DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+//   for (Index = 0; Index < NumberOfAlgorithms; Index++) {
+//     DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
+//     DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
+//     DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
+//   }
 
-  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
-  DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
-  VendorInfo = VendorInfoSize + 1;
-  DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
-  for (Index = 0; Index < *VendorInfoSize; Index++) {
-    DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
-  }
+//   VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+//   DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
+//   VendorInfo = VendorInfoSize + 1;
+//   DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
+//   for (Index = 0; Index < *VendorInfoSize; Index++) {
+//     DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-}
+//   DEBUG ((DEBUG_INFO, "\n"));
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   This function get size of TCG_EfiSpecIDEventStruct.
@@ -525,184 +532,185 @@ GetTcgEfiSpecIdEventStructSize (
   return sizeof (TCG_EfiSpecIDEventStruct) + sizeof (UINT32) + (NumberOfAlgorithms * sizeof (TCG_EfiSpecIdEventAlgorithmSize)) + sizeof (UINT8) + (*VendorInfoSize);
 }
 
-/**
-  This function dump PCR event 2.
+// MU_CHANGE [BEGIN] - Move to Tpm2DebugLib
+// /**
+//   This function dump PCR event 2.
 
-  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
-**/
-VOID
-DumpEvent2 (
-  IN TCG_PCR_EVENT2  *TcgPcrEvent2
-  )
-{
-  UINTN          Index;
-  UINT32         DigestIndex;
-  UINT32         DigestCount;
-  TPMI_ALG_HASH  HashAlgo;
-  UINT32         DigestSize;
-  UINT8          *DigestBuffer;
-  UINT32         EventSize;
-  UINT8          *EventBuffer;
+//   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+// **/
+// VOID
+// DumpEvent2 (
+//   IN TCG_PCR_EVENT2  *TcgPcrEvent2
+//   )
+// {
+//   UINTN          Index;
+//   UINT32         DigestIndex;
+//   UINT32         DigestCount;
+//   TPMI_ALG_HASH  HashAlgo;
+//   UINT32         DigestSize;
+//   UINT8          *DigestBuffer;
+//   UINT32         EventSize;
+//   UINT8          *EventBuffer;
 
-  DEBUG ((DEBUG_INFO, "  Event:\n"));
-  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
-  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
+//   DEBUG ((DEBUG_INFO, "  Event:\n"));
+//   DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
+//   DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
 
-  DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
+//   DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
 
-  DigestCount  = TcgPcrEvent2->Digest.count;
-  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
-  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
-  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
-    DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
-    for (Index = 0; Index < DigestSize; Index++) {
-      DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
-    }
+//   DigestCount  = TcgPcrEvent2->Digest.count;
+//   HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+//   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+//   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+//     DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
+//     DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
+//     DigestSize = GetHashSizeFromAlgo (HashAlgo);
+//     for (Index = 0; Index < DigestSize; Index++) {
+//       DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
+//     }
 
-    DEBUG ((DEBUG_INFO, "\n"));
-    //
-    // Prepare next
-    //
-    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
-    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
-  }
+//     DEBUG ((DEBUG_INFO, "\n"));
+//     //
+//     // Prepare next
+//     //
+//     CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+//     DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+//   }
 
-  DEBUG ((DEBUG_INFO, "\n"));
-  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+//   DEBUG ((DEBUG_INFO, "\n"));
+//   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
-  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
-  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
-  InternalDumpHex (EventBuffer, EventSize);
-}
+//   CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+//   DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
+//   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+//   InternalDumpHex (EventBuffer, EventSize);
+// }
 
-/**
-  This function returns size of TCG PCR event 2.
+// /**
+//   This function returns size of TCG PCR event 2.
 
-  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+//   @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
 
-  @return size of TCG PCR event 2.
-**/
-UINTN
-GetPcrEvent2Size (
-  IN TCG_PCR_EVENT2  *TcgPcrEvent2
-  )
-{
-  UINT32         DigestIndex;
-  UINT32         DigestCount;
-  TPMI_ALG_HASH  HashAlgo;
-  UINT32         DigestSize;
-  UINT8          *DigestBuffer;
-  UINT32         EventSize;
-  UINT8          *EventBuffer;
+//   @return size of TCG PCR event 2.
+// **/
+// UINTN
+// GetPcrEvent2Size (
+//   IN TCG_PCR_EVENT2  *TcgPcrEvent2
+//   )
+// {
+//   UINT32         DigestIndex;
+//   UINT32         DigestCount;
+//   TPMI_ALG_HASH  HashAlgo;
+//   UINT32         DigestSize;
+//   UINT8          *DigestBuffer;
+//   UINT32         EventSize;
+//   UINT8          *EventBuffer;
 
-  DigestCount  = TcgPcrEvent2->Digest.count;
-  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
-  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
-  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
-    DigestSize = GetHashSizeFromAlgo (HashAlgo);
-    //
-    // Prepare next
-    //
-    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
-    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
-  }
+//   DigestCount  = TcgPcrEvent2->Digest.count;
+//   HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+//   DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+//   for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+//     DigestSize = GetHashSizeFromAlgo (HashAlgo);
+//     //
+//     // Prepare next
+//     //
+//     CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+//     DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+//   }
 
-  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+//   DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
 
-  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
-  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+//   CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+//   EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
 
-  return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
-}
+//   return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
+// }
 
-/**
-  This function dump event log.
+// /**
+//   This function dump event log.
 
-  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
-  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
-  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
-                                 address of the start of the last entry in the event log in memory.
-  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
-**/
-VOID
-DumpEventLog (
-  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
-  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
-  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
-  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
-  )
-{
-  TCG_PCR_EVENT_HDR         *EventHdr;
-  TCG_PCR_EVENT2            *TcgPcrEvent2;
-  TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINT64                    NumberOfEvents; // MU_CHANGE: CodeQL
+//   @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+//   @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+//   @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+//                                  address of the start of the last entry in the event log in memory.
+//   @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+// **/
+// VOID
+// DumpEventLog (
+//   IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+//   IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+//   IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+//   IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+//   )
+// {
+//   TCG_PCR_EVENT_HDR         *EventHdr;
+//   TCG_PCR_EVENT2            *TcgPcrEvent2;
+//   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
+//   UINT64                    NumberOfEvents; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
 
-  DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
+//   DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
 
-  switch (EventLogFormat) {
-    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
-      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      // MU_CHANGE: CodeQL
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
-        DumpEvent (EventHdr);
-        EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
-      }
+//   switch (EventLogFormat) {
+//     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+//       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+//       while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
+//         // MU_CHANGE - CodeQL Change
+//         DumpEvent (EventHdr);
+//         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+//       }
 
-      if (FinalEventsTable == NULL) {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
-      } else {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+//       if (FinalEventsTable == NULL) {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+//       } else {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+//         DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+//         DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
-        EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
-        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
-          DumpEvent (EventHdr);
-          EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
-        }
-      }
+//         EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
+//         for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+//           DumpEvent (EventHdr);
+//           EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+//         }
+//       }
 
-      break;
-    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
-      //
-      // Dump first event
-      //
-      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      DumpEvent (EventHdr);
+//       break;
+//     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+//       //
+//       // Dump first event
+//       //
+//       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+//       DumpEvent (EventHdr);
 
-      TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
-      DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
+//       TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
+//       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
-      TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      // MU_CHANGE: CodeQL
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
-        DumpEvent2 (TcgPcrEvent2);
-        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
-      }
+//       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
+//       while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+//         // MU_CHANGE -  CodeQL
+//         DumpEvent2 (TcgPcrEvent2);
+//         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+//       }
 
-      if (FinalEventsTable == NULL) {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
-      } else {
-        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
-        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
-        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+//       if (FinalEventsTable == NULL) {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+//       } else {
+//         DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+//         DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+//         DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
 
-        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
-        // MU_CHANGE: CodeQL
-        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
-          DumpEvent2 (TcgPcrEvent2);
-          TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
-        }
-      }
+//         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
+//         for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+//           DumpEvent2 (TcgPcrEvent2);
+//           TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+//         }
+//       }
 
-      break;
-  }
+//       break;
+//   }
 
-  return;
-}
+//   return;
+// }
+// MU_CHANGE END: Move to Tpm2DebugLib
 
 /**
   The EFI_TCG2_PROTOCOL Get Event Log function call allows a caller to

--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
@@ -72,6 +72,7 @@
   OemTpm2InitLib
 ## MSChange [END]
   PcdLib  # MU_CHANGE
+  Tpm2DebugLib
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"

--- a/UefiTestingPkg/AuditTests/PagingAudit/README.md
+++ b/UefiTestingPkg/AuditTests/PagingAudit/README.md
@@ -55,9 +55,7 @@ results will be saved to an XML file in the same file system as the app (or the 
 available writable simple file system):
 
 - **NoReadWriteExecute:** Checks if the page/translation table has any readable, writable,
-and executable regions.  
-- **UnallocatedMemoryIsRP:** Checks that all EfiConventionalMemory is EFI_MEMORY_RP or
-is not mapped.  
+and executable regions.
 - **IsMemoryAttributeProtocolPresent:** Checks if the EFI Memory Attribute Protocol
 is installed.  
 - **NullPageIsRp:** Checks if page 0 is EFI_MEMORY_RP or is not mapped.  

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/Dxe/App/DxePagingAuditTestApp.c
@@ -893,61 +893,6 @@ NoReadWriteExecute (
 }
 
 /**
-  Checks that EfiConventionalMemory is EFI_MEMORY_RP or
-  is not mapped.
-
-  @param[in] Context            Unit test context
-
-  @retval UNIT_TEST_PASSED      The unit test passed
-  @retval other                 The unit test failed
-**/
-UNIT_TEST_STATUS
-EFIAPI
-UnallocatedMemoryIsRP (
-  IN UNIT_TEST_CONTEXT  Context
-  )
-{
-  BOOLEAN                TestFailure;
-  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEntry;
-  EFI_MEMORY_DESCRIPTOR  *EfiMemoryMapEnd;
-
-  DEBUG ((DEBUG_INFO, "%a Enter...\n", __FUNCTION__));
-
-  UT_ASSERT_NOT_EFI_ERROR (ValidatePageTableMapSize ());
-  UT_ASSERT_NOT_EFI_ERROR (ValidateEfiMemoryMapSize ());
-  UT_ASSERT_NOT_EFI_ERROR (PopulateEfiMemoryMap ());
-  UT_ASSERT_NOT_EFI_ERROR (PopulatePageTableMap ());
-
-  TestFailure = FALSE;
-
-  EfiMemoryMapEntry = mEfiMemoryMap;
-  EfiMemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)mEfiMemoryMap + mEfiMemoryMapSize);
-
-  while (EfiMemoryMapEntry < EfiMemoryMapEnd) {
-    if (EfiMemoryMapEntry->Type == EfiConventionalMemory) {
-      if (!ValidateRegionAttributes (
-             &mMap,
-             EfiMemoryMapEntry->PhysicalStart,
-             (EfiMemoryMapEntry->NumberOfPages * EFI_PAGE_SIZE),
-             EFI_MEMORY_RP,
-             TRUE,
-             TRUE,
-             TRUE
-             ))
-      {
-        TestFailure = TRUE;
-      }
-    }
-
-    EfiMemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (EfiMemoryMapEntry, mEfiMemoryMapDescriptorSize);
-  }
-
-  UT_ASSERT_FALSE (TestFailure);
-
-  return UNIT_TEST_PASSED;
-}
-
-/**
   Checks if the EFI Memory Attribute Protocol is Present.
 
   @param[in] Context            Unit test context
@@ -1435,7 +1380,6 @@ DxePagingAuditTestAppEntryPoint (
     }
 
     AddTestCase (Misc, "No pages are  readable, writable, and executable", "Security.Misc.NoReadWriteExecute", NoReadWriteExecute, NULL, GeneralTestCleanup, NULL);
-    AddTestCase (Misc, "Unallocated memory is EFI_MEMORY_RP", "Security.Misc.UnallocatedMemoryIsRP", UnallocatedMemoryIsRP, NULL, GeneralTestCleanup, NULL);
     AddTestCase (Misc, "Memory Attribute Protocol is present", "Security.Misc.IsMemoryAttributeProtocolPresent", IsMemoryAttributeProtocolPresent, NULL, NULL, NULL);
     AddTestCase (Misc, "NULL page is EFI_MEMORY_RP", "Security.Misc.NullPageIsRp", NullPageIsRp, NULL, GeneralTestCleanup, NULL);
     AddTestCase (Misc, "MMIO Regions are EFI_MEMORY_XP", "Security.Misc.MmioIsXp", MmioIsXp, NULL, GeneralTestCleanup, NULL);

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -32,7 +32,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/DebugImageInfoTable.h>
 #include <Guid/MemoryAttributesTable.h>
 
-#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x1000
+#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x10000
 #define    MEM_INFO_DATABASE_MAX_STRING_SIZE  0x400
 #define    MAX_STRING_SIZE                    0x1000
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.h
@@ -32,7 +32,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/DebugImageInfoTable.h>
 #include <Guid/MemoryAttributesTable.h>
 
-#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x10000
+#define    MEM_INFO_DATABASE_REALLOC_CHUNK    0x10000000
 #define    MEM_INFO_DATABASE_MAX_STRING_SIZE  0x400
 #define    MAX_STRING_SIZE                    0x1000
 

--- a/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAudit.c
+++ b/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAudit.c
@@ -155,7 +155,7 @@ GetPcrEvent2Size (
   @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
 **/
 EFI_STATUS
-DumpEventLog (
+TpmAuditDumpEventLog  (
   IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
   IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
   IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
@@ -332,7 +332,7 @@ UefiTestApp (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "Failed to retrieve the event log.  %r\n", Status));
     } else {
-      Status = DumpEventLog (RequestedFormat, EventLogLocation, EventLogLastEntry, NULL);
+      Status = TpmAuditDumpEventLog (RequestedFormat, EventLogLocation, EventLogLastEntry, NULL);
     }
   }
 

--- a/UefiTestingPkg/UefiTestingPkg.dsc
+++ b/UefiTestingPkg/UefiTestingPkg.dsc
@@ -75,7 +75,7 @@
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerPhyCounterLib/ArmGenericTimerPhyCounterLib.inf
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmSmcLib|ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
+  ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
   CpuExceptionHandlerLib|ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.inf
   DefaultExceptionHandlerLib|ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLib.inf
   MuArmGicExLib|MsCorePkg/Library/MuArmGicExLib/MuArmGicExLib.inf

--- a/UefiTestingPkg/UefiTestingPkg.dsc
+++ b/UefiTestingPkg/UefiTestingPkg.dsc
@@ -70,6 +70,8 @@
   DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLibNull/DxeMemoryProtectionHobLibNull.inf
   FlatPageTableLib|UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.inf
 
+  Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
+
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   ArmGenericTimerCounterLib|ArmPkg/Library/ArmGenericTimerPhyCounterLib/ArmGenericTimerPhyCounterLib.inf
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf

--- a/XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.c
+++ b/XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.c
@@ -222,8 +222,6 @@ OutputUnitTestFrameworkReport (
     }
 
     SuiteNode = New_TestSuiteNodeInList (Doc, SuiteName, SuitePackage, Id);
-    FreePool (SuiteName);
-    FreePool (SuitePackage);
     if (SuiteNode == NULL) {
       DEBUG ((DEBUG_ERROR, "%a Failed to create new test suite\n", __FUNCTION__));
       Status = EFI_DEVICE_ERROR;
@@ -262,18 +260,6 @@ OutputUnitTestFrameworkReport (
 
       // TODO:  need to handle timing.  Right now its hard coded to 1 second.
       New_TestCaseInSuite (SuiteNode, Name, ClassName, 1, Log, FailureMsg, GetStringForFailureType (Test->UT.FailureType), Skipped);
-
-      if (Name != NULL) {
-        FreePool (Name);
-      }
-
-      if (Log != NULL) {
-        FreePool (Log);
-      }
-
-      if (ClassName != NULL) {
-        FreePool (ClassName);
-      }
     } // End Test iteration
 
     Status = AddTestSuiteStats (SuiteNode, TotalTests, TotalFailures, TotalSkips, TotalErrors);

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -16,4 +16,4 @@ edk2-pytool-library==0.23.2
 edk2-pytool-extensions==0.29.2
 antlr4-python3-runtime==4.13.2
 regex==2024.11.6
-pygount==2.0.0
+pygount==3.1.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 
 [tools]
 cargo-make = "0.37.24"


### PR DESCRIPTION
## Description
When a handle only has a GOP protocol installed on it, uninstalling
the GOP protocol interface from it will cause the handle to be freed.
The subsequent InstallProtocol for the GopOverride protocol will fail.

## How This Was Tested
Boot on development platform.

