### PR TITLE
MfciPkg: Fix MfciDxeRoT unit test.

### DIFF
--- a/MfciPkg/MfciDxe/MfciDxeRoT.c
+++ b/MfciPkg/MfciDxe/MfciDxeRoT.c
@@ -240,6 +240,7 @@ VerifyPolicyAndChange (
   // Step 5: reboot!
   ResetSystemWithSubtype (EfiResetCold, &gMfciPolicyChangeResetGuid);
   CpuDeadLoop ();
+  return;
 
 Exit:
   // Non-change: trigger the variable policies

--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.c
@@ -54,6 +54,7 @@ EFI_RUNTIME_SERVICES  mMockRuntime = {
 
 extern MFCI_POLICY_TYPE  mCurrentPolicy;
 extern BOOLEAN           mVarPolicyRegistered;
+BOOLEAN                  mSystemResetCalled;
 
 EFI_STATUS
 EFIAPI
@@ -83,6 +84,28 @@ NotifyMfciPolicyChange (
   return (EFI_STATUS)mock ();
 }
 
+VOID
+EFIAPI
+ResetSystemWithSubtype (
+  IN EFI_RESET_TYPE  ResetType,
+  IN CONST  GUID     *ResetSubtype
+  )
+{
+  check_expected (ResetType);
+  check_expected_ptr (ResetSubtype);
+  mSystemResetCalled = TRUE;
+  return;
+}
+
+VOID
+EFIAPI
+CpuDeadLoop (
+  VOID
+  )
+{
+  return;
+}
+
 EFI_STATUS
 EFIAPI
 InitPublicInterface (
@@ -100,6 +123,7 @@ VerifyPrerequisite (
 {
   mCurrentPolicy       = CUSTOMER_STATE;
   mVarPolicyRegistered = TRUE;
+  mSystemResetCalled   = FALSE;
   return UNIT_TEST_PASSED;
 }
 
@@ -111,6 +135,7 @@ VerifyCleanup (
 {
   mCurrentPolicy       = CUSTOMER_STATE;
   mVarPolicyRegistered = FALSE;
+  mSystemResetCalled   = FALSE;
 }
 
 VOID
@@ -127,8 +152,7 @@ UnitTestVerifyAndChangeNormal (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  BASE_LIBRARY_JUMP_BUFFER  JumpBuf;
-  MFCI_POLICY_TYPE          Policy = STD_ACTION_TPM_CLEAR;
+  MFCI_POLICY_TYPE  Policy = STD_ACTION_TPM_CLEAR;
 
   will_return (MfciRetrieveTargetPolicy, STD_ACTION_TPM_CLEAR);
   will_return (MfciRetrieveTargetPolicy, EFI_SUCCESS);
@@ -143,11 +167,9 @@ UnitTestVerifyAndChangeNormal (
 
   expect_value (ResetSystemWithSubtype, ResetType, EfiResetCold);
   expect_value (ResetSystemWithSubtype, ResetSubtype, &gMfciPolicyChangeResetGuid);
-  will_return (ResetSystemWithSubtype, &JumpBuf);
 
-  if (!SetJump (&JumpBuf)) {
-    VerifyPolicyAndChange (NULL, NULL);
-  }
+  VerifyPolicyAndChange (NULL, NULL);
+  UT_ASSERT_TRUE (mSystemResetCalled)
 
   return UNIT_TEST_PASSED;
 }
@@ -203,8 +225,7 @@ UnitTestVerifyAndChangeTargetPolicyFailedNonCustomer (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  BASE_LIBRARY_JUMP_BUFFER  JumpBuf;
-  MFCI_POLICY_TYPE          Policy = CUSTOMER_STATE;
+  MFCI_POLICY_TYPE  Policy = CUSTOMER_STATE;
 
   mCurrentPolicy = STD_ACTION_TPM_CLEAR;
 
@@ -221,11 +242,9 @@ UnitTestVerifyAndChangeTargetPolicyFailedNonCustomer (
 
   expect_value (ResetSystemWithSubtype, ResetType, EfiResetCold);
   expect_value (ResetSystemWithSubtype, ResetSubtype, &gMfciPolicyChangeResetGuid);
-  will_return (ResetSystemWithSubtype, &JumpBuf);
 
-  if (!SetJump (&JumpBuf)) {
-    VerifyPolicyAndChange (NULL, NULL);
-  }
+  VerifyPolicyAndChange (NULL, NULL);
+  UT_ASSERT_TRUE (mSystemResetCalled)
 
   return UNIT_TEST_PASSED;
 }

--- a/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.inf
+++ b/MfciPkg/MfciDxe/Test/MfciVerifyPolicyAndChangeRoTHostTest.inf
@@ -38,7 +38,6 @@
   VariablePolicyHelperLib
   MfciRetrievePolicyLib
   MfciRetrieveTargetPolicyLib
-  ResetUtilityLib
   UefiRuntimeServicesTableLib
   MuTelemetryHelperLib
 
@@ -58,3 +57,8 @@
   gMuVarPolicyWriteOnceStateVarGuid   ## CONSUMES ## GUID ## Variable namespace
   gMfciPolicyChangeResetGuid          ## CONSUMES
   gMfciHobGuid                        ## CONSUMES
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /DCpuDeadLoop=MockCpuDeadLoop
+  GCC:*_*_*_CC_FLAGS = -D CpuDeadLoop=MockCpuDeadLoop
+  


### PR DESCRIPTION

## Description

Unit tests are failing due to use of setjump/longjump.

There are multiple bug reports about the use of setjump/longjump when dealing with address sanitizer. There are a lot of false positives triggered because the address sanitizer is unable to verify the stack when it is directly manipulated.

Fixing the failing case by removing setjump/longjump from the failing unit test.


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Pipeline is failing.
Local CI fails.

After integrating changes, local CI is passing.

## Integration Instructions
No Integration necessary.