### PR TITLE
GopOverrideDxe: prevent single-protocol handle from being freed

### DIFF
--- a/MsGraphicsPkg/GopOverrideDxe/GopOverrideDxe.c
+++ b/MsGraphicsPkg/GopOverrideDxe/GopOverrideDxe.c
@@ -79,20 +79,6 @@ GopRegisteredCallback (
   }
 
   //
-  // Uninstall Graphics Output Protocol on this handle.
-  //
-  Status = gBS->UninstallMultipleProtocolInterfaces (
-                  Handles[0],
-                  &gEfiGraphicsOutputProtocolGuid,
-                  (VOID *)pGop,
-                  NULL
-                  );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to uninstall %g protocol - code=%r\n", &gEfiGraphicsOutputProtocolGuid, Status));
-    goto Exit;
-  }
-
-  //
   // Now, install Graphics Output Override Protocol on this handle.
   //
   Status = gBS->InstallProtocolInterface (
@@ -103,6 +89,20 @@ GopRegisteredCallback (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to install %g protocol - code=%r\n", mMsGopOverrideProtocolGuid, Status));
+    goto Exit;
+  }
+
+  //
+  // Uninstall Graphics Output Protocol on this handle.
+  //
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  Handles[0],
+                  &gEfiGraphicsOutputProtocolGuid,
+                  (VOID *)pGop,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ERROR [GOP]: Unable to uninstall %g protocol - code=%r\n", &gEfiGraphicsOutputProtocolGuid, Status));
     goto Exit;
   }
 


### PR DESCRIPTION
## Description
When a handle only has a GOP protocol installed on it, uninstalling the GOP protocol interface from it will cause the handle to be freed. The subsequent InstallProtocol for the GopOverride protocol will fail.

Link: https://github.com/cmruffin/mu_basecore/blob/d6e01136697c1aed85bb83cff98b74ec11e96e1a/MdeModulePkg/Core/Dxe/Hand/Handle.c#L774

Authored-by: kdincer@microsoft.com
Signed-off-by: v-chrruffin@microsoft.com

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

Fixes #724 

## How This Was Tested
Boot tested on hardware.

## Integration Instructions
na