### PR TITLE
[TPM] Tpm2HelpLib Updates (#735)

### DIFF
--- a/MfciPkg/MfciPkg.dsc
+++ b/MfciPkg/MfciPkg.dsc
@@ -53,6 +53,7 @@
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
   Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   SecureBootVariableLib|SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.inf
   PlatformPKProtectionLib|SecurityPkg/Library/PlatformPKProtectionLibVarPolicy/PlatformPKProtectionLibVarPolicy.inf
   MfciRetrievePolicyLib|MfciPkg/Library/MfciRetrievePolicyLibNull/MfciRetrievePolicyLibNull.inf

--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.c
@@ -38,6 +38,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PrintLib.h>
 #include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h> // MU_CHANGE
 #include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
 #include <Library/Tpm2DeviceLib.h>

--- a/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
+++ b/TpmTestingPkg/Overrides/Tcg2Dxe/Tcg2Dxe.inf
@@ -73,6 +73,7 @@
 ## MSChange [END]
   PcdLib  # MU_CHANGE
   Tpm2DebugLib
+  Tpm2HelpLib # MU_CHANGE
 
 [Guids]
   ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"

--- a/TpmTestingPkg/TpmReplayPei/Pei/TpmReplayPei.inf
+++ b/TpmTestingPkg/TpmReplayPei/Pei/TpmReplayPei.inf
@@ -58,6 +58,7 @@
   PeiServicesLib
   ReportStatusCodeLib
   Tpm2CommandLib
+  Tpm2HelpLib
 
 [Guids]
   gTcgEvent2EntryHobGuid                                        ## PRODUCES ## HOB

--- a/TpmTestingPkg/TpmReplayPei/Pei/TpmReplayPeiTpmInitialized.c
+++ b/TpmTestingPkg/TpmReplayPei/Pei/TpmReplayPeiTpmInitialized.c
@@ -28,6 +28,7 @@
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/Tpm2CommandLib.h>
 #include <Library/Tpm2DeviceLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Ppi/TpmInitialized.h>
 #include <Protocol/Tcg2Protocol.h>              // For macro definitions in the header file
 

--- a/TpmTestingPkg/TpmReplayPei/TpmReplayTcg.c
+++ b/TpmTestingPkg/TpmReplayPei/TpmReplayTcg.c
@@ -18,7 +18,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 
 /**
   Unpacks TPM digest values.

--- a/TpmTestingPkg/TpmTestingPkg.dsc
+++ b/TpmTestingPkg/TpmTestingPkg.dsc
@@ -37,6 +37,7 @@
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf

--- a/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAudit.c
+++ b/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAudit.c
@@ -13,7 +13,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiApplicationEntryPoint.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <Protocol/Tcg2Protocol.h>
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include "TpmEventLogXml.h"

--- a/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf
@@ -29,7 +29,7 @@
   ShellLib
   UefiBootServicesTableLib
   BaseMemoryLib
-  Tpm2CommandLib
+  Tpm2HelpLib
   XmlTreeLib
   XmlTreeQueryLib
 

--- a/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogXml.h
+++ b/UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogXml.h
@@ -20,7 +20,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/XmlTreeLib.h>
 #include <Library/XmlTreeQueryLib.h>
 #include <Library/ShellLib.h>
-#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2HelpLib.h>
 #include <IndustryStandard/UefiTcgPlatform.h>
 
 /**

--- a/UefiTestingPkg/UefiTestingPkg.dsc
+++ b/UefiTestingPkg/UefiTestingPkg.dsc
@@ -55,6 +55,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf
 
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   XmlTreeLib|XmlSupportPkg/Library/XmlTreeLib/XmlTreeLib.inf
   XmlTreeQueryLib|XmlSupportPkg/Library/XmlTreeQueryLib/XmlTreeQueryLib.inf


### PR DESCRIPTION
## Description

Changes related to the new Tpm2HelpLib which replaces the need for Tpm2CommandLib which houses Tpm2Help.c.
Reliant on https://github.com/microsoft/mu_tiano_plus/pull/437

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Verified by building and running on physical platform.

## Integration Instructions

Need to update platform .dsc to include the new Tpm2HelpLib.
