### PR TITLE
Added PcdAlwaysPrintAssertMsgToSerialPort

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -131,6 +131,12 @@
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel|0xFFFFFFFF|UINT32|0x00010180
 
+  ## Always Print Assert Message to Serial Port
+  #
+  # Enable AssertLib to print ASSERT message to serial port in addition of AdvLogger
+  #
+  gAdvLoggerPkgTokenSpaceGuid.PcdAlwaysPrintAssertMsgToSerialPort|FALSE|BOOLEAN|0x00010199
+
 
 [UserExtensions.TianoCore."ExtraFiles"]
   AdvLoggerPkgExtra.uni

--- a/AdvLoggerPkg/Library/AssertLib/AssertLib.c
+++ b/AdvLoggerPkg/Library/AssertLib/AssertLib.c
@@ -18,6 +18,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/SerialPortLib.h>
 
 //
 // Define the maximum debug and assert message length that this library supports
@@ -64,6 +65,10 @@ DebugAssert (
   // Send the print string to the Logging device device
   //
   AdvancedLoggerWrite (DEBUG_ERROR, Buffer, AsciiStrnLenS (Buffer, sizeof (Buffer)));
+
+  if (PcdGetBool(PcdAlwaysPrintAssertMsgToSerialPort)) {
+    SerialPortWrite(Buffer, AsciiStrnLenS (Buffer, sizeof (Buffer)));
+  }
 
   if ((PcdGet8 (PcdDebugPropertyMask) & DEBUG_PROPERTY_ASSERT_BREAKPOINT_ENABLED) != 0) {
     CpuBreakpoint ();

--- a/AdvLoggerPkg/Library/AssertLib/AssertLib.inf
+++ b/AdvLoggerPkg/Library/AssertLib/AssertLib.inf
@@ -34,6 +34,8 @@
   BaseLib
   PcdLib
   PrintLib
+  SerialPortLib
 
 [Pcd]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask      ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask                  ## CONSUMES
+  gAdvLoggerPkgTokenSpaceGuid.PcdAlwaysPrintAssertMsgToSerialPort ## CONSUMES


### PR DESCRIPTION
## Description

With the PCD enabled, assert lib will print the ASSERT message to serial port in addition of AdvancedLogger

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on platform and disable normal debug print via AdvancedLogger, the ASSERT message still shows up in the serial port console.

## Integration Instructions

N/A