### PR TITLE
[Dev/202502] Adding missing depex gEfiSmmVariableProtocolGuid

### DIFF
--- a/MsWheaPkg/MsWheaReport/Smm/MsWheaReportSmm.inf
+++ b/MsWheaPkg/MsWheaReport/Smm/MsWheaReportSmm.inf
@@ -73,4 +73,5 @@
 
 [Depex]
   gEfiMmRscHandlerProtocolGuid AND
-  gEfiVariableWriteArchProtocolGuid
+  gEfiVariableWriteArchProtocolGuid AND
+  gEfiSmmVariableProtocolGuid

--- a/MsWheaPkg/MsWheaReport/Smm/MsWheaReportStandaloneMm.inf
+++ b/MsWheaPkg/MsWheaReport/Smm/MsWheaReportStandaloneMm.inf
@@ -73,4 +73,5 @@
 
 [Depex]
   gEfiMmRscHandlerProtocolGuid AND
-  gEfiSmmFaultTolerantWriteProtocolGuid
+  gEfiSmmFaultTolerantWriteProtocolGuid AND
+  gEfiSmmVariableProtocolGuid


### PR DESCRIPTION
## Description

MsWheaReportStandaloneMM and MsWheaReportSmm are missing a required Depex.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

On my QemuQ35 platform I've changed the order of crypto and in doing so uncovered this. This change allows the system to continue on.
 
## Integration Instructions

N/A