### PR TITLE
Configure watchdog interrupt for ARM platform

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -720,10 +720,10 @@ CpuArchBspSleepPrep (
 
   // Watchdog interrupt is level and active high
   Status = mInterruptProtocol->SetTriggerType (
-                  mInterruptProtocol,
-                  PcdGet32 (PcdGenericWatchdogEl2IntrNum),
-                  EFI_HARDWARE_INTERRUPT2_TRIGGER_LEVEL_HIGH
-                  );
+                                 mInterruptProtocol,
+                                 PcdGet32 (PcdGenericWatchdogEl2IntrNum),
+                                 EFI_HARDWARE_INTERRUPT2_TRIGGER_LEVEL_HIGH
+                                 );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a setting trigger type failed - %r.\n", __FUNCTION__, Status));
     goto Done;

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -31,6 +31,8 @@
 #include <Protocol/WatchdogTimer.h>
 #include <Guid/ArmMpCoreInfo.h>
 #include <Library/MuArmGicExLib.h>
+#include <Protocol/HardwareInterrupt2.h>
+
 #include "MpManagementInternal.h"
 
 /* Features flags for CPU SUSPEND power state parameter format. Bits [1:1] */
@@ -52,6 +54,10 @@
 #define PSTATE_TYPE_POWERDOWN   0x1
 
 #define AP_TEMP_STACK_SIZE  EFI_PAGE_SIZE
+
+/* GIC specific information */
+#define FIRST_SPI_INTID                  32
+#define GIC_IROUTER_REGISTER_SIZE_BYTES  8
 
 /*
   Architectural metadata structure for ARM context losing resume routines.
@@ -81,6 +87,7 @@ UINT64                            *gApStacksBase      = NULL;
 CONST UINT64                      gApStackSize        = AP_TEMP_STACK_SIZE;
 UINT64                            mWatchDogTimer      = 0;
 EFI_WATCHDOG_TIMER_ARCH_PROTOCOL  *mWatchDogProtocol  = NULL;
+EFI_HARDWARE_INTERRUPT2_PROTOCOL  *mInterruptProtocol = NULL;
 
 /**
   EFI_CPU_INTERRUPT_HANDLER that is called when a processor interrupt occurs.
@@ -667,6 +674,8 @@ CpuArchBspSleepPrep (
   IN UINTN  TimeoutInMicrosecond
   )
 {
+  UINT64      MpId;
+  UINT64      CpuTarget;
   EFI_STATUS  Status;
 
   if (mWatchDogProtocol == NULL) {
@@ -676,7 +685,7 @@ CpuArchBspSleepPrep (
                     (VOID **)&mWatchDogProtocol
                     );
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a locating watch dog protocol failed - %r.\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a locating watchdog protocol failed - %r.\n", __FUNCTION__, Status));
       goto Done;
     }
   }
@@ -689,13 +698,50 @@ CpuArchBspSleepPrep (
     DEBUG ((DEBUG_INFO, "%a got current timer period - %lld.\n", __FUNCTION__, mWatchDogTimer));
   }
 
-  // Set the timeout in watch dog timer
+  // Set the timeout in watchdog timer
   Status = mWatchDogProtocol->SetTimerPeriod (mWatchDogProtocol, TimeoutInMicrosecond * 10);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a set timer period failed - %r.\n", __FUNCTION__, Status));
     goto Done;
   }
 
+  // Get the hardware interrupt protocol
+  if (mInterruptProtocol == NULL) {
+    Status = gBS->LocateProtocol (
+                    &gHardwareInterrupt2ProtocolGuid,
+                    NULL,
+                    (VOID **)&mInterruptProtocol
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a locating hardware interrupt protocol failed - %r.\n", __FUNCTION__, Status));
+      goto Done;
+    }
+  }
+
+  // Watchdog interrupt is level and active high
+  Status = mInterruptProtocol->SetTriggerType (
+                  mInterruptProtocol,
+                  PcdGet32 (PcdGenericWatchdogEl2IntrNum),
+                  EFI_HARDWARE_INTERRUPT2_TRIGGER_LEVEL_HIGH
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a setting trigger type failed - %r.\n", __FUNCTION__, Status));
+    goto Done;
+  }
+
+  // All cores will power off so we need affinity routing instead of IRM.
+  // The receiving core for the interrupt will be the bsp.
+  MpId      = ArmReadMpidr ();
+  CpuTarget = MpId &
+              (ARM_CORE_AFF0 | ARM_CORE_AFF1 | ARM_CORE_AFF2 | ARM_CORE_AFF3);
+  MmioWrite64 (
+    PcdGet64 (PcdGicDistributorBase) +
+    ARM_GICD_IROUTER +
+    ((PcdGet32 (PcdGenericWatchdogEl2IntrNum) - FIRST_SPI_INTID) * GIC_IROUTER_REGISTER_SIZE_BYTES),
+    CpuTarget
+    );
+
+  // Enable the watchdog interrupt
   ArmGicEnableInterrupt (PcdGet64 (PcdGicDistributorBase), PcdGet64 (PcdGicRedistributorsBase), PcdGet32 (PcdGenericWatchdogEl2IntrNum));
 
 Done:

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.inf
@@ -38,6 +38,7 @@
   MdeModulePkg/MdeModulePkg.dec
   MsCorePkg/MsCorePkg.dec
   UefiTestingPkg/UefiTestingPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
 
 [Packages.AARCH64]
   ArmPkg/ArmPkg.dec
@@ -61,7 +62,7 @@
   gArmTokenSpaceGuid.PcdGicRedistributorsBase
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
   gArmTokenSpaceGuid.PcdGicSgiIntId
-    gUefiTestingPkgTokenSpaceGuid.PcdGicPerPackageOffset
+  gUefiTestingPkgTokenSpaceGuid.PcdGicPerPackageOffset
 
 [Pcd.AARCH64]
   gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum
@@ -81,6 +82,7 @@
 [Protocols.AARCH64]
   gEfiTimerArchProtocolGuid           ## CONSUMES
   gEfiWatchdogTimerArchProtocolGuid   ## CONSUMES
+  gHardwareInterrupt2ProtocolGuid     ## CONSUMES
 
 [Depex]
   gEfiMpServiceProtocolGuid

--- a/UefiTestingPkg/PerfTests/FbptDump/FbptDump.c
+++ b/UefiTestingPkg/PerfTests/FbptDump/FbptDump.c
@@ -179,7 +179,7 @@ LocateAcpiTableBySignature (
   @param[in] SystemTable  A pointer to the EFI System Table.
 
   @retval EFI_SUCCESS     The entry point executed successfully.
-  @retval other           Some error occured when executing this entry point.
+  @retval other           Some error occurred when executing this entry point.
 
 **/
 EFI_STATUS

--- a/UefiTestingPkg/UefiTestingPkg.ci.yaml
+++ b/UefiTestingPkg/UefiTestingPkg.ci.yaml
@@ -31,6 +31,7 @@
             "StandaloneMmPkg/StandaloneMmPkg.dec",
             "ArmPkg/ArmPkg.dec",
             "MsCorePkg/MsCorePkg.dec",
+            EmbeddedPkg/EmbeddedPkg.dec,
             "IntelSiliconPkg/IntelSiliconPkg.dec" #this is bad layering.  Need to fix.
         ],
         "AcceptableDependencies-HOST_APPLICATION":[ # for host based unit tests

--- a/UefiTestingPkg/UefiTestingPkg.ci.yaml
+++ b/UefiTestingPkg/UefiTestingPkg.ci.yaml
@@ -95,6 +95,8 @@
             "SMRRs",
             "unsplit",
             "lfanew", # PE/COFF
+            "intid",
+            "irouter",
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
     }


### PR DESCRIPTION
## Description

When using `MpManagement` to suspend all cores to a C-state that powers down the core the non-secure watchdog is being used to wake up a core after a certain amount of time.

On ARM reference platforms the non-secure watchdog interrupt is a level interrupt and active high. and this PR configures the interrupt trigger accordingly. Also, when all cores are powered down interrupt `IRM (Interrupt Routing Mode)` can't be used and the interrupt have to be routed to a specific core using the affinity fields. This PR programs the interrupt to go to the `BSP`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Tested on custom Microsoft hardware.

Following use case was run:
1. Program watchdog timer.
2. Power down cores.
3. Watchdog interrupt to wake up BSP.

## Integration Instructions

N/A
