### PR TITLE
AdvLoggerPkg: Fix AdvancedLogDumper HII initialization bug

### DIFF
--- a/AdvLoggerPkg/Application/AdvancedLogDumper/AdvancedLogDumper.inf
+++ b/AdvLoggerPkg/Application/AdvancedLogDumper/AdvancedLogDumper.inf
@@ -44,10 +44,13 @@
 [LibraryClasses]
   AdvancedLoggerAccessLib
   DebugLib
+  HiiLib
   MemoryAllocationLib
   PcdLib
   PrintLib
   ShellLib
   UefiApplicationEntryPoint
+  UefiBootServicesTableLib
+  UefiHiiServicesLib
   UefiLib
   UefiRuntimeServicesTableLib

--- a/AdvLoggerPkg/Application/AdvancedLogDumper/AdvancedLogDumperDynamicCommand.inf
+++ b/AdvLoggerPkg/Application/AdvancedLogDumper/AdvancedLogDumperDynamicCommand.inf
@@ -51,6 +51,7 @@
   UefiRuntimeServicesTableLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
+  UefiHiiServicesLib
   HiiLib
 
 [Protocols]


### PR DESCRIPTION
## Description

Commit 005cfdd5b9942e98ff6218a7b06360f6b7606396 added HII support to AdvancedLogDumper but did not link UefiHiiServicesLib to the application.

Running the EFI app will give an assert similar to the following:

```
INFO - ASSERT_EFI_ERROR (Status = Invalid Parameter)
INFO - ASSERT [AdvancedLogDumper]
  AdvLoggerPkg\Application\AdvancedLogDumper\LogDumperCommon.c(337):
    !(((RETURN_STATUS)(Status)) >= 0x8000000000000000ULL)
```

UefiHiiServicesLib needs to be linked (added to the INF file) for gHiiDatabase to be initialized properly.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run the `AdvancedLogDumper` EFI application before and after the change
  - It dumps the log successfully after the change

## Integration Instructions

- N/A