### PR TITLE
AdvLoggerPkg: Fix memory bucket stability

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -213,8 +213,10 @@ class AdvLogParser ():
     # EFI_TIME    Time;                               // Uefi Time Field
     # UINT32      HwPrintLevel;                       // Logging level to be printed at hw port
     # UINT32      Reserved3;                          //
+    # EFI_PHYSICAL_ADDRESS    NewLoggerInfoAddress;   // If non-zero, this field holds the address of new logger info (added in later V5 revision, may not be present in older logs)
     # } ADVANCED_LOGGER_INFO;
     V5_LOGGER_INFO_SIZE = 80
+    V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS = 88
     V5_LOGGER_INFO_VERSION = 5
 
     # ---------------------------------------------------------------------- #
@@ -458,14 +460,24 @@ class AdvLogParser ():
 
         elif Version == self.V5_LOGGER_INFO_VERSION:
             InFile.read(4)  # skip over rest of reserved section
-            Size = self.V5_LOGGER_INFO_SIZE
+            # V5 can be either 80 bytes or 88 bytes (minor version 1 update with NewLoggerInfoAddress)
+            BaseAddress = 0
+            LoggerInfo["LogBufferOffset"] = struct.unpack("=I", InFile.read(4))[0]
+            Size = LoggerInfo["LogBufferOffset"]
+
+            # Determine if this has the NewLoggerInfoAddress field based on structure size
+            if Size == self.V5_LOGGER_INFO_SIZE:
+                HasNewLoggerInfoAddress = False
+            elif Size == self.V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS:
+                HasNewLoggerInfoAddress = True
+            else:
+                raise Exception('Error initializing logger info. Unexpected V5 structure size: %d' % Size)
+
             # we no longer have this field in the struct but for compatibility can calculate it
             # to be used
             LoggerInfo["LogBuffer"] = Size
             # this is only used to calculate LogCurrent as an offset, but V5 uses
             # LogCurrentOffset already, so we do this just to share the common code
-            BaseAddress = 0
-            LoggerInfo["LogBufferOffset"] = struct.unpack("=I", InFile.read(4))[0]
             InFile.read(4)  # skip over reserved4 field
             LoggerInfo["LogCurrentOffset"] = struct.unpack("=I", InFile.read(4))[0]
             # we don't have this field anymore, but to share the common code we
@@ -499,10 +511,16 @@ class AdvLogParser ():
             InFile.read(4)
             InFile.read(4)
 
+            # Read NewLoggerInfoAddress if present (88-byte V5 format)
+            if HasNewLoggerInfoAddress:
+                LoggerInfo["NewLoggerInfoAddress"] = struct.unpack("=Q", InFile.read(8))[0]
+            else:
+                LoggerInfo["NewLoggerInfoAddress"] = 0
+
             self._Compute_Basetime(LoggerInfo)
 
             if InFile.tell() != (Size):
-                raise Exception('Error initializing logger info. AmountRead: %d' % InFile.tell())
+                raise Exception('Error initializing logger info. AmountRead: %d, Expected: %d' % (InFile.tell(), Size))
 
         else:
             raise Exception('Error initializing logger info. Unsupported version: 0x%X' % LoggerInfo["Version"])

--- a/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
+++ b/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
@@ -28,7 +28,7 @@
 // Version 2: New backward incompatible V2 structure (ADVANCED_LOGGER_MESSAGE_ENTRY_V2
 //
 #define ADVANCED_LOGGER_MSG_MAJ_VER  2
-#define ADVANCED_LOGGER_MSG_MIN_VER  0
+#define ADVANCED_LOGGER_MSG_MIN_VER  1
 
 #define ADVANCED_LOGGER_VERSION  ADVANCED_LOGGER_HW_LVL_VER
 
@@ -46,6 +46,11 @@
 #define ADVANCED_LOGGER_PHASE_CNT          11
 
 //
+// The maximum depth to follow when traversing chains of advanced logger info structures
+//
+#define ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH  3
+
+//
 // These Pcds are used to carve out a PEI memory buffer from the temporary RAM.
 //
 //  PcdAdvancedLoggerBase -        NULL = UEFI starts with PEI, and SEC provides no memory log buffer
@@ -60,25 +65,26 @@
 #pragma pack (push, 1)
 
 typedef volatile struct {
-  UINT32      Signature;                          // Signature 'ALOG'
-  UINT16      Version;                            // Current Version
-  UINT16      Reserved[3];                        // Reserved for future
-  UINT32      LogBufferOffset;                    // Offset from LoggerInfo to start of log, expected to be the size of this structure 8 byte aligned
-  UINT32      Reserved4;
-  UINT32      LogCurrentOffset;                   // Offset from LoggerInfo to where to store next log entry.
-  UINT32      DiscardedSize;                      // Number of bytes of messages missed
-  UINT32      LogBufferSize;                      // Size of allocated buffer
-  BOOLEAN     InPermanentRAM;                     // Log in permanent RAM
-  BOOLEAN     AtRuntime;                          // After ExitBootServices
-  BOOLEAN     GoneVirtual;                        // After VirtualAddressChange
-  BOOLEAN     HdwPortInitialized;                 // HdwPort initialized
-  BOOLEAN     HdwPortDisabled;                    // HdwPort is Disabled
-  BOOLEAN     Reserved2[3];                       //
-  UINT64      TimerFrequency;                     // Ticks per second for log timing
-  UINT64      TicksAtTime;                        // Ticks when Time Acquired
-  EFI_TIME    Time;                               // Uefi Time Field
-  UINT32      HwPrintLevel;                       // Logging level to be printed at hw port
-  UINT32      Reserved3;                          //
+  UINT32                  Signature;              // Signature 'ALOG'
+  UINT16                  Version;                // Current Version
+  UINT16                  Reserved[3];            // Reserved for future
+  UINT32                  LogBufferOffset;        // Offset from LoggerInfo to start of log, expected to be the size of this structure 8 byte aligned
+  UINT32                  Reserved4;
+  UINT32                  LogCurrentOffset;       // Offset from LoggerInfo to where to store next log entry.
+  UINT32                  DiscardedSize;          // Number of bytes of messages missed
+  UINT32                  LogBufferSize;          // Size of allocated buffer
+  BOOLEAN                 InPermanentRAM;         // Log in permanent RAM
+  BOOLEAN                 AtRuntime;              // After ExitBootServices
+  BOOLEAN                 GoneVirtual;            // After VirtualAddressChange
+  BOOLEAN                 HdwPortInitialized;     // HdwPort initialized
+  BOOLEAN                 HdwPortDisabled;        // HdwPort is Disabled
+  BOOLEAN                 Reserved2[3];           //
+  UINT64                  TimerFrequency;         // Ticks per second for log timing
+  UINT64                  TicksAtTime;            // Ticks when Time Acquired
+  EFI_TIME                Time;                   // Uefi Time Field
+  UINT32                  HwPrintLevel;           // Logging level to be printed at hw port
+  UINT32                  Reserved3;              //
+  EFI_PHYSICAL_ADDRESS    NewLoggerInfoAddress;   // If non-zero, this field holds the address of new logger info that should be used
 } ADVANCED_LOGGER_INFO;
 
 typedef struct {

--- a/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
+++ b/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
@@ -11,8 +11,22 @@
 #ifndef __ADVANCED_LOGGER_INTERNAL_H__
 #define __ADVANCED_LOGGER_INTERNAL_H__
 
-#define ADVANCED_LOGGER_SIGNATURE    SIGNATURE_32('A','L','O','G')
-#define ADVANCED_LOGGER_HW_LVL_VER   5
+#define ADVANCED_LOGGER_SIGNATURE  SIGNATURE_32('A','L','O','G')
+
+//
+// Advanced Logger Hardware Port Level Support Version
+//
+// Writing to hardware port based on message DebugLevel is supported
+// (AdvancedLoggerHdwPortWrite()).
+//
+#define ADVANCED_LOGGER_HW_LVL_VER  5
+
+//
+// Advanced Logger Message structure versions
+//
+// Version 1: Original structure (ADVANCED_LOGGER_MESSAGE_ENTRY)
+// Version 2: New backward incompatible V2 structure (ADVANCED_LOGGER_MESSAGE_ENTRY_V2
+//
 #define ADVANCED_LOGGER_MSG_MAJ_VER  2
 #define ADVANCED_LOGGER_MSG_MIN_VER  0
 

--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
@@ -30,6 +30,69 @@ STATIC UINTN                 mLoggerTransferSize = 0;
 extern UINTN                 mVariableBufferPayloadSize;
 
 /**
+  Follow the logger info redirection chain and update the provided logger info pointer.
+
+  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
+  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
+  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
+
+  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
+  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
+**/
+STATIC
+BOOLEAN
+AdvancedLoggerCheckForNewerLogger (
+  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
+  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
+  OUT    UINT32                *BufferSize  OPTIONAL
+  )
+{
+  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
+  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
+  UINTN                 Depth;
+
+  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
+    return FALSE;
+  }
+
+  CurrentLoggerInfo = *LoggerInfo;
+  Depth             = 0;
+
+  // Follow the chain to find the current logger
+  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
+    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
+
+    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
+      return FALSE;
+    }
+
+    CurrentLoggerInfo = NextLoggerInfo;
+    Depth++;
+  }
+
+  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
+    return FALSE;
+  }
+
+  // Update if we found a newer logger
+  if (CurrentLoggerInfo != *LoggerInfo) {
+    *LoggerInfo = CurrentLoggerInfo;
+
+    if (MaxAddress != NULL) {
+      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
+    }
+
+    if (BufferSize != NULL) {
+      *BufferSize = CurrentLoggerInfo->LogBufferSize;
+    }
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
     CheckAddress
 
     The address of the ADVANCE_LOGGER_INFO block pointer is captured before END_OF_DXE.
@@ -110,6 +173,12 @@ AdvLoggerAccessInit (
 
   if (mLoggerInfo != NULL) {
     mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
+  }
+
+  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
   }
 
   //
@@ -194,6 +263,12 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
 
+  if ((mLoggerInfo != NULL) && !mLoggerInfo->AtRuntime && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
+  }
+
   if ((!ValidateInfoBlock ()) || (mLoggerTransferSize == 0)) {
     return EFI_UNSUPPORTED;
   }
@@ -260,6 +335,12 @@ AdvLoggerAccessAtRuntime (
   VOID
   )
 {
+  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ExitBootServices. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
+  }
+
   if (mLoggerInfo != NULL) {
     mLoggerInfo->AtRuntime = TRUE;
   }

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
@@ -30,6 +30,69 @@ STATIC UINTN                 mLoggerTransferSize = 0;
 extern UINTN                 mVariableBufferPayloadSize;
 
 /**
+  Follow the logger info redirection chain and update the provided logger info pointer.
+
+  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
+  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
+  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
+
+  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
+  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
+**/
+STATIC
+BOOLEAN
+AdvancedLoggerCheckForNewerLogger (
+  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
+  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
+  OUT    UINT32                *BufferSize  OPTIONAL
+  )
+{
+  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
+  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
+  UINTN                 Depth;
+
+  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
+    return FALSE;
+  }
+
+  CurrentLoggerInfo = *LoggerInfo;
+  Depth             = 0;
+
+  // Follow the chain to find the current logger
+  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
+    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
+
+    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
+      return FALSE;
+    }
+
+    CurrentLoggerInfo = NextLoggerInfo;
+    Depth++;
+  }
+
+  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
+    return FALSE;
+  }
+
+  // Update if we found a newer logger
+  if (CurrentLoggerInfo != *LoggerInfo) {
+    *LoggerInfo = CurrentLoggerInfo;
+
+    if (MaxAddress != NULL) {
+      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
+    }
+
+    if (BufferSize != NULL) {
+      *BufferSize = CurrentLoggerInfo->LogBufferSize;
+    }
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
     CheckAddress
 
     The address of the ADVANCE_LOGGER_INFO block pointer is captured before END_OF_DXE. LogBufferOffset,
@@ -127,6 +190,10 @@ AdvLoggerAccessInit (
     mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     if (mLoggerInfo != NULL) {
       mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
+
+      if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+        DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+      }
     }
 
     if (!ValidateInfoBlock ()) {
@@ -194,6 +261,12 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
 
+  if ((mLoggerInfo != NULL) && !mLoggerInfo->AtRuntime) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
+  }
+
   if ((!ValidateInfoBlock ()) || (mLoggerTransferSize == 0)) {
     return EFI_UNSUPPORTED;
   }
@@ -260,6 +333,12 @@ AdvLoggerAccessAtRuntime (
   VOID
   )
 {
+  if (mLoggerInfo != NULL) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ExitBootServices. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
+  }
+
   if (mLoggerInfo != NULL) {
     mLoggerInfo->AtRuntime = TRUE;
   }

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
@@ -45,4 +45,7 @@
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize
 
+[FeaturePcd]
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
+
 [Depex]

--- a/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
@@ -40,6 +40,69 @@ CONST   CHAR8                 *AdvMsgEntryPrefix[ADVANCED_LOGGER_PHASE_CNT] = {
   "[TFA  ]",
 };
 
+/**
+  Follow the logger info redirection chain and update the provided logger info pointer.
+
+  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
+  @param[out]     LowAddress    Optional pointer to update with the low address of the current logger.
+  @param[out]     HighAddress   Optional pointer to update with the high address of the current logger.
+
+  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
+  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
+**/
+STATIC
+BOOLEAN
+AdvancedLoggerCheckForNewerLogger (
+  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
+  OUT    EFI_PHYSICAL_ADDRESS  *LowAddress  OPTIONAL,
+  OUT    EFI_PHYSICAL_ADDRESS  *HighAddress  OPTIONAL
+  )
+{
+  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
+  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
+  UINTN                 Depth;
+
+  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
+    return FALSE;
+  }
+
+  CurrentLoggerInfo = *LoggerInfo;
+  Depth             = 0;
+
+  // Follow the chain to find the current logger
+  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
+    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
+
+    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
+      return FALSE;
+    }
+
+    CurrentLoggerInfo = NextLoggerInfo;
+    Depth++;
+  }
+
+  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
+    return FALSE;
+  }
+
+  // Update if we found a newer logger
+  if (CurrentLoggerInfo != *LoggerInfo) {
+    *LoggerInfo = CurrentLoggerInfo;
+
+    if (LowAddress != NULL) {
+      *LowAddress = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (CurrentLoggerInfo));
+    }
+
+    if (HighAddress != NULL) {
+      *HighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (CurrentLoggerInfo));
+    }
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 // Define a structure to hold debug level information
 typedef struct {
   CONST CHAR8    *Name;
@@ -253,6 +316,8 @@ AdvancedLoggerAccessLibGetNextMessageBlock (
   if (BlockEntry == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+
+  AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mLowAddress, &mHighAddress);
 
   if (mLoggerInfo->LogCurrentOffset == mLoggerInfo->LogBufferOffset) {
     return EFI_END_OF_FILE;
@@ -552,6 +617,8 @@ AdvancedLoggerAccessLibConstructor (
     mLoggerInfo  = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     mLowAddress  = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (mLoggerInfo));
     mHighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (mLoggerInfo));
+
+    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mLowAddress, &mHighAddress);
 
     // Leave this debug message as ERROR.
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -20,6 +20,101 @@
 #include "../AdvancedLoggerCommon.h"
 
 /**
+  Follow the logger info redirection chain to find the current logger info.
+
+  This is primarily used to support migrating an advanced logger buffer to a new location.
+
+  @param[in]  LoggerInfo    Pointer to a logger info structure to start the chain walk.
+
+  @return               Pointer to the current logger info structure (with NewLoggerInfoAddress == 0).
+                        Returns NULL if the input is NULL or if the chain is invalid.
+**/
+ADVANCED_LOGGER_INFO *
+AdvancedLoggerGetCurrentLoggerInfo (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  )
+{
+  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
+  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
+  UINTN                 Depth;
+
+  if (LoggerInfo == NULL) {
+    return NULL;
+  }
+
+  CurrentLoggerInfo = LoggerInfo;
+  Depth             = 0;
+
+  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
+    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
+
+    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
+      return CurrentLoggerInfo;
+    }
+
+    CurrentLoggerInfo = NextLoggerInfo;
+    Depth++;
+  }
+
+  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
+    return NULL;
+  }
+
+  return CurrentLoggerInfo;
+}
+
+/**
+  Follow the logger info redirection chain and update the provided logger info pointer.
+
+  This function follows the logger address chain to find the current logger info
+  and updates the input pointer if a new logger is found.
+
+  The function does not attempt to make any validation statement about the logger info
+  structures and it is expected NULL may be provided as input.
+
+  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
+  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
+  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
+
+  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
+  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
+**/
+BOOLEAN
+AdvancedLoggerCheckForNewerLogger (
+  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
+  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
+  OUT    UINT32                *BufferSize  OPTIONAL
+  )
+{
+  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
+
+  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
+    return FALSE;
+  }
+
+  CurrentLoggerInfo = AdvancedLoggerGetCurrentLoggerInfo (*LoggerInfo);
+  if (CurrentLoggerInfo == NULL) {
+    return FALSE;
+  }
+
+  if (CurrentLoggerInfo != *LoggerInfo) {
+    *LoggerInfo = CurrentLoggerInfo;
+
+    if (MaxAddress != NULL) {
+      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
+    }
+
+    if (BufferSize != NULL) {
+      *BufferSize = CurrentLoggerInfo->LogBufferSize;
+    }
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
   Write data from buffer into the in memory logging buffer.
 
   Writes NumberOfBytes data bytes from Buffer to the logging buffer.
@@ -59,6 +154,8 @@ AdvancedLoggerMemoryLoggerWrite (
   }
 
   LoggerInfo = AdvancedLoggerGetLoggerInfo ();
+
+  LoggerInfo = AdvancedLoggerGetCurrentLoggerInfo (LoggerInfo);
 
   if (LoggerInfo != NULL) {
     EntrySize = MESSAGE_ENTRY_SIZE_V2 (OFFSET_OF (ADVANCED_LOGGER_MESSAGE_ENTRY_V2, MessageText), NumberOfBytes);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -10,6 +10,49 @@
 #ifndef __ADVANCED_LOGGER_COMMON_H__
 #define __ADVANCED_LOGGER_COMMON_H__
 
+//
+// The maximum depth to follow when traversing chains of advanced logger info structures
+//
+#define ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH  3
+
+/**
+  Follow the logger info redirection chain to find the current logger info.
+
+  This is primarily used to support migrating an advanced logger buffer to a new location.
+
+  @param[in]  LoggerInfo    Pointer to a logger info structure to start the chain walk.
+
+  @return               Pointer to the current logger info structure (with NewLoggerInfoAddress == 0).
+                        Returns NULL if the input is NULL or if the chain is invalid.
+**/
+ADVANCED_LOGGER_INFO *
+AdvancedLoggerGetCurrentLoggerInfo (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  );
+
+/**
+  Follow the logger info redirection chain and update the provided logger info pointer.
+
+  This function follows the logger address chain to find the current logger info
+  and updates the input pointer if a new logger is found.
+
+  The function does not attempt to make any validation statement about the logger info
+  structures and it is expected NULL may be provided as input.
+
+  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
+  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
+  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
+
+  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
+  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
+**/
+BOOLEAN
+AdvancedLoggerCheckForNewerLogger (
+  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
+  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
+  OUT    UINT32                *BufferSize  OPTIONAL
+  );
+
 /**
     Write data from buffer into the in memory logging buffer.
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -111,6 +111,8 @@ AdvancedLoggerGetLoggerInfo (
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
     DEBUG ((DEBUG_ERROR, "%a: LoggerInfo marked invalid\n", __FUNCTION__));
+  } else if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize);
   }
 
   return mLoggerInfo;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -110,7 +110,7 @@ AdvancedLoggerGetLoggerInfo (
 
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
-    DEBUG ((DEBUG_ERROR, "%a: LoggerInfo marked invalid\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: LoggerInfo marked invalid\n", __func__));
   } else if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
     AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize);
   }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -42,6 +42,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -209,7 +209,7 @@ OnRealTimeClockArchNotification (
 
   SystemTable = (EFI_SYSTEM_TABLE *)Context;
 
-  DEBUG ((DEBUG_INFO, "%a: getting real time\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: getting real time\n", __func__));
 
   SystemTable->BootServices->CloseEvent (Event);
 
@@ -243,7 +243,7 @@ OnVariableWriteNotification (
 
   SystemTable = (EFI_SYSTEM_TABLE *)Context;
 
-  DEBUG ((DEBUG_INFO, "%a: writing locator variable\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: writing locator variable\n", __func__));
 
   SystemTable->RuntimeServices->SetVariable (
                                   ADVANCED_LOGGER_LOCATOR_NAME,
@@ -278,11 +278,11 @@ OnVariablePolicyProtocolNotification (
 
   SystemTable = (EFI_SYSTEM_TABLE *)Context;
 
-  DEBUG ((DEBUG_INFO, "%a: writing locator variable policy\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: writing locator variable policy\n", __func__));
 
   Status = SystemTable->BootServices->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: - Locating Variable Policy failed - Code=%r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: - Locating Variable Policy failed - Code=%r\n", __func__, Status));
     ASSERT_EFI_ERROR (Status);
     return;
   }
@@ -298,7 +298,7 @@ OnVariablePolicyProtocolNotification (
              VARIABLE_POLICY_TYPE_LOCK_ON_CREATE               // Will act as LOCK now if already created
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: - Error registering AdvancedLoggerLocator - Code=%r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: - Error registering AdvancedLoggerLocator - Code=%r\n", __func__, Status));
     ASSERT_EFI_ERROR (Status);
   }
 
@@ -330,7 +330,7 @@ ProcessProtocolRegistration (
   //
   // Register for protocol notification.
   //
-  DEBUG ((DEBUG_INFO, "%a: Registering for %g\n", __FUNCTION__, ProtocolGuid));
+  DEBUG ((DEBUG_INFO, "%a: Registering for %g\n", __func__, ProtocolGuid));
   Status = SystemTable->BootServices->CreateEvent (
                                         EVT_NOTIFY_SIGNAL,
                                         TPL_CALLBACK,
@@ -340,7 +340,7 @@ ProcessProtocolRegistration (
                                         );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to create notification callback event (%r)\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: failed to create notification callback event (%r)\n", __func__, Status));
     goto Cleanup;
   }
 
@@ -351,7 +351,7 @@ ProcessProtocolRegistration (
                                         );
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to register for notification (%r)\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: failed to register for notification (%r)\n", __func__, Status));
     SystemTable->BootServices->CloseEvent (ProtocolEvent);
     goto Cleanup;
   }
@@ -597,7 +597,7 @@ DxeCoreAdvancedLoggerLibConstructor (
       mMaxAddress = LOG_MAX_ADDRESS (LoggerInfo);
       mBufferSize = LoggerInfo->LogBufferSize;
     } else {
-      DEBUG ((DEBUG_ERROR, "%a: Error allocating Advanced Logger Buffer\n", __FUNCTION__));
+      DEBUG ((DEBUG_ERROR, "%a: Error allocating Advanced Logger Buffer\n", __func__));
     }
   }
 
@@ -629,7 +629,7 @@ DxeCoreAdvancedLoggerLibConstructor (
                                           );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Error installing protocol - %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Error installing protocol - %r\n", __func__, Status));
       // If the protocol doesn't install, don't fail.
     }
 
@@ -651,12 +651,12 @@ DxeCoreAdvancedLoggerLibConstructor (
                                             &EndOfDxeEvent
                                             );
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to create End of DXE event - %r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_ERROR, "%a: Failed to create End of DXE event - %r\n", __func__, Status));
       }
     }
   }
 
-  DEBUG ((DEBUG_INFO, "%a Initialized. mLoggerInfo = %p, Container=%p\n", __FUNCTION__, mLoggerInfo, &mAdvLoggerProtocol));
+  DEBUG ((DEBUG_INFO, "%a Initialized. mLoggerInfo = %p, Container=%p\n", __func__, mLoggerInfo, &mAdvLoggerProtocol));
 
   ProcessProtocolRegistration (
     SystemTable,

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -17,6 +17,7 @@
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Library/AdvancedLoggerHdwPortLib.h>
+#include <Library/MmUnblockMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
@@ -32,10 +33,12 @@
 //
 // Protocol interface that connects the DXE library instances with the AdvancedLogger
 //
-STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo = NULL;
-STATIC UINT32                mBufferSize  = 0;
-STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress  = 0;
-STATIC BOOLEAN               mInitialized = FALSE;
+STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo  = NULL;
+STATIC UINT32                mBufferSize   = 0;
+STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress   = 0;
+STATIC BOOLEAN               mInitialized  = FALSE;
+STATIC EFI_SYSTEM_TABLE      *mSystemTable = NULL;
+STATIC EFI_HANDLE            mImageHandle  = NULL;
 
 VOID
 EFIAPI
@@ -163,6 +166,8 @@ AdvancedLoggerGetLoggerInfo (
 
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
+  } else if ((mLoggerInfo != NULL) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+    DEBUG ((DEBUG_INFO, "DxeCore %a: Logger Update. LoggerInfo=%p\n", __func__, mLoggerInfo));
   }
 
   return mLoggerInfo;
@@ -358,8 +363,212 @@ Cleanup:
 }
 
 /**
+  Initialize a logger info structure with basic values.
+
+  Sets up the signature, version, buffer offsets, sizes, and hardware print level.
+  Does not initialize hardware port - caller must do that separately if needed.
+
+  @param[in,out] LoggerInfo  Pointer to logger info structure to initialize.
+
+**/
+STATIC
+VOID
+InitializeLoggerInfoStructure (
+  IN OUT ADVANCED_LOGGER_INFO  *LoggerInfo
+  )
+{
+  if (LoggerInfo == NULL) {
+    return;
+  }
+
+  ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
+  LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+  LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+  LoggerInfo->LogBufferSize    = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
+  LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
+  LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+}
+
+/**
+  Process logs in the pre-DXE logs HOB.
+
+  Retrieves the pre-DXE logs HOB and writes the log data to the logger buffer.
+
+**/
+STATIC
+VOID
+ProcessPreDxeLogs (
+  VOID
+  )
+{
+  ADVANCED_LOGGER_PRE_DXE_LOGS_HOB  *PreDxeLogs;
+  EFI_HOB_GUID_TYPE                 *PreDxeLogsHobEntry;
+
+  PreDxeLogsHobEntry = GetFirstGuidHob (&gAdvancedLoggerPreDxeLogsGuid);
+  if (PreDxeLogsHobEntry != NULL) {
+    PreDxeLogs = (ADVANCED_LOGGER_PRE_DXE_LOGS_HOB *)GET_GUID_HOB_DATA (PreDxeLogsHobEntry);
+    if (PreDxeLogs->Signature != ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE) {
+      ASSERT (PreDxeLogs->Signature == ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE);
+    } else {
+      AdvancedLoggerMemoryLoggerWrite (DEBUG_INFO, (CONST CHAR8 *)(UINTN)PreDxeLogs->BaseAddress, PreDxeLogs->LengthInBytes);
+    }
+  }
+}
+
+/**
+  Initialize the timer frequency for the logger.
+
+**/
+STATIC
+VOID
+InitializeTimerFrequency (
+  VOID
+  )
+{
+  if (mLoggerInfo != NULL) {
+    mLoggerInfo->TimerFrequency = GetPerformanceCounterProperties (NULL, NULL);
+  }
+}
+
+/**
+  Migrate the PEI logger buffer to a new DXE reserved buffer.
+
+  Called at End of DXE to ensure all MM services are available to unblock the new logger buffer.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  The pointer to the notification function's context.
+**/
+STATIC
+VOID
+EFIAPI
+OnEndOfDxe (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS            Status;
+  EFI_TPL               OldTpl;
+  ADVANCED_LOGGER_INFO  *ExistingLoggerInfo;
+  ADVANCED_LOGGER_INFO  *NewLoggerInfo;
+  EFI_BOOT_SERVICES     *BootServices;
+
+  DEBUG ((DEBUG_INFO, "%a: Migrating logger buffer\n", __func__));
+
+  BootServices = (EFI_BOOT_SERVICES *)Context;
+  if (BootServices == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Boot services context is null, the logger buffer will not be migrated.\n", __func__));
+    return;
+  }
+
+  ExistingLoggerInfo = AdvancedLoggerGetLoggerInfo ();
+
+  //
+  // Allocate new reserved buffer for the logger
+  //
+  NewLoggerInfo = (ADVANCED_LOGGER_INFO *)AllocateReservedPages (FixedPcdGet32 (PcdAdvancedLoggerPages));
+  if (NewLoggerInfo == NULL) {
+    ASSERT (NewLoggerInfo != NULL);
+    return;
+  }
+
+  //
+  // Unblock the new buffer for MM access
+  // If this is not needed on a platform, the null instance of MmUnblockMemoryLib can be used.
+  //
+  Status = MmUnblockMemoryRequest (
+             (EFI_PHYSICAL_ADDRESS)(UINTN)NewLoggerInfo,
+             FixedPcdGet32 (PcdAdvancedLoggerPages)
+             );
+  if (EFI_ERROR (Status) && (Status != EFI_UNSUPPORTED)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to unblock advanced logger buffer for MM access - %r\n", __func__, Status));
+  }
+
+  //
+  // Prevent other notifications at TPL NOTIFY or lower from interrupting the overall migration flow.
+  // First, check that raising to TPL_NOTIFY is successful.
+  //
+  OldTpl = BootServices->RaiseTPL (TPL_NOTIFY);
+
+  //
+  // Raise to TPL_HIGH_LEVEL during the main copy operation so interrupts are disabled.
+  // No need to store the current TPL since was just set to TPL_NOTIFY.
+  //
+  BootServices->RaiseTPL (TPL_HIGH_LEVEL);
+
+  InitializeLoggerInfoStructure (NewLoggerInfo);
+
+  //
+  // If a pre-existing buffer was provided, copy its contents to the new buffer
+  //
+  if (ExistingLoggerInfo != NULL) {
+    NewLoggerInfo->TimerFrequency = ExistingLoggerInfo->TimerFrequency;
+    NewLoggerInfo->TicksAtTime    = ExistingLoggerInfo->TicksAtTime;
+    CopyMem ((VOID *)&NewLoggerInfo->Time, (VOID *)&ExistingLoggerInfo->Time, sizeof (NewLoggerInfo->Time));
+
+    if (ExistingLoggerInfo->LogCurrentOffset > ExistingLoggerInfo->LogBufferOffset) {
+      CopyMem (
+        LOG_BUFFER_FROM_ALI (NewLoggerInfo),
+        LOG_BUFFER_FROM_ALI (ExistingLoggerInfo),
+        USED_LOG_SIZE (ExistingLoggerInfo)
+        );
+      NewLoggerInfo->LogCurrentOffset = NewLoggerInfo->LogBufferOffset + USED_LOG_SIZE (ExistingLoggerInfo);
+    }
+
+    NewLoggerInfo->DiscardedSize = ExistingLoggerInfo->DiscardedSize;
+
+    //
+    // Set the old logger info's NewLoggerInfoAddress to redirect to the new buffer
+    //
+    ExistingLoggerInfo->NewLoggerInfoAddress = PA_FROM_PTR (NewLoggerInfo);
+  }
+
+  //
+  // Update module state to use the new buffer
+  //
+  mMaxAddress                   = LOG_MAX_ADDRESS (NewLoggerInfo);
+  mBufferSize                   = NewLoggerInfo->LogBufferSize;
+  mLoggerInfo                   = NewLoggerInfo;
+  mAdvLoggerProtocol.LoggerInfo = NewLoggerInfo;
+
+  //
+  // Restore back to TPL_NOTIFY before calling functions with level restrictions.
+  //
+  BootServices->RestoreTPL (TPL_NOTIFY);
+
+  //
+  // Initialize the hardware port if not already done
+  //
+  if (!NewLoggerInfo->HdwPortInitialized) {
+    AdvancedLoggerHdwPortInitialize ();
+    NewLoggerInfo->HdwPortInitialized = TRUE;
+  }
+
+  //
+  // Reinstall protocol with the new buffer information.
+  // This updates any existing protocol installation to point to the migrated buffer.
+  //
+  Status = mSystemTable->BootServices->ReinstallProtocolInterface (
+                                         mImageHandle,
+                                         &gAdvancedLoggerProtocolGuid,
+                                         &mAdvLoggerProtocol.AdvLoggerProtocol,
+                                         &mAdvLoggerProtocol.AdvLoggerProtocol
+                                         );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Error reinstalling advanced logger protocol - %r\n", __func__, Status));
+  }
+
+  BootServices->RestoreTPL (OldTpl);
+
+  //
+  // Close the event as we only need to migrate once
+  //
+  mSystemTable->BootServices->CloseEvent (Event);
+}
+
+/**
   DxeCore Advanced Logger initialization.
- **/
+**/
 EFI_STATUS
 EFIAPI
 DxeCoreAdvancedLoggerLibConstructor (
@@ -367,31 +576,23 @@ DxeCoreAdvancedLoggerLibConstructor (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  ADVANCED_LOGGER_INFO              *LoggerInfo;
-  EFI_STATUS                        Status;
-  ADVANCED_LOGGER_PRE_DXE_LOGS_HOB  *PreDxeLogs;
-  EFI_HOB_GUID_TYPE                 *PreDxeLogsHobEntry;
+  EFI_STATUS            Status;
+  EFI_EVENT             EndOfDxeEvent;
+  ADVANCED_LOGGER_INFO  *LoggerInfo;
 
-  LoggerInfo = AdvancedLoggerGetLoggerInfo ();      // Sets mLoggerInfo if Logger Information block found in HOB.
+  mSystemTable = SystemTable;
+  mImageHandle = ImageHandle;
+
+  LoggerInfo = AdvancedLoggerGetLoggerInfo ();
 
   //
-  // For an implementation of the AdvancedLogger with a PEI implementation, there will be a
+  // For an implementation of the AdvancedLogger with a pre-DXE implementation, there will be a
   // Logger Information block published and available.
   //
   if (LoggerInfo == NULL) {
     LoggerInfo = (ADVANCED_LOGGER_INFO *)AllocateReservedPages (FixedPcdGet32 (PcdAdvancedLoggerPages));
     if (LoggerInfo != NULL) {
-      ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
-      LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
-      LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
-      LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-      LoggerInfo->LogBufferSize    = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
-      LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
-      LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-      if (LoggerInfo->HdwPortInitialized == FALSE) {
-        AdvancedLoggerHdwPortInitialize ();
-        LoggerInfo->HdwPortInitialized = TRUE;
-      }
+      InitializeLoggerInfoStructure (LoggerInfo);
 
       mMaxAddress = LOG_MAX_ADDRESS (LoggerInfo);
       mBufferSize = LoggerInfo->LogBufferSize;
@@ -402,20 +603,24 @@ DxeCoreAdvancedLoggerLibConstructor (
 
   mLoggerInfo = LoggerInfo;
   if (LoggerInfo != NULL) {
-    mAdvLoggerProtocol.LoggerInfo = LoggerInfo;
-    mLoggerInfo->TimerFrequency   = GetPerformanceCounterProperties (NULL, NULL);
-
-    PreDxeLogsHobEntry = GetFirstGuidHob (&gAdvancedLoggerPreDxeLogsGuid);
-
-    if (PreDxeLogsHobEntry != NULL) {
-      PreDxeLogs = (ADVANCED_LOGGER_PRE_DXE_LOGS_HOB *)GET_GUID_HOB_DATA (PreDxeLogsHobEntry);
-      if (PreDxeLogs->Signature != ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE) {
-        ASSERT (PreDxeLogs->Signature == ADVANCED_LOGGER_PRE_DXE_LOGS_SIGNATURE);
-      } else {
-        AdvancedLoggerMemoryLoggerWrite (DEBUG_INFO, (CONST CHAR8 *)(UINTN)PreDxeLogs->BaseAddress, PreDxeLogs->LengthInBytes);
-      }
+    //
+    // Initialize hardware port if not already done
+    //
+    if (!LoggerInfo->HdwPortInitialized) {
+      AdvancedLoggerHdwPortInitialize ();
+      LoggerInfo->HdwPortInitialized = TRUE;
     }
 
+    mMaxAddress                   = LOG_MAX_ADDRESS (LoggerInfo);
+    mBufferSize                   = LoggerInfo->LogBufferSize;
+    mAdvLoggerProtocol.LoggerInfo = LoggerInfo;
+
+    InitializeTimerFrequency ();
+    ProcessPreDxeLogs ();
+
+    //
+    // Install protocol
+    //
     Status = SystemTable->BootServices->InstallProtocolInterface (
                                           &ImageHandle,
                                           &gAdvancedLoggerProtocolGuid,
@@ -426,6 +631,28 @@ DxeCoreAdvancedLoggerLibConstructor (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Error installing protocol - %r\n", __FUNCTION__, Status));
       // If the protocol doesn't install, don't fail.
+    }
+
+    //
+    // Only allocate a new reserved buffer and migrate when the address was not designated
+    // to be fixed in RAM.
+    //
+    if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+      //
+      // Migrate the advanced logger buffer at End of DXE.
+      // This allows the migrated buffer to be unblocked for MM access.
+      //
+      Status = SystemTable->BootServices->CreateEventEx (
+                                            EVT_NOTIFY_SIGNAL,
+                                            TPL_CALLBACK,
+                                            OnEndOfDxe,
+                                            SystemTable->BootServices,
+                                            &gEfiEndOfDxeEventGroupGuid,
+                                            &EndOfDxeEvent
+                                            );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to create End of DXE event - %r\n", __FUNCTION__, Status));
+      }
     }
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -38,6 +38,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  MmUnblockMemoryLib
   PcdLib
   SynchronizationLib
   TimerLib

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.inf
@@ -36,6 +36,7 @@
   AdvancedLoggerHdwPortLib
   # BaseMemoryLib
   HobLib
+  MmUnblockMemoryLib
   # MemoryAllocationLib
   PcdLib
   SynchronizationLib

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
@@ -117,6 +117,13 @@ AdvancedLoggerGetLoggerInfo (
     //
   }
 
+  //
+  // Check for buffer migration before validation, as migration changes buffer size/address.
+  //
+  if (mLoggerInfo != NULL) {
+    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize);
+  }
+
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
     DEBUG ((DEBUG_ERROR, "MmCore %a: LoggerInfo marked invalid\n", __func__));

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.inf
@@ -20,6 +20,7 @@
 
 [Sources]
   AdvancedLoggerMmCoreGoogleTest.cpp
+  ../../AdvancedLoggerCommon.c
   ../AdvancedLoggerLib.c # Resolve function ValidateInfoBlock()
 
 [Packages]

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -207,7 +207,7 @@ InstallPermanentMemoryBuffer (
       // Must be PeiCore allocated small memory buffer
       //
       Status = PeiServicesAllocatePages (
-                 EfiRuntimeServicesData,
+                 EfiBootServicesData,
                  FixedPcdGet32 (PcdAdvancedLoggerPages),
                  &NewLogBuffer
                  );

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -195,10 +195,10 @@ InstallPermanentMemoryBuffer (
   PEI_CORE_INSTANCE     *PeiCoreInstance;
   EFI_STATUS            Status;
 
-  DEBUG ((DEBUG_INFO, "%a: Find PeiCore HOB for Install Permanent Buffer...\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a: Find PeiCore HOB for Install Permanent Buffer...\n", __func__));
   GuidHob = GetFirstGuidHob (&gAdvancedLoggerHobGuid);
   if (GuidHob == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Advanced Logger Hob not found\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Advanced Logger Hob not found\n", __func__));
   } else {
     LogPtr     = (ADVANCED_LOGGER_PTR *)GET_GUID_HOB_DATA (GuidHob);
     LoggerInfo = ALI_FROM_PA (LogPtr->LogBuffer);
@@ -240,10 +240,10 @@ InstallPermanentMemoryBuffer (
         Status = MmUnblockMemoryRequest (NewLogBuffer, FixedPcdGet32 (PcdAdvancedLoggerPages));
         if (EFI_ERROR (Status)) {
           if (Status != EFI_UNSUPPORTED) {
-            DEBUG ((DEBUG_ERROR, "%a: Unable to notify StandaloneMM. Code=%r\n", __FUNCTION__, Status));
+            DEBUG ((DEBUG_ERROR, "%a: Unable to notify StandaloneMM. Code=%r\n", __func__, Status));
           }
         } else {
-          DEBUG ((DEBUG_INFO, "%a: StandaloneMM Hob data published\n", __FUNCTION__));
+          DEBUG ((DEBUG_INFO, "%a: StandaloneMM Hob data published\n", __func__));
         }
 
         PeiServicesFreePages (
@@ -260,7 +260,7 @@ InstallPermanentMemoryBuffer (
         DEBUG ((
           DebugLevel,
           "%a: - New Info=%p, Buffer Offset=%x, Current Offset=%x, Size=%d, Discarded=%d\n",
-          __FUNCTION__,
+          __func__,
           NewLoggerInfo,
           NewLoggerInfo->LogBufferOffset,
           NewLoggerInfo->LogCurrentOffset,
@@ -616,7 +616,7 @@ AdvancedLoggerGetLoggerInfo (
       ASSERT_EFI_ERROR (Status);
 
       if (FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-        DEBUG ((DEBUG_INFO, "%a: Standalone MM Hob of fixed data published\n", __FUNCTION__));
+        DEBUG ((DEBUG_INFO, "%a: Standalone MM Hob of fixed data published\n", __func__));
       } else {
         PeiServicesNotifyPpi (mMemoryDiscoveredNotifyList);
       }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -20,11 +20,13 @@
 
 #include "../AdvancedLoggerCommon.h"
 
-STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo           = NULL;
-STATIC UINT32                mBufferSize            = 0;
-STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress            = 0;
-STATIC EFI_BOOT_SERVICES     *mBS                   = NULL;
-STATIC EFI_EVENT             mExitBootServicesEvent = NULL;
+STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo                 = NULL;
+STATIC UINT32                mBufferSize                  = 0;
+STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress                  = 0;
+STATIC EFI_BOOT_SERVICES     *mBS                         = NULL;
+STATIC EFI_EVENT             mExitBootServicesEvent       = NULL;
+STATIC EFI_EVENT             mAdvancedLoggerProtocolEvent = NULL;
+STATIC VOID                  *mAdvancedLoggerProtocolReg  = NULL;
 
 /**
     CheckAddress
@@ -76,8 +78,60 @@ ValidateInfoBlock (
 }
 
 /**
+  Update cached logger info from the first Advanced Logger Protocol instance found.
+
+  @retval EFI_SUCCESS           Logger info successfully updated.
+  @retval EFI_NOT_FOUND         The advanced logger protocol was not found.
+  @retval EFI_INVALID_PARAMETER Invalid protocol signature or version.
+
+**/
+STATIC
+EFI_STATUS
+UpdateLoggerInfoFromProtocol (
+  VOID
+  )
+{
+  ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
+  EFI_STATUS                Status;
+
+  if (mBS == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  Status = mBS->LocateProtocol (
+                  &gAdvancedLoggerProtocolGuid,
+                  NULL,
+                  (VOID **)&LoggerProtocol
+                  );
+  if (EFI_ERROR (Status) || (LoggerProtocol == NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  ASSERT (LoggerProtocol->Signature == ADVANCED_LOGGER_PROTOCOL_SIGNATURE);
+  ASSERT (LoggerProtocol->Version == ADVANCED_LOGGER_PROTOCOL_VERSION);
+
+  if ((LoggerProtocol->Signature != ADVANCED_LOGGER_PROTOCOL_SIGNATURE) ||
+      (LoggerProtocol->Version != ADVANCED_LOGGER_PROTOCOL_VERSION))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
+
+  if (mLoggerInfo != NULL) {
+    mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
+    // Force the buffer size to be reevaluated
+    mBufferSize = 0;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
     Get the Logger Information block
 
+    @return   A pointer to the active advanced logger info structure or NULL if the structure is
+              invalid.
  **/
 ADVANCED_LOGGER_INFO *
 EFIAPI
@@ -85,25 +139,8 @@ AdvancedLoggerGetLoggerInfo (
   VOID
   )
 {
-  ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
-  EFI_STATUS                Status;
-
-  if ((mLoggerInfo == NULL) && (mBS != NULL)) {
-    Status = mBS->LocateProtocol (
-                    &gAdvancedLoggerProtocolGuid,
-                    NULL,
-                    (VOID **)&LoggerProtocol
-                    );
-    if (!EFI_ERROR (Status) && (LoggerProtocol != NULL)) {
-      ASSERT (LoggerProtocol->Signature == ADVANCED_LOGGER_PROTOCOL_SIGNATURE);
-      ASSERT (LoggerProtocol->Version == ADVANCED_LOGGER_PROTOCOL_VERSION);
-
-      mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
-
-      if (mLoggerInfo != NULL) {
-        mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
-      }
-    }
+  if (mLoggerInfo == NULL) {
+    UpdateLoggerInfoFromProtocol ();
   }
 
   if (!ValidateInfoBlock ()) {
@@ -128,6 +165,25 @@ AdvancedLoggerGetPhase (
   )
 {
   return ADVANCED_LOGGER_PHASE_RUNTIME;
+}
+
+/**
+  Notification function for Advanced Logger Protocol installation.
+
+  This function is called when the Advanced Logger Protocol is installed or reinstalled
+  (e.g., during buffer migration). It updates the globally cached logger to the new logger buffer.
+
+  @param[in]  Event    Event whose notification function is being invoked.
+  @param[in]  Context  Pointer to the notification function's context.
+**/
+VOID
+EFIAPI
+OnAdvancedLoggerProtocolNotification (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  UpdateLoggerInfoFromProtocol ();
 }
 
 /**
@@ -177,9 +233,34 @@ DxeRuntimeAdvancedLoggerLibConstructor (
   mBS = SystemTable->BootServices;
   AdvancedLoggerGetLoggerInfo ();
 
-  ASSERT (mLoggerInfo != NULL);
+  //
+  // Register a notification function for Advanced Logger Protocol installation.
+  //
+  Status = mBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  OnAdvancedLoggerProtocolNotification,
+                  NULL,
+                  &mAdvancedLoggerProtocolEvent
+                  );
 
-  if (mLoggerInfo != 0) {
+  if (!EFI_ERROR (Status)) {
+    Status = mBS->RegisterProtocolNotify (
+                    &gAdvancedLoggerProtocolGuid,
+                    mAdvancedLoggerProtocolEvent,
+                    &mAdvancedLoggerProtocolReg
+                    );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - Register Protocol Notify failed. Code = %r\n", __func__, Status));
+      mBS->CloseEvent (mAdvancedLoggerProtocolEvent);
+      mAdvancedLoggerProtocolEvent = NULL;
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a - Create Event for Protocol Notify failed. Code = %r\n", __func__, Status));
+  }
+
+  if (mLoggerInfo != NULL) {
     //
     // Register notify function for ExitBootServices.
     //
@@ -192,7 +273,7 @@ DxeRuntimeAdvancedLoggerLibConstructor (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a - Create Event for Address Change failed. Code = %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a - Create Event for Exit Boot Services failed. Code = %r\n", __FUNCTION__, Status));
     }
   }
 
@@ -217,6 +298,10 @@ DxeRuntimeAdvancedLoggerLibDestructor (
 {
   if (mExitBootServicesEvent != NULL) {
     mBS->CloseEvent (mExitBootServicesEvent);
+  }
+
+  if (mAdvancedLoggerProtocolEvent != NULL) {
+    mBS->CloseEvent (mAdvancedLoggerProtocolEvent);
   }
 
   return EFI_SUCCESS;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -273,7 +273,7 @@ DxeRuntimeAdvancedLoggerLibConstructor (
                     );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a - Create Event for Exit Boot Services failed. Code = %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a - Create Event for Exit Boot Services failed. Code = %r\n", __func__, Status));
     }
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Smm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Smm/AdvancedLoggerLib.c
@@ -57,7 +57,7 @@ SmmInitializeLoggerInfo (
     // If mSmmLoggerProtocol is NULL at this point, there is no Advanced Logger for SMM modules.
     //
 
-    DEBUG ((DEBUG_INFO, "%a: SmmLoggerProtocol=%p, code=%r\n", __FUNCTION__, mSmmLoggerProtocol, Status));
+    DEBUG ((DEBUG_INFO, "%a: SmmLoggerProtocol=%p, code=%r\n", __func__, mSmmLoggerProtocol, Status));
   }
 }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
@@ -176,6 +176,10 @@ AdvancedLoggerGetLoggerInfo (
 {
   SmmInitializeLoggerInfo ();
 
+  if ((mLoggerInfo != NULL) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+    DEBUG ((DEBUG_INFO, "MmCore %a: Logger Update. LoggerInfo=%p\n", __func__, mLoggerInfo));
+  }
+
   return mLoggerInfo;
 }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
@@ -156,7 +156,7 @@ SmmInitializeLoggerInfo (
     // If mLoggerInfo is NULL at this point, there is no Advanced Logger.
     //
 
-    DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __FUNCTION__, mLoggerInfo, Status));
+    DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __func__, mLoggerInfo, Status));
   }
 
   if (!ValidateInfoBlock ()) {
@@ -239,7 +239,7 @@ SmmCoreAdvancedLoggerLibConstructor (
                     &mAdvLoggerProtocol.AdvLoggerProtocol
                     );
 
-  DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __FUNCTION__, mLoggerInfo, Status));
+  DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __func__, mLoggerInfo, Status));
   ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;


### PR DESCRIPTION
## Description

Right now, the PEI Core instance of AdvancedLoggerLib will always allocate the logger buffer as `EfiRuntimeServicesData`. This means it is not allocated into the DXE Core managed RT Services Data memory bucket. The DXE Core instance of AdvancedLoggerLib either continues to use this buffer it is provided or allocates a new `EfiReservedMemoryType` buffer.

This change always allocates a `EfiReservedMemoryType` buffer in the DXE Core instance to ensure it is allocated from the reserved memory type buckets setup by the DXE Core. The PEI Core logger buffer is updated to be `EfiBootServicesData` so it does not affect runtime allocations.

The logger buffer will not attempt to be migrated if `PcdAdvancedLoggerFixedInRAM` is `FALSE`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- Boot on a virtual and physical Intel platform and confirm the logger is functional
  - Note: Has not been tested on an ARM64 platform yet

## Integration Instructions

- N/A