### PR TITLE
UefiHidDxeV2: fix cargo clippy issues for toolchain 1.92.0

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer/absolute_pointer.rs
@@ -351,14 +351,14 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            if wait_for_ptr.is_none() {
-                // This is a test, so we expect the wait_for_pointer function to be set.
-                panic!("wait_for_pointer function should be set");
-            } else {
+            if let Some(value) = wait_for_ptr {
                 assert!(ptr::fn_addr_eq(
-                    wait_for_ptr.unwrap(),
+                    value,
                     PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
                 ));
+            } else {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
             }
             assert_ne!(context, ptr::null_mut());
             unsafe {
@@ -436,14 +436,14 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            if wait_for_ptr.is_none() {
-                // This is a test, so we expect the wait_for_pointer function to be set.
-                panic!("wait_for_pointer function should be set");
-            } else {
+            if let Some(value) = wait_for_ptr {
                 assert!(ptr::fn_addr_eq(
-                    wait_for_ptr.unwrap(),
+                    value,
                     PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
                 ));
+            } else {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
             }
             assert_ne!(context, ptr::null_mut());
             unsafe {
@@ -528,14 +528,14 @@ mod test {
 
         // expected on PointerHidHandler::initialize().
         boot_services.expect_create_event().returning(|_, _, wait_for_ptr, context, event_ptr| {
-            if wait_for_ptr.is_none() {
-                // This is a test, so we expect the wait_for_pointer function to be set.
-                panic!("wait_for_pointer function should be set");
-            } else {
+            if let Some(value) = wait_for_ptr {
                 assert!(ptr::fn_addr_eq(
-                    wait_for_ptr.unwrap(),
+                    value,
                     PointerContext::wait_for_pointer as extern "efiapi" fn(efi::Event, *mut c_void)
                 ));
+            } else {
+                // This is a test, so we expect the wait_for_pointer function to be set.
+                panic!("wait_for_pointer function should be set");
             }
             assert_ne!(context, ptr::null_mut());
             unsafe {


### PR DESCRIPTION
## Description

* Update UefiHidDxeV2 tests for absolute_pointer to meet clippy requirements.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
* Local CI validation and cargo testing with rust toolchain 1.92.0

## Integration Instructions

N/A
