### PR TITLE
Fixing use after free issue for extra data in WHEA record

### DIFF
--- a/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportDxe.c
+++ b/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportDxe.c
@@ -360,6 +360,11 @@ MsWheaProcList (
 
       if (EFI_ERROR (Status) != FALSE) {
         DEBUG ((DEBUG_ERROR, "%a: Linked list entry process failed %r\n", __FUNCTION__, Status));
+      } else {
+        // Clean up the extra section after processing
+        if (MsWheaEntryMD->ExtraSection != 0) {
+          FreePool ((VOID *)(UINTN)(MsWheaEntryMD->ExtraSection));
+        }
       }
     }
 

--- a/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
+++ b/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
@@ -28,10 +28,10 @@ CreateNewEntry (
   IN MS_WHEA_ERROR_ENTRY_MD  *MsWheaEntryMD
   )
 {
-  MS_WHEA_LIST_ENTRY  *MsWheaListEntry = NULL;
-  MS_WHEA_ERROR_ENTRY_MD  *TempMsWheaEntryMD = NULL;
-  MS_WHEA_ERROR_EXTRA_SECTION_DATA *ExtraSectionPtr = NULL;
-  UINT32              Index            = 0;
+  MS_WHEA_LIST_ENTRY                *MsWheaListEntry   = NULL;
+  MS_WHEA_ERROR_ENTRY_MD            *TempMsWheaEntryMD = NULL;
+  MS_WHEA_ERROR_EXTRA_SECTION_DATA  *ExtraSectionPtr   = NULL;
+  UINT32                            Index              = 0;
 
   // Input argument sanity check
   if (MsWheaEntryMD == NULL) {
@@ -57,12 +57,12 @@ CreateNewEntry (
   CopyMem (&((UINT8 *)MsWheaListEntry->PayloadPtr)[Index], MsWheaEntryMD, sizeof (MS_WHEA_ERROR_ENTRY_MD));
 
   TempMsWheaEntryMD = (MS_WHEA_ERROR_ENTRY_MD *)MsWheaListEntry->PayloadPtr;
-  ExtraSectionPtr = (MS_WHEA_ERROR_EXTRA_SECTION_DATA *)(UINTN)(MsWheaEntryMD->ExtraSection);
+  ExtraSectionPtr   = (MS_WHEA_ERROR_EXTRA_SECTION_DATA *)(UINTN)(MsWheaEntryMD->ExtraSection);
   if (ExtraSectionPtr != NULL) {
     TempMsWheaEntryMD->ExtraSection = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateCopyPool (
-                                      sizeof (MS_WHEA_ERROR_EXTRA_SECTION_DATA) + ExtraSectionPtr->DataSize,
-                                      ExtraSectionPtr
-                                      );
+                                                                     sizeof (MS_WHEA_ERROR_EXTRA_SECTION_DATA) + ExtraSectionPtr->DataSize,
+                                                                     ExtraSectionPtr
+                                                                     );
   }
 
   Index                                                               += sizeof (MS_WHEA_ERROR_ENTRY_MD);

--- a/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
+++ b/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
@@ -8,7 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <Uefi.h>
 #include "MsWheaReportList.h"
 
 /**

--- a/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
+++ b/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportList.c
@@ -8,6 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#include <Uefi.h>
 #include "MsWheaReportList.h"
 
 /**
@@ -29,6 +30,8 @@ CreateNewEntry (
   )
 {
   MS_WHEA_LIST_ENTRY  *MsWheaListEntry = NULL;
+  MS_WHEA_ERROR_ENTRY_MD  *TempMsWheaEntryMD = NULL;
+  MS_WHEA_ERROR_EXTRA_SECTION_DATA *ExtraSectionPtr = NULL;
   UINT32              Index            = 0;
 
   // Input argument sanity check
@@ -53,6 +56,15 @@ CreateNewEntry (
   // Copy linked list and payload
   Index = 0;
   CopyMem (&((UINT8 *)MsWheaListEntry->PayloadPtr)[Index], MsWheaEntryMD, sizeof (MS_WHEA_ERROR_ENTRY_MD));
+
+  TempMsWheaEntryMD = (MS_WHEA_ERROR_ENTRY_MD *)MsWheaListEntry->PayloadPtr;
+  ExtraSectionPtr = (MS_WHEA_ERROR_EXTRA_SECTION_DATA *)(UINTN)(MsWheaEntryMD->ExtraSection);
+  if (ExtraSectionPtr != NULL) {
+    TempMsWheaEntryMD->ExtraSection = (EFI_PHYSICAL_ADDRESS)(UINTN)AllocateCopyPool (
+                                      sizeof (MS_WHEA_ERROR_EXTRA_SECTION_DATA) + ExtraSectionPtr->DataSize,
+                                      ExtraSectionPtr
+                                      );
+  }
 
   Index                                                               += sizeof (MS_WHEA_ERROR_ENTRY_MD);
   ((MS_WHEA_ERROR_ENTRY_MD *)MsWheaListEntry->PayloadPtr)->PayloadSize = Index;

--- a/MsWheaPkg/MsWheaReport/MsWheaReportCommon.c
+++ b/MsWheaPkg/MsWheaReport/MsWheaReportCommon.c
@@ -158,8 +158,11 @@ ReportHwErrRecRouter (
   }
 
 Cleanup:
-  if (ExtraData != NULL) {
-    FreePool (ExtraData);
+  if (EFI_ERROR (Status)) {
+    // Only free the ExtraData when there is any error.
+    if (ExtraData != NULL) {
+      FreePool (ExtraData);
+    }
   }
 
   return Status;

--- a/MsWheaPkg/MsWheaReport/MsWheaReportCommon.c
+++ b/MsWheaPkg/MsWheaReport/MsWheaReportCommon.c
@@ -158,11 +158,8 @@ ReportHwErrRecRouter (
   }
 
 Cleanup:
-  if (EFI_ERROR (Status)) {
-    // Only free the ExtraData when there is any error.
-    if (ExtraData != NULL) {
-      FreePool (ExtraData);
-    }
+  if (ExtraData != NULL) {
+    FreePool (ExtraData);
   }
 
   return Status;


### PR DESCRIPTION
## Description

The current implementation will free the extra data immediately after the entry is logged. This is fine if the log is directly materialized into `HwErrRec` UEFI variables.

However, if this logic occurs in the early DXE stage, it will cause the collected linked list contain dangling pointer.

This change fixed the issue by duplicating the buffer when it is added to the linked list and freed after linked list is processed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested by adding a telemetry entry before variable service is available and verified that the WHEA driver collected and then later processed the entry properly.

## Integration Instructions

N/A