### PR TITLE
[CHERRY-PICK] Add SEC support to BaseArm instance of AdvancedLoggerLib.inf

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -1,5 +1,5 @@
 ## @file
-#  MM_STANDALONE instance of the Advanced Logger library.
+#  MM_STANDALONE and SEC instance of the Advanced Logger library.
 #
 #  Copyright (c) Microsoft Corporation.
 #
@@ -14,7 +14,7 @@
   FILE_GUID                      = 916f2e2d-1f55-4ca4-b229-18487e94c747
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = AdvancedLoggerLib | MM_STANDALONE
+  LIBRARY_CLASS                  = AdvancedLoggerLib | MM_STANDALONE SEC
   PI_SPECIFICATION_VERSION       = 0x00010032
 
 #


### PR DESCRIPTION
## Description

When dereferencing `PcdAdvancedLoggerBase`, the current SEC-specific library uses `ADVANCED_LOGGER_PTR`, whereas the BaseArm implementation uses `ADVANCED_LOGGER_INFO`.

On ARM64 platforms, this discrepancy causes issues during the SEC phase when the BaseArm instance is limited to MM standalone usage. Specifically, the SEC instance corrupts the STMM phase buffer signature, rendering STMM logging inoperative.

This update extends the BaseArm logging library to support the SEC phase as well, enabling reuse of the buffer initialized by STMM and preserving logging functionality across phases.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This change is test on proprietary hardware.