### PR TITLE
MfciPkg: Address PCD pointers that are not aligned.

### DIFF
--- a/MfciPkg/MfciDxe/MfciDxe.c
+++ b/MfciPkg/MfciDxe/MfciDxe.c
@@ -667,8 +667,7 @@ ValidateBlobWithXdrCertificates (
       break;
     }
 
-    PublicKeyDataCurrent = PublicKeyData + PublicKeyDataLength;
-    PublicKeyDataCurrent = (UINT8 *)ALIGN_POINTER (PublicKeyDataCurrent, sizeof (UINT32));
+    PublicKeyDataCurrent += ALIGN_VALUE (PublicKeyDataLength, 4);
   }
 
   // above is inspired/borrowed from FmpDxe.c


### PR DESCRIPTION

## Description
XDR certificates are 4 byte aligned, but getting the PCD value does not guarantee an aligned pointer. Existing logic would align pointer, which was an issue for if the pointer was unaigned to begin with.

Use align to goto the next public key, to account for unaligned pointer being returned from pcd.

Brining this fix from https://github.com/tianocore/edk2/pull/11529 into MFCI.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Untested. This change is being brought from the FmpDxe, which encountered
this problem with an unaligned PCD pointer.


## Integration Instructions
N/A