### PR TITLE
Fixed DecodeUefiLlog.py encoding in log output and improve readability

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -716,7 +716,7 @@ class AdvLogParser ():
             # Add an extra space for readability
             PhaseString = self.PHASE_STRING_LIST[Phase] + ' '
         return PhaseString
-    
+
     #
     #   Get the formatted debug level string
     #
@@ -1057,7 +1057,7 @@ def main():
 
         if options.OutFilePath is not None:
             if options.FileSize == 0:
-                OutFile = open(options.OutFilePath, "w", newline=None)
+                OutFile = open(options.OutFilePath, "w", newline=None, encoding='utf-8')
                 OutFile.writelines(lines)
                 OutFile.close()
                 CountOfLines = len(lines)
@@ -1073,7 +1073,7 @@ def main():
                         SeparateFileIndex = 1
                         CountOfLines = 0
                         SeparatedFilePath = FilePathPart[0] + '_' + str(SeparateFileIndex) + FilePathPart[1]
-                        OutFile = open(SeparatedFilePath, "w", newline=None)
+                        OutFile = open(SeparatedFilePath, "w", newline=None, encoding='utf-8')
 
                     CurrentLineSize = len(LineStr.encode('utf-8')) + 1
                     if CurrentFileSize + CurrentLineSize > MaxSize:


### PR DESCRIPTION
## Description

Found an exception issue on our project, the bios could print something in unicode and cause the tool exception here is the error log

```
- Tool reads 841 variables worth of log successfully
- Fails during log output processing with UnicodeEncodeError
- Error: 'charmap' codec can't encode character '\ufffd' in position 67: character maps to <undefined>
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested based on the bios would print unicode and check the log is saved successfully:

```
PS C:\DecodeUefiLog> python .\DecodeUefiLog.py -o 567.log
Reading the Advanced Logger log
Found 841 variables worth of log
24396 lines written to 567.log
Log complete
```

## Integration Instructions

N/A