### PR TITLE
AdvLoggerPkg: Minor fix in DecodeUefiLog.py _GetNextMessageBlock()

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -606,6 +606,10 @@ class AdvLogParser ():
 
         (MessageEntry, NextMessage) = self._ReadMessageEntry(LoggerInfo)
 
+        if MessageEntry is None:
+            print("Invalid message signature at offset 0x%x" % InFile.tell())
+            raise Exception("Message block has the wrong signature at offset 0x%x" % InFile.tell())
+
         if MessageEntry["Signature"] != 'ALMS' and MessageEntry["Signature"] != 'ALM2':
             print("Log signature was incorrect.  Should be either 'ALMS' or 'ALM2', was '%s'" % MessageEntry["Signature"])
             raise Exception("Message Block has wrong signature at offset 0x%X" % InFile.tell())


### PR DESCRIPTION
## Description

This is a minor issue that has been present in the script for a very long time.

The function calls `self._ReadMessageEntry()` to read the next message entry from the log file. That function can return `None` for the `MessageEntry` if it encounters an invalid signature.

This function needs to handle that case properly to avoid trying to access fields of a `None` object, which would lead to an `AttributeError`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Force `self._ReadMessageEntry()` to enter the case where it returns `(None, None)` and verify the `AttributeError` does not occur.

## Integration Instructions

- N/A

---

> Note: I'd normally use f-strings here, but this follows the convention used in the rest of the file.