### PR TITLE
AdvLoggerPkg: Remove added HII package before application returns

### DIFF
--- a/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
+++ b/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
@@ -28,7 +28,7 @@ EntryPoint (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS Status;
+  EFI_STATUS  Status;
 
   gAdvLogHiiHandle = InitializeHiiPackage (ImageHandle);
   if (gAdvLogHiiHandle == NULL) {

--- a/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
+++ b/AdvLoggerPkg/Application/AdvancedLogDumper/LogDumper.c
@@ -28,10 +28,17 @@ EntryPoint (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
+  EFI_STATUS Status;
+
   gAdvLogHiiHandle = InitializeHiiPackage (ImageHandle);
   if (gAdvLogHiiHandle == NULL) {
     return EFI_ABORTED;
   }
 
-  return AdvLogDumperInternalWorker (ImageHandle, SystemTable);
+  Status = AdvLogDumperInternalWorker (ImageHandle, SystemTable);
+
+  // Remove the package before returning.
+  HiiRemovePackages (gAdvLogHiiHandle);
+
+  return Status;
 }


### PR DESCRIPTION
## Description

Current log dumper application will add an HII entry to the database but never removes it. This will cause the system to crash if we were to invoke it again.

This change removes the added package before returning.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and double invoked the application without asserts.

## Integration Instructions

N/A
