### PR TITLE
MsWheaPkg: Change debug prints to avoid confusion

### DIFF
--- a/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportDxe.c
+++ b/MsWheaPkg/MsWheaReport/Dxe/MsWheaReportDxe.c
@@ -211,11 +211,11 @@ MsWheaReportHandlerDxe (
   if (ReadyToWriteVariable ()) {
     // Variable service is ready, store to HwErrRecXXXX
     Status = MsWheaReportHERAdd (MsWheaEntryMD);
-    DEBUG ((DEBUG_INFO, "%a: error record written to flash - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_INFO, "%a: Telemetry record written to flash - %r\n", __FUNCTION__, Status));
   } else {
     // Add to linked list, similar to hob list
     Status = MsWheaAddReportEvent (&mMsWheaEntryList, MsWheaEntryMD);
-    DEBUG ((DEBUG_INFO, "%a: error record added to linked list - %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_INFO, "%a: Telemetry record added to linked list - %r\n", __FUNCTION__, Status));
   }
 
 Cleanup:

--- a/MsWheaPkg/MsWheaReport/Smm/MsWheaReportMm.c
+++ b/MsWheaPkg/MsWheaReport/Smm/MsWheaReportMm.c
@@ -171,7 +171,7 @@ MsWheaReportHandlerMm (
 
   // Variable service is ready, store to HwErrRecXXXX
   Status = MsWheaReportHERAdd (MsWheaEntryMD);
-  DEBUG ((DEBUG_INFO, "%a: error record written to flash - %r\n", __FUNCTION__, Status));
+  DEBUG ((DEBUG_INFO, "%a: Telemetry record written to flash - %r\n", __FUNCTION__, Status));
 
 Cleanup:
   return Status;


### PR DESCRIPTION
## Description

The current debug output labels all `HwErrRec` entries as error records. While technically accurate given the “Hardware Error Record” naming, this can be misleading, as some entries are informational rather than actual errors.

This change updates the debug output to use “telemetry record” instead, reducing the risk of confusion.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Debug print change only, non-functional.

## Integration Instructions

N/A