### PR TITLE
HidPkg/UefiHidDxeV2: Prevent TPL escalation when sending output reports

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -437,11 +437,10 @@ impl KeyboardHidHandler {
     /// Called to send LED state to the device.
     pub fn send_led_reports(&mut self, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
         let output_reports = self.generate_led_output_reports();
-        if let Err(result) = self.send_output_reports(hid_io, output_reports) {
-            debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", result);
-            return Err(result);
-        }
-        Ok(())
+        self.send_output_reports(hid_io, output_reports).map_err(|err| {
+            debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", err);
+            err
+        })
     }
 
     /// Returns a clone of the keystroke at the front of the keystroke queue.

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -393,15 +393,32 @@ impl KeyboardHidHandler {
         Ok(())
     }
 
+    /// Called to send HID reports to the device.
+    fn send_output_reports(
+        &mut self,
+        hid_io: &dyn HidIo,
+        output_reports: Vec<(Option<ReportId>, Vec<u8>)>,
+    ) -> Result<(), efi::Status> {
+        for (id, output_report) in output_reports {
+            let result = hid_io.set_output_report(id.map(|x| u32::from(x) as u8), &output_report);
+            if let Err(result) = result {
+                debugln!(
+                    DEBUG_ERROR,
+                    "KeyboardHidHandler:set_output_report: unexpected error sending output report: {:?}",
+                    result
+                );
+                return Err(result);
+            }
+        }
+        Ok(())
+    }
+
     /// Resets the keyboard driver state. Clears any pending key state. `extended verification` will also reset toggle
     /// state.
-    pub fn reset(&mut self, hid_io: &dyn HidIo, extended_verification: bool) -> Result<(), efi::Status> {
+    pub fn reset(&mut self, _hid_io: &dyn HidIo, extended_verification: bool) -> Result<(), efi::Status> {
         self.last_keys.clear();
         self.current_keys.clear();
         self.key_queue.reset(extended_verification);
-        if extended_verification {
-            self.send_led_reports(hid_io)?;
-        }
         Ok(())
     }
 
@@ -416,12 +433,10 @@ impl KeyboardHidHandler {
 
     /// Called to send LED state to the device.
     pub fn send_led_reports(&mut self, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
-        for (id, output_report) in self.generate_led_output_reports() {
-            let result = hid_io.set_output_report(id.map(|x| u32::from(x) as u8), &output_report);
-            if let Err(result) = result {
-                debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", result);
-                return Err(result);
-            }
+        let output_reports = self.generate_led_output_reports();
+        if let Err(result) = self.send_output_reports(hid_io, output_reports) {
+            debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", result);
+            return Err(result);
         }
         Ok(())
     }
@@ -626,11 +641,8 @@ impl HidReportReceiver for KeyboardHidHandler {
         self.boot_services.restore_tpl(old_tpl);
 
         // if any output reports, send them after releasing handler.
-        for (id, output_report) in output_reports {
-            let result = hid_io.set_output_report(id.map(|x| u32::from(x) as u8), &output_report);
-            if let Err(result) = result {
-                debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", result);
-            }
+        if let Err(result) = self.send_output_reports(hid_io, output_reports) {
+            debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", result);
         }
     }
 }

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -437,9 +437,8 @@ impl KeyboardHidHandler {
     /// Called to send LED state to the device.
     pub fn send_led_reports(&mut self, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
         let output_reports = self.generate_led_output_reports();
-        self.send_output_reports(hid_io, output_reports).map_err(|err| {
+        self.send_output_reports(hid_io, output_reports).inspect_err(|&err| {
             debugln!(DEBUG_ERROR, "unexpected error sending output report: {:?}", err);
-            err
         })
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -419,6 +419,9 @@ impl KeyboardHidHandler {
         self.last_keys.clear();
         self.current_keys.clear();
         self.key_queue.reset(extended_verification);
+        if extended_verification {
+            self.led_state.clear();
+        }
         Ok(())
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -415,7 +415,7 @@ impl KeyboardHidHandler {
 
     /// Resets the keyboard driver state. Clears any pending key state. `extended verification` will also reset toggle
     /// state.
-    pub fn reset(&mut self, _hid_io: &dyn HidIo, extended_verification: bool) -> Result<(), efi::Status> {
+    pub fn reset(&mut self, extended_verification: bool) -> Result<(), efi::Status> {
         self.last_keys.clear();
         self.current_keys.clear();
         self.key_queue.reset(extended_verification);
@@ -548,7 +548,7 @@ impl HidReportReceiver for KeyboardHidHandler {
     fn initialize(&mut self, controller: efi::Handle, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
         let descriptor = hid_io.get_report_descriptor()?;
         self.process_descriptor(descriptor)?;
-        self.reset(hid_io, true)?;
+        self.reset(true)?;
         self.install_protocol_interfaces(controller)?;
         self.initialize_keyboard_layout()?;
         Ok(())
@@ -1159,9 +1159,7 @@ mod test {
         let prev_led_state = keyboard_handler.led_state.clone();
         assert!(!keyboard_handler.last_keys.is_empty());
 
-        let hid_io = MockHidIo::new();
-
-        keyboard_handler.reset(&hid_io, false).unwrap();
+        keyboard_handler.reset(false).unwrap();
         assert!(keyboard_handler.key_queue.peek_key().is_none());
         assert!(keyboard_handler.last_keys.is_empty());
         assert_eq!(keyboard_handler.led_state, prev_led_state);
@@ -1172,7 +1170,7 @@ mod test {
             Ok(())
         });
 
-        keyboard_handler.reset(&hid_io, true).unwrap();
+        keyboard_handler.reset(true).unwrap();
         assert!(keyboard_handler.led_state.is_empty());
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -393,7 +393,7 @@ impl KeyboardHidHandler {
         Ok(())
     }
 
-    /// Called to send HID reports to the device.
+    // Called to send HID reports to the device.
     fn send_output_reports(
         &mut self,
         hid_io: &dyn HidIo,

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -193,6 +193,7 @@ impl SimpleTextInFfi {
             }
         }
         context.boot_services.restore_tpl(old_tpl);
+        // Avoid sending output reports at the higher TPL
         if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
             status = keyboard_handler
                 .send_output_reports(hid_io.as_ref(), output_reports)

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -177,7 +177,7 @@ impl SimpleTextInFfi {
                     let hid_io = UefiHidIoFactory::new(context.boot_services, keyboard_handler.agent())
                         .new_hid_io(controller, false);
                     if let Ok(hid_io) = hid_io {
-                        if let Err(err) = keyboard_handler.reset(hid_io.as_ref(), extended_verification.into()) {
+                        if let Err(err) = keyboard_handler.reset(extended_verification.into()) {
                             status = err;
                         } else {
                             if extended_verification.into() {

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in.rs
@@ -8,7 +8,7 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::{ffi::c_void, ptr};
 
 use r_efi::{efi, protocols};
@@ -165,6 +165,9 @@ impl SimpleTextInFfi {
         }
         let context = unsafe { (this as *mut SimpleTextInFfi).as_mut() }.expect("bad pointer");
         let old_tpl = context.boot_services.raise_tpl(efi::TPL_NOTIFY);
+        let mut output_reports = Vec::new();
+        let mut keyboard_handler_ref = None;
+        let mut hid_io_ref = None;
         let mut status = efi::Status::DEVICE_ERROR;
         '_reset_processing: {
             let keyboard_handler = unsafe { context.keyboard_handler.as_mut() };
@@ -177,6 +180,12 @@ impl SimpleTextInFfi {
                         if let Err(err) = keyboard_handler.reset(hid_io.as_ref(), extended_verification.into()) {
                             status = err;
                         } else {
+                            if extended_verification.into() {
+                                // update keyboard leds
+                                output_reports = keyboard_handler.generate_led_output_reports();
+                                keyboard_handler_ref = Some(keyboard_handler);
+                                hid_io_ref = Some(hid_io);
+                            }
                             status = efi::Status::SUCCESS;
                         }
                     }
@@ -184,6 +193,12 @@ impl SimpleTextInFfi {
             }
         }
         context.boot_services.restore_tpl(old_tpl);
+        if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
+            status = keyboard_handler
+                .send_output_reports(hid_io.as_ref(), output_reports)
+                .err()
+                .unwrap_or(efi::Status::SUCCESS);
+        }
         status
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -208,20 +208,39 @@ impl SimpleTextInExFfi {
         }
         let context = unsafe { (this as *mut SimpleTextInExFfi).as_mut() }.expect("bad pointer");
         let old_tpl = context.boot_services.raise_tpl(efi::TPL_NOTIFY);
-        let status = 'reset_processing: {
+        let mut output_reports = Vec::new();
+        let mut keyboard_handler_ref = None;
+        let mut hid_io_ref = None;
+        let mut status = 'reset_processing: {
             let Some(keyboard_handler) = (unsafe { context.keyboard_handler.as_mut() }) else {
                 break 'reset_processing efi::Status::DEVICE_ERROR;
             };
             let Some(controller) = keyboard_handler.controller() else {
                 break 'reset_processing efi::Status::DEVICE_ERROR;
             };
-            UefiHidIoFactory::new(context.boot_services, keyboard_handler.agent())
-                .new_hid_io(controller, false)
-                .and_then(|hid_io| keyboard_handler.reset(hid_io.as_ref(), extended_verification.into()))
-                .err()
-                .unwrap_or(efi::Status::SUCCESS)
+            let Ok(hid_io) =
+                UefiHidIoFactory::new(context.boot_services, keyboard_handler.agent()).new_hid_io(controller, false)
+            else {
+                break 'reset_processing efi::Status::DEVICE_ERROR;
+            };
+            if let Err(err) = keyboard_handler.reset(hid_io.as_ref(), extended_verification.into()) {
+                break 'reset_processing err;
+            };
+            if extended_verification.into() {
+                // update keyboard leds
+                output_reports = keyboard_handler.generate_led_output_reports();
+                keyboard_handler_ref = Some(keyboard_handler);
+                hid_io_ref = Some(hid_io);
+            }
+            efi::Status::SUCCESS
         };
         context.boot_services.restore_tpl(old_tpl);
+        if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
+            status = keyboard_handler
+                .send_output_reports(hid_io.as_ref(), output_reports)
+                .err()
+                .unwrap_or(efi::Status::SUCCESS);
+        }
         status
     }
 
@@ -266,7 +285,10 @@ impl SimpleTextInExFfi {
         }
         let context = unsafe { (this as *mut SimpleTextInExFfi).as_mut() }.expect("bad pointer");
         let old_tpl = context.boot_services.raise_tpl(efi::TPL_NOTIFY);
-        let status = 'set_state_processing: {
+        let mut output_reports = Vec::new();
+        let mut keyboard_handler_ref = None;
+        let mut hid_io_ref = None;
+        let mut status = 'set_state_processing: {
             let Some(keyboard_handler) = (unsafe { context.keyboard_handler.as_mut() }) else {
                 break 'set_state_processing efi::Status::DEVICE_ERROR;
             };
@@ -279,9 +301,18 @@ impl SimpleTextInExFfi {
                 break 'set_state_processing efi::Status::DEVICE_ERROR;
             };
             keyboard_handler.set_key_toggle_state(unsafe { key_toggle_state.read() });
-            keyboard_handler.update_leds(hid_io.as_ref()).err().unwrap_or(efi::Status::SUCCESS)
+            output_reports = keyboard_handler.generate_led_output_reports();
+            keyboard_handler_ref = Some(keyboard_handler);
+            hid_io_ref = Some(hid_io);
+            efi::Status::SUCCESS
         };
         context.boot_services.restore_tpl(old_tpl);
+        if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
+            status = keyboard_handler
+                .send_output_reports(hid_io.as_ref(), output_reports)
+                .err()
+                .unwrap_or(efi::Status::SUCCESS);
+        }
         status
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -235,6 +235,7 @@ impl SimpleTextInExFfi {
             efi::Status::SUCCESS
         };
         context.boot_services.restore_tpl(old_tpl);
+        // Avoid sending output reports at the higher TPL
         if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
             status = keyboard_handler
                 .send_output_reports(hid_io.as_ref(), output_reports)
@@ -307,6 +308,7 @@ impl SimpleTextInExFfi {
             efi::Status::SUCCESS
         };
         context.boot_services.restore_tpl(old_tpl);
+        // Avoid sending output reports at the higher TPL
         if let (Some(keyboard_handler), Some(hid_io)) = (keyboard_handler_ref, hid_io_ref) {
             status = keyboard_handler
                 .send_output_reports(hid_io.as_ref(), output_reports)

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -223,7 +223,7 @@ impl SimpleTextInExFfi {
             else {
                 break 'reset_processing efi::Status::DEVICE_ERROR;
             };
-            if let Err(err) = keyboard_handler.reset(hid_io.as_ref(), extended_verification.into()) {
+            if let Err(err) = keyboard_handler.reset(extended_verification.into()) {
                 break 'reset_processing err;
             };
             if extended_verification.into() {


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/mu_plus/issues/788

Separate `send_output_reports` from `send_led_reports` to avoid issues caused by an elevated TPL when invoked from `simple_text_in_ex_set_state`, `simple_text_in_ex_reset` or `simple_text_in_reset`. These functions raise the TPL to TPL_NOTIFY, but the HID I/O instance may require the TPL to be at or below TPL_CALLBACK.
By decoupling these operations, we ensure proper TPL handling and prevent conflicts during HID output report transmission.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on laptop and no TPL conflicts observed.

## Integration Instructions

N/A