### PR TITLE
OnScreenKeyboardDriver: Add null check for SCT Compiliance

### DIFF
--- a/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDriver.c
+++ b/MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDriver.c
@@ -2872,6 +2872,10 @@ OSKReadKeyStrokeEx (
   OUT EFI_KEY_DATA                       *pKey
   )
 {
+  if (pKey == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   ZeroMem (pKey, sizeof (EFI_KEY_DATA));
 
   pKey->KeyState.KeyShiftState  = EFI_SHIFT_STATE_VALID;


### PR DESCRIPTION
## Description

OnScreenKeyboardDriver's OSKReadKeyStrokeEx does not validate pKey is not NULL, resulting in a DEBUG_ASSERT in ZeroMem if pKey is infact NULL. SCTs expected an EFI_INVALID_PARAMETER, not an assert, in this scenario.

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

SCTs no longer assert

## Integration Instructions

N/A
