### PR TITLE
MfciPkg: Fix alignment handling of multiple XDR certs in PCD

### DIFF
--- a/MfciPkg/MfciDxe/MfciDxe.c
+++ b/MfciPkg/MfciDxe/MfciDxe.c
@@ -667,8 +667,7 @@ ValidateBlobWithXdrCertificates (
       break;
     }
 
-    PublicKeyDataCurrent = PublicKeyData + PublicKeyDataLength;
-    PublicKeyDataCurrent = (UINT8 *)ALIGN_POINTER (PublicKeyDataCurrent, sizeof (UINT32));
+    PublicKeyDataCurrent = PublicKeyData + ALIGN_VALUE (PublicKeyDataLength, sizeof (UINT32));
   }
 
   // above is inspired/borrowed from FmpDxe.c


### PR DESCRIPTION
## Description

Fixes an issue where XDR certificates may not be correctly parsed in MfciDxe - ValidateBlobWithXdrCertificates when the buffer containing the certs is not aligned to a 4-byte boundary, even if the certs are aligned within the buffer itself. The alignment should be taken with respect to the start of the buffer, rather than the absolute position in memory.

Fixes #814 

Related fix in EDK2 FmpDevicePkg: https://github.com/tianocore/edk2/pull/11529

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified using the second cert on a platform with the cert buffer pointer forced to be unaligned.

Before fix:
```
00:00:06.656 : [DXE  ] [INFO] MfciDxe: VerifyPolicyAndChange() - Enter
00:00:06.659 : [DXE  ] [INFO] VerifyPolicyAndChange - Step 2: Check current policy related variables.
00:00:06.660 : [DXE  ] [INFO] VerifyPolicyAndChange - Get current MFCI Policy blob - Not Found
00:00:06.662 : [DXE  ] [INFO] VerifyPolicyAndChange - Clear other current variables returned, proceeding to TARGET step.
00:00:06.662 : [DXE  ] [ERR ] VerifyPolicyAndChange - Verify targeting step!
00:00:06.663 : [DXE  ] [INFO] ValidateBlobWithXdrCertificates: Certificate #1 [E8CDE29E..E8CDF126].
00:00:06.663 : [DXE  ] [INFO] ValidateBlob()
00:00:06.663 : [DXE  ] [INFO] ValidateSignature()
00:00:06.663 : [DXE  ] [ERR ] Pkcs7Verify() returns FALSE
00:00:06.663 : [DXE  ] [ERR ] ValidateSignature() returned EFI_ERROR: Security Violation
00:00:06.663 : [DXE  ] [INFO] ValidateBlobWithXdrCertificates: Certificate #2 [E8CDE9B4..E8CDF126].
00:00:06.663 : [DXE  ] [INFO] ValidateBlob()
00:00:06.663 : [DXE  ] [INFO] ValidateSignature()
00:00:06.663 : [DXE  ] [ERR ] SignedPolicy NULL or Size == 0, or TrustAnchorCert NULL or Size 0, or EKU NULL
00:00:06.664 : [DXE  ] [ERR ] ValidateSignature() returned EFI_ERROR: Invalid Parameter
00:00:06.664 : [DXE  ] [INFO] ValidateBlobWithXdrCertificates: Certificate #3 [E8CDE9B8..E8CDF126].
00:00:06.664 : [DXE  ] [ERR ] ValidateBlobWithXdrCertificates - PcdMfciPkcs7CertBufferXdr size incorrect: PublicKeyData(0xE8CDE9BC) PublicKeyDataLength(0x76C3082) PublicKeyDataXdrEnd(0xE8CDF126)
00:00:06.664 : [DXE  ] [ERR ] VerifyPolicyAndChange - Target blob validation failed - Aborted.
```

With fix:
```
00:00:06.944 : [DXE  ] [INFO] MfciDxe: VerifyPolicyAndChange() - Enter
00:00:06.947 : [DXE  ] [INFO] VerifyPolicyAndChange - Step 2: Check current policy related variables.
00:00:06.948 : [DXE  ] [INFO] ValidateBlobWithXdrCertificates: Certificate #1 [E8CDE1AE..E8CDF036].
00:00:06.948 : [DXE  ] [INFO] ValidateBlob()
00:00:06.948 : [DXE  ] [INFO] ValidateSignature()
00:00:06.949 : [DXE  ] [ERR ] Pkcs7Verify() returns FALSE
00:00:06.949 : [DXE  ] [ERR ] ValidateSignature() returned EFI_ERROR: Security Violation
00:00:06.949 : [DXE  ] [INFO] ValidateBlobWithXdrCertificates: Certificate #2 [E8CDE8C6..E8CDF036].
00:00:06.949 : [DXE  ] [INFO] ValidateBlob()
00:00:06.949 : [DXE  ] [INFO] ValidateSignature()
00:00:06.950 : [DXE  ] [INFO] SanityCheckSignedPolicy()
00:00:06.950 : [DXE  ] [INFO] SanityCheckPolicy()
00:00:06.950 : [DXE  ] [INFO] MfciDxe: VerifyTargeting() - Enter
00:00:06.950 : [DXE  ] [INFO] ExtractChar16()
00:00:06.950 : [DXE  ] [INFO] ExtractChar16()
00:00:06.951 : [DXE  ] [INFO] ExtractChar16()
00:00:06.951 : [DXE  ] [INFO] ExtractChar16()
00:00:06.952 : [DXE  ] [INFO] ExtractChar16()
00:00:06.952 : [DXE  ] [INFO] ExtractUint64()
00:00:06.953 : [DXE  ] [INFO] ExtractUint64()
00:00:06.953 : [DXE  ] [ERR ] VerifyPolicyAndChange - Verify targeting step!
00:00:06.953 : [DXE  ] [INFO] VerifyPolicyAndChange - No target blob found, bail here.
```


## Integration Instructions

N/A
