### PR TITLE
Remove unused Rust dependencies

### DIFF
--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -22,7 +22,6 @@ hidparser = {workspace=true}
 HiiKeyboardLayout = {workspace=true}
 mu_rust_helpers = {workspace=true}
 r-efi = {workspace=true}
-rustversion = {workspace=true}
 RustAdvancedLoggerDxe = {workspace=true}
 scroll = {workspace=true}
 

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
@@ -19,3 +19,6 @@ mu_uefi_boot_services = { workspace = true, features = ["mockall"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+
+[package.metadata.cargo-machete]
+ignored = ["mockall"]


### PR DESCRIPTION
## Description

Removes dependencies that are not needed:

- `UefiHidDxeV2`: Drop `rustversion`

For users running `cargo machete`, add `mockall` to the machete ignore list in `MuTelemetryHelperLib`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- `cargo make all`
- CI

## Integration Instructions

- N/A