### PR TITLE
QrEncoderLib: Prevent memcpy intrinisc in PolynomialDivision()

### DIFF
--- a/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
+++ b/MsGraphicsPkg/Library/QrEncoderLib/QrEncoderLib.c
@@ -411,9 +411,10 @@ PolynomialDivision (
     DEBUG ((DEBUG_INFO, "Result - "));
   }
 
-  for (j = 0; j < RemainderCount; j++) {
-    Remainder[j] = TempRemainder[j+DividendCount];     // Copy remainder
-    if (gFlags & QR_FLAGS_DEBUG_POLYDIVIDE) {
+  CopyMem (Remainder, &TempRemainder[DividendCount], RemainderCount * sizeof (TempRemainder[0]));
+
+  if (gFlags & QR_FLAGS_DEBUG_POLYDIVIDE) {
+    for (j = 0; j < RemainderCount; j++) {
       DEBUG ((DEBUG_INFO, " %3d,", Remainder[j]));
     }
   }


### PR DESCRIPTION
## Description

Use `CopyMem()` to prevent `memcpy` on recent MSVC versions.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- `QrEncoderLib` platform integration with MSVC 14.44.35207

## Integration Instructions

- N/A