### PR TITLE
Mask non-affinity bits for mCpuInfo MPIDR values

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -44,7 +44,9 @@ ASM_PFX(AsmApEntryPoint):
 // TODO: This is, again, reverse engineering to correlate the CPU index with the MPIDRs...
 1:
   ldr x3, [x1]                // x3 = *x1
-  bic x3, x3, 0x00ff000000    // Mask the non-affinity bits
+  // Mask the non-affinity bits
+  bic x3, x3, 0x00ff000000
+  and x3, x3, 0xffffffffff
   cmp x0, x3                  // if mpidr_el1 == mCpuInfo[x].Mpidr then break loop
   beq JumpToCFunction
   add x1, x1, #40             // x1 = x1 + sizeof (ARM_CORE_INFO)

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -44,6 +44,7 @@ ASM_PFX(AsmApEntryPoint):
 // TODO: This is, again, reverse engineering to correlate the CPU index with the MPIDRs...
 1:
   ldr x3, [x1]                // x3 = *x1
+  bic x3, x3, 0x00ff000000    // Mask the non-affinity bits
   cmp x0, x3                  // if mpidr_el1 == mCpuInfo[x].Mpidr then break loop
   beq JumpToCFunction
   add x1, x1, #40             // x1 = x1 + sizeof (ARM_CORE_INFO)


### PR DESCRIPTION
## Description

Current core's MPIDR value has masked non-affinity bits before comparing with MPIDR values populated in mCpuInfo. This change is to apply the same mask for MPIDR values within mCpuInfo before the compare

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested in custom Microsoft hardware

## Integration Instructions

N/A