### PR TITLE
Add allow list to DMAProtectionAudit tests for IVRS.

### DIFF
--- a/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/IVRS/DMAProtectionTestArch.c
+++ b/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/IVRS/DMAProtectionTestArch.c
@@ -26,6 +26,39 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /// ================================================================================================
 /// ================================================================================================
 ///
+/// HELPER FUNCTIONS
+///
+/// ================================================================================================
+/// ================================================================================================
+
+/**
+ * Check if the given memory type is allowed.
+ *
+ * @param MemoryType The memory type to check.
+ * @return TRUE if the memory type is allowed, FALSE otherwise.
+ *         Returns TRUE if MemoryType is in the allowed list: [EfiReservedMemoryType, EfiACPIMemoryNVS]
+ */
+BOOLEAN
+IsMemoryTypeAllowed (
+  IN EFI_MEMORY_TYPE  MemoryType
+  )
+{
+  UINTN  Index;
+
+  EFI_MEMORY_TYPE  AllowedMemoryTypes[] = { EfiReservedMemoryType, EfiACPIMemoryNVS };
+
+  for (Index = 0; Index < ARRAY_SIZE (AllowedMemoryTypes); Index++) {
+    if (MemoryType == AllowedMemoryTypes[Index]) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/// ================================================================================================
+/// ================================================================================================
+///
 /// TEST CASES
 ///
 /// ================================================================================================
@@ -47,13 +80,6 @@ CheckExcludedRegions (
   UINT32                 EfiDescriptorVersion;
   IVMDListNode           *Head;
   IVMDListNode           *Current;
-  UINTN                  MemoryTypesIndex;
-  BOOLEAN                IsAllowed;
-  UINTN                  AllowedMemoryTypesCount;
-
-  EFI_MEMORY_TYPE  AllowedMemoryTypes[] = { EfiReservedMemoryType, EfiACPIMemoryNVS };
-
-  AllowedMemoryTypesCount = sizeof (AllowedMemoryTypes) / sizeof (AllowedMemoryTypes[0]);
 
   //
   // Step 1: Get IVRS Table
@@ -114,15 +140,7 @@ CheckExcludedRegions (
        && ((EfiMemNext->PhysicalStart + EFI_PAGE_SIZE * EfiMemNext->NumberOfPages) >= (Current->IVMD->IVMDStartAddress + Current->IVMD->IVMDMemoryBlockLength)))
     {
       // Verify memory range type is in the allow list
-      IsAllowed = FALSE;
-      for (MemoryTypesIndex = 0; MemoryTypesIndex < AllowedMemoryTypesCount; MemoryTypesIndex++) {
-        if (EfiMemNext->Type == (UINT32)AllowedMemoryTypes[MemoryTypesIndex]) {
-          IsAllowed = TRUE;
-          break;
-        }
-      }
-
-      UT_ASSERT_TRUE (IsAllowed);
+      UT_ASSERT_TRUE (IsMemoryTypeAllowed (EfiMemNext->Type));
       UT_LOG_INFO ("IVMDs between %X and %X found with type %d\n", Current->IVMD->IVMDStartAddress, Current->IVMD->IVMDStartAddress + Current->IVMD->IVMDMemoryBlockLength, EfiMemNext->Type);
 
       // Move on to next IVMD and start search at beginning of memory map again

--- a/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/IVRS/DMAProtectionTestArch.c
+++ b/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/IVRS/DMAProtectionTestArch.c
@@ -47,6 +47,13 @@ CheckExcludedRegions (
   UINT32                 EfiDescriptorVersion;
   IVMDListNode           *Head;
   IVMDListNode           *Current;
+  UINTN                  MemoryTypesIndex;
+  BOOLEAN                IsAllowed;
+  UINTN                  AllowedMemoryTypesCount;
+
+  EFI_MEMORY_TYPE  AllowedMemoryTypes[] = { EfiReservedMemoryType, EfiACPIMemoryNVS };
+
+  AllowedMemoryTypesCount = sizeof (AllowedMemoryTypes) / sizeof (AllowedMemoryTypes[0]);
 
   //
   // Step 1: Get IVRS Table
@@ -106,9 +113,17 @@ CheckExcludedRegions (
     if (  (EfiMemNext->PhysicalStart <= Current->IVMD->IVMDStartAddress)
        && ((EfiMemNext->PhysicalStart + EFI_PAGE_SIZE * EfiMemNext->NumberOfPages) >= (Current->IVMD->IVMDStartAddress + Current->IVMD->IVMDMemoryBlockLength)))
     {
-      // Verify memory range is marked as reserved
-      UT_ASSERT_EQUAL (EfiMemNext->Type, EfiACPIMemoryNVS);
-      UT_LOG_INFO ("IVMDs between %X and %X found with type EfiACPIMemoryNVS\n", Current->IVMD->IVMDStartAddress, Current->IVMD->IVMDStartAddress + Current->IVMD->IVMDMemoryBlockLength);
+      // Verify memory range type is in the allow list
+      IsAllowed = FALSE;
+      for (MemoryTypesIndex = 0; MemoryTypesIndex < AllowedMemoryTypesCount; MemoryTypesIndex++) {
+        if (EfiMemNext->Type == (UINT32)AllowedMemoryTypes[MemoryTypesIndex]) {
+          IsAllowed = TRUE;
+          break;
+        }
+      }
+
+      UT_ASSERT_TRUE (IsAllowed);
+      UT_LOG_INFO ("IVMDs between %X and %X found with type %d\n", Current->IVMD->IVMDStartAddress, Current->IVMD->IVMDStartAddress + Current->IVMD->IVMDMemoryBlockLength, EfiMemNext->Type);
 
       // Move on to next IVMD and start search at beginning of memory map again
       EfiMemNext = EfiMemoryMap;

--- a/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/README.md
+++ b/UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/README.md
@@ -12,8 +12,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 Shell based UEFI unit test based off of the UnitTestFrameworkPkg that test for:
 
 1. IOMMU status register shows IOMMU enabled
-2. All excluded regions are set as EfiReservedMemoryType(VTd)/EfiACPIMemoryNVS(IVRS)
-3. Bus mastering enabled (BME) is disabled on ExitBootServices. Because we can no longer write to file after ExitBootServices
+2. All excluded regions are set as EfiReservedMemoryType for VTd.
+3. All excluded regions are set as (EfiReservedMemoryType or EfiACPIMemoryNVS) for IVRS.
+4. Bus mastering enabled (BME) is disabled on ExitBootServices. Because we can no longer write to file after ExitBootServices
     a variable is used to store the test state and the machine.
 
 Note: this unit test requires a restart to finish its testing. If you plan to use this unit test in automation make sure


### PR DESCRIPTION
## Description

Add allow list to DMAProtectionAudit tests for IVRS.

Allow list to now include [EfiReservedMemoryType, EfiACPIMemoryNVS]

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A