### PR TITLE
Refactor HID Keyboard Reset support

### DIFF
--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -579,7 +579,7 @@ extern "efiapi" fn reset_notification_function(key_data: *mut protocols::simple_
 
     //DEL scan code received with shift state indicating CTRL-ALT also pressed.
     debugln!(DEBUG_WARN, "Ctrl-Alt-Del pressed, resetting system.");
-    if let Some(runtime_services) = unsafe { RUNTIME_SERVICES.load(Ordering::SeqCst).as_mut() } {
+    if let Some(runtime_services) = unsafe { RUNTIME_SERVICES.load(Ordering::SeqCst).as_ref() } {
         (runtime_services.reset_system)(efi::RESET_COLD, efi::Status::SUCCESS, 0, core::ptr::null_mut());
     }
     panic!("Reset failed.");

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -19,9 +19,18 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use core::sync::atomic::Ordering;
 use core::{ffi::c_void, ptr};
 
-use r_efi::{efi, hii, protocols};
+use r_efi::{
+    efi, hii,
+    protocols::{
+        self,
+        simple_text_input_ex::{
+            LEFT_ALT_PRESSED, LEFT_CONTROL_PRESSED, RIGHT_ALT_PRESSED, RIGHT_CONTROL_PRESSED, SHIFT_STATE_VALID,
+        },
+    },
+};
 
 use hidparser::{
     ArrayField, ReportDescriptor, ReportField, VariableField,
@@ -31,6 +40,7 @@ use mu_rust_helpers::function;
 use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN, debugln};
 
 use crate::{
+    RUNTIME_SERVICES,
     boot_services::UefiBootServices,
     hid_io::{HidIo, HidReportReceiver},
     keyboard::key_queue::OrdKeyData,
@@ -542,6 +552,39 @@ impl KeyboardHidHandler {
     }
 }
 
+// Notification function called when Ctrl-Alt-Delete is pressed.
+extern "efiapi" fn reset_notification_function(key_data: *mut protocols::simple_text_input_ex::KeyData) -> efi::Status {
+    // Any DEL key press will trigger this callback; check that it is qualified with a CTRL-ALT state.
+    // This is done here to allow for easier checking for arbitrary CTRL-ALT presses (left or right) rather than
+    // registering a separate callback for each possible combination.
+
+    if key_data.is_null() {
+        return efi::Status::INVALID_PARAMETER;
+    }
+
+    // SAFETY: null-checked above, using read_unaligned to avoid any alignment issues.
+    let key_data = unsafe { key_data.read_unaligned() };
+    if key_data.key.scan_code != key_queue::SCAN_DELETE {
+        return efi::Status::SUCCESS; // No delete
+    }
+
+    // Check that DEL is qualified with valid CTRL-ALT state.
+    if key_data.key_state.key_shift_state & SHIFT_STATE_VALID == 0
+        || key_data.key_state.key_shift_state & (LEFT_CONTROL_PRESSED | RIGHT_CONTROL_PRESSED) == 0
+        || key_data.key_state.key_shift_state & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) == 0
+    {
+        // DEL pressed without valid CTRL-ALT qualification, so do not reset.
+        return efi::Status::SUCCESS;
+    }
+
+    //DEL scan code received with shift state indicating CTRL-ALT also pressed.
+    debugln!(DEBUG_WARN, "Ctrl-Alt-Del pressed, resetting system.");
+    if let Some(runtime_services) = unsafe { RUNTIME_SERVICES.load(Ordering::SeqCst).as_mut() } {
+        (runtime_services.reset_system)(efi::RESET_COLD, efi::Status::SUCCESS, 0, core::ptr::null_mut());
+    }
+    panic!("Reset failed.");
+}
+
 impl HidReportReceiver for KeyboardHidHandler {
     fn initialize(&mut self, controller: efi::Handle, hid_io: &dyn HidIo) -> Result<(), efi::Status> {
         let descriptor = hid_io.get_report_descriptor()?;
@@ -549,6 +592,16 @@ impl HidReportReceiver for KeyboardHidHandler {
         self.reset(true)?;
         self.install_protocol_interfaces(controller)?;
         self.initialize_keyboard_layout()?;
+
+        // Register a Ctrl-Alt-Delete handler to reset the system. Register only for DEL scan code; CTRL-ALT
+        // shift state will be qualified in the callback.
+        let reset_key_data = protocols::simple_text_input_ex::KeyData {
+            key: protocols::simple_text_input::InputKey { scan_code: key_queue::SCAN_DELETE, unicode_char: 0 },
+            key_state: protocols::simple_text_input_ex::KeyState { key_toggle_state: 0, key_shift_state: 0 },
+        };
+
+        let _ = self.insert_key_notify_callback(reset_key_data, reset_notification_function);
+
         Ok(())
     }
 

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -804,6 +804,7 @@ mod test {
     use core::{ffi::c_void, mem::MaybeUninit, ptr, slice::from_raw_parts_mut};
 
     use hii_keyboard_layout::HiiKeyboardLayout;
+    use mu_rust_helpers::function;
     use r_efi::{efi, hii, protocols};
     use scroll::Pwrite;
     use std::sync::Mutex;
@@ -1315,64 +1316,81 @@ mod test {
         extern "efiapi" fn mock_key_notify_callback(
             _key_data: *mut protocols::simple_text_input_ex::KeyData,
         ) -> efi::Status {
+            // note: print here is functionally required to ensure that `mock_key_notify_callback` and
+            // `mock_key_notify_callback2` are not merged into the same function by the optimizer.
+            println!("{}", function!());
             efi::Status::SUCCESS
         }
 
         extern "efiapi" fn mock_key_notify_callback2(
             _key_data: *mut protocols::simple_text_input_ex::KeyData,
         ) -> efi::Status {
+            // note: print here is functionally required to ensure that `mock_key_notify_callback` and
+            // `mock_key_notify_callback2` are not merged into the same function by the optimizer.
+            println!("{}", function!());
             efi::Status::SUCCESS
         }
 
+        let mut existing_handles = Vec::new();
         let mut key_data: protocols::simple_text_input_ex::KeyData = Default::default();
 
         key_data.key.unicode_char = 'a' as u16;
         let handle = keyboard_handler.insert_key_notify_callback(key_data, mock_key_notify_callback);
-        assert_eq!(handle, 1);
+        assert_ne!(handle, 0);
+        assert!(!existing_handles.contains(&handle));
+        existing_handles.push(handle);
 
         key_data.key.unicode_char = 'b' as u16;
         let handle = keyboard_handler.insert_key_notify_callback(key_data, mock_key_notify_callback);
-        assert_eq!(handle, 2);
+        assert_ne!(handle, 0);
+        assert!(!existing_handles.contains(&handle));
+        existing_handles.push(handle);
 
         key_data.key.unicode_char = 'c' as u16;
         let handle = keyboard_handler.insert_key_notify_callback(key_data, mock_key_notify_callback);
-        assert_eq!(handle, 3);
+        assert_ne!(handle, 0);
+        assert!(!existing_handles.contains(&handle));
+        existing_handles.push(handle);
+
         //insert a second callback function tied to same key
         let handle = keyboard_handler.insert_key_notify_callback(key_data, mock_key_notify_callback2);
-        assert_eq!(handle, 4);
+        assert_ne!(handle, 0);
+        assert!(!existing_handles.contains(&handle));
+        existing_handles.push(handle);
 
         //insert a key_data/callback pair that is already present.
         key_data.key.unicode_char = 'a' as u16;
         let handle = keyboard_handler.insert_key_notify_callback(key_data, mock_key_notify_callback);
-        assert_eq!(handle, 1);
+        assert_eq!(handle, existing_handles[0]);
 
-        //check state after adding callbacks.
-        assert_eq!(keyboard_handler.next_notify_handle, 4);
-        assert_eq!(keyboard_handler.notification_callbacks.len(), 4);
+        //check state after adding callbacks. Note that there is an implicit registration for reset callback, so account for that.
+        assert_eq!(keyboard_handler.next_notify_handle, existing_handles.len() + 1);
+        assert_eq!(keyboard_handler.notification_callbacks.len(), existing_handles.len() + 1);
+
         key_data.key.unicode_char = 'a' as u16;
-        assert_eq!(keyboard_handler.notification_callbacks.get(&1).unwrap().0, OrdKeyData(key_data));
+        assert_eq!(keyboard_handler.notification_callbacks.get(&existing_handles[0]).unwrap().0, OrdKeyData(key_data));
         assert!(ptr::fn_addr_eq(
-            keyboard_handler.notification_callbacks.get(&1).unwrap().1,
+            keyboard_handler.notification_callbacks.get(&existing_handles[0]).unwrap().1,
             mock_key_notify_callback
                 as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
         ));
         key_data.key.unicode_char = 'b' as u16;
-        assert_eq!(keyboard_handler.notification_callbacks.get(&2).unwrap().0, OrdKeyData(key_data));
+        assert_eq!(keyboard_handler.notification_callbacks.get(&existing_handles[1]).unwrap().0, OrdKeyData(key_data));
         assert!(ptr::fn_addr_eq(
-            keyboard_handler.notification_callbacks.get(&2).unwrap().1,
+            keyboard_handler.notification_callbacks.get(&existing_handles[1]).unwrap().1,
             mock_key_notify_callback
                 as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
         ));
         key_data.key.unicode_char = 'c' as u16;
-        assert_eq!(keyboard_handler.notification_callbacks.get(&3).unwrap().0, OrdKeyData(key_data));
+        assert_eq!(keyboard_handler.notification_callbacks.get(&existing_handles[2]).unwrap().0, OrdKeyData(key_data));
         assert!(ptr::fn_addr_eq(
-            keyboard_handler.notification_callbacks.get(&3).unwrap().1,
+            keyboard_handler.notification_callbacks.get(&existing_handles[2]).unwrap().1,
             mock_key_notify_callback
                 as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
         ));
-        assert_eq!(keyboard_handler.notification_callbacks.get(&4).unwrap().0, OrdKeyData(key_data));
+        assert_eq!(keyboard_handler.notification_callbacks.get(&existing_handles[3]).unwrap().0, OrdKeyData(key_data));
         assert!(ptr::fn_addr_eq(
-            keyboard_handler.notification_callbacks.get(&4).unwrap().1,
+            keyboard_handler.notification_callbacks.get(&existing_handles[3]).unwrap().1,
             mock_key_notify_callback2
                 as extern "efiapi" fn(*mut protocols::simple_text_input_ex::KeyData) -> efi::Status
         ));
@@ -1401,7 +1419,7 @@ mod test {
         assert!(callbacks.is_empty());
 
         //remove one of the 'c' callbacks and make sure the other still works.
-        keyboard_handler.remove_key_notify_callback(4).unwrap();
+        keyboard_handler.remove_key_notify_callback(existing_handles[3]).unwrap();
 
         //press and release 'a' key and 'c' key
         let report: &[u8] = &[0x00, 0x00, 0x04, 0x06, 0x00, 0x00, 0x00, 0x00];
@@ -1427,9 +1445,9 @@ mod test {
         }
 
         //remove all the callbacks.
-        keyboard_handler.remove_key_notify_callback(1).unwrap();
-        keyboard_handler.remove_key_notify_callback(2).unwrap();
-        keyboard_handler.remove_key_notify_callback(3).unwrap();
+        keyboard_handler.remove_key_notify_callback(existing_handles[0]).unwrap();
+        keyboard_handler.remove_key_notify_callback(existing_handles[1]).unwrap();
+        keyboard_handler.remove_key_notify_callback(existing_handles[2]).unwrap();
 
         //press and release 'a' key 'b' key, and 'c' key
         let report: &[u8] = &[0x00, 0x00, 0x04, 0x05, 0x06, 0x00, 0x00, 0x00];

--- a/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/key_queue.rs
@@ -13,16 +13,11 @@ use alloc::{
     collections::{BTreeSet, VecDeque},
     vec::Vec,
 };
-use core::{ops::Deref, sync::atomic::Ordering};
+use core::ops::Deref;
 use hidparser::report_data_types::Usage;
 use hii_keyboard_layout::{EfiKey, HiiKey, HiiKeyboardLayout, HiiNsKeyDescriptor};
-use r_efi::{
-    efi,
-    protocols::{self, hii_database::*, simple_text_input::InputKey, simple_text_input_ex::*},
-};
+use r_efi::protocols::{self, hii_database::*, simple_text_input::InputKey, simple_text_input_ex::*};
 use rust_advanced_logger_dxe::{DEBUG_WARN, debugln};
-
-use crate::RUNTIME_SERVICES;
 
 // The set of HID usages that represent modifier keys this driver is interested in.
 #[rustfmt::skip]
@@ -36,9 +31,9 @@ const KEYBOARD_MODIFIERS: &[u16] = &[
 const TOGGLE_MODIFIERS: &[u16] = &[NUM_LOCK_MODIFIER, CAPS_LOCK_MODIFIER, SCROLL_LOCK_MODIFIER];
 
 // Control, Shift, and Alt modifiers.
-const CTRL_MODIFIERS: &[u16] = &[LEFT_CONTROL_MODIFIER, RIGHT_CONTROL_MODIFIER];
+const _CTRL_MODIFIERS: &[u16] = &[LEFT_CONTROL_MODIFIER, RIGHT_CONTROL_MODIFIER];
 const SHIFT_MODIFIERS: &[u16] = &[LEFT_SHIFT_MODIFIER, RIGHT_SHIFT_MODIFIER];
-const ALT_MODIFIERS: &[u16] = &[LEFT_ALT_MODIFIER, RIGHT_ALT_MODIFIER];
+const _ALT_MODIFIERS: &[u16] = &[LEFT_ALT_MODIFIER, RIGHT_ALT_MODIFIER];
 
 /// Defines whether a key stroke represents a key being pressed (KeyDown) or released (KeyUp)
 #[derive(Debug, PartialEq, Eq)]
@@ -220,18 +215,6 @@ impl KeyQueue {
             } else {
                 self.active_modifiers.insert(current_descriptor.modifier);
             }
-        }
-
-        //handle ctrl-alt-delete
-        if CTRL_MODIFIERS.iter().any(|x| self.active_modifiers.contains(x))
-            && ALT_MODIFIERS.iter().any(|x| self.active_modifiers.contains(x))
-            && current_descriptor.modifier == DELETE_MODIFIER
-        {
-            debugln!(DEBUG_WARN, "Ctrl-Alt-Del pressed, resetting system.");
-            if let Some(runtime_services) = unsafe { RUNTIME_SERVICES.load(Ordering::SeqCst).as_mut() } {
-                (runtime_services.reset_system)(efi::RESET_WARM, efi::Status::SUCCESS, 0, core::ptr::null_mut());
-            }
-            panic!("Reset failed.");
         }
 
         if action == KeyAction::KeyUp {
@@ -551,32 +534,31 @@ fn usage_to_efi_key(usage: Usage) -> Option<EfiKey> {
 }
 
 //These should be defined in r_efi::protocols::simple_text_input
-const SCAN_NULL: u16 = 0x0000;
-const SCAN_UP: u16 = 0x0001;
-const SCAN_DOWN: u16 = 0x0002;
-const SCAN_RIGHT: u16 = 0x0003;
-const SCAN_LEFT: u16 = 0x0004;
-const SCAN_HOME: u16 = 0x0005;
-const SCAN_END: u16 = 0x0006;
-const SCAN_INSERT: u16 = 0x0007;
-const SCAN_DELETE: u16 = 0x0008;
-const SCAN_PAGE_UP: u16 = 0x0009;
-const SCAN_PAGE_DOWN: u16 = 0x000A;
-const SCAN_F1: u16 = 0x000B;
-const SCAN_F2: u16 = 0x000C;
-const SCAN_F3: u16 = 0x000D;
-const SCAN_F4: u16 = 0x000E;
-const SCAN_F5: u16 = 0x000F;
-const SCAN_F6: u16 = 0x0010;
-const SCAN_F7: u16 = 0x0011;
-const SCAN_F8: u16 = 0x0012;
-const SCAN_F9: u16 = 0x0013;
-const SCAN_F10: u16 = 0x0014;
-const SCAN_F11: u16 = 0x0015;
-const SCAN_F12: u16 = 0x0016;
-const SCAN_ESC: u16 = 0x0017;
-const SCAN_PAUSE: u16 = 0x0048;
-
+pub const SCAN_NULL: u16 = 0x0000;
+pub const SCAN_UP: u16 = 0x0001;
+pub const SCAN_DOWN: u16 = 0x0002;
+pub const SCAN_RIGHT: u16 = 0x0003;
+pub const SCAN_LEFT: u16 = 0x0004;
+pub const SCAN_HOME: u16 = 0x0005;
+pub const SCAN_END: u16 = 0x0006;
+pub const SCAN_INSERT: u16 = 0x0007;
+pub const SCAN_DELETE: u16 = 0x0008;
+pub const SCAN_PAGE_UP: u16 = 0x0009;
+pub const SCAN_PAGE_DOWN: u16 = 0x000A;
+pub const SCAN_F1: u16 = 0x000B;
+pub const SCAN_F2: u16 = 0x000C;
+pub const SCAN_F3: u16 = 0x000D;
+pub const SCAN_F4: u16 = 0x000E;
+pub const SCAN_F5: u16 = 0x000F;
+pub const SCAN_F6: u16 = 0x0010;
+pub const SCAN_F7: u16 = 0x0011;
+pub const SCAN_F8: u16 = 0x0012;
+pub const SCAN_F9: u16 = 0x0013;
+pub const SCAN_F10: u16 = 0x0014;
+pub const SCAN_F11: u16 = 0x0015;
+pub const SCAN_F12: u16 = 0x0016;
+pub const SCAN_ESC: u16 = 0x0017;
+pub const SCAN_PAUSE: u16 = 0x0048;
 // helper routine that converts the given modifier to the corresponding SCAN code
 fn modifier_to_scan(modifier: u16) -> u16 {
     match modifier {

--- a/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard/simple_text_in_ex.rs
@@ -914,6 +914,8 @@ mod test {
 
         let mut key_data: protocols::simple_text_input_ex::KeyData = Default::default();
         key_data.key.unicode_char = 'a' as u16;
+
+        let mut existing_notify_handles = Vec::new();
         let mut notify_handle = ptr::null_mut();
 
         let status = SimpleTextInExFfi::simple_text_in_ex_register_key_notify(
@@ -923,7 +925,8 @@ mod test {
             ptr::addr_of_mut!(notify_handle),
         );
         assert_eq!(status, efi::Status::SUCCESS);
-        assert_eq!(notify_handle as usize, 1);
+        assert_ne!(notify_handle as usize, 0);
+        existing_notify_handles.push(notify_handle);
 
         notify_handle = ptr::null_mut();
         let status = SimpleTextInExFfi::simple_text_in_ex_register_key_notify(
@@ -933,7 +936,9 @@ mod test {
             ptr::addr_of_mut!(notify_handle),
         );
         assert_eq!(status, efi::Status::SUCCESS);
-        assert_eq!(notify_handle as usize, 2);
+        assert_ne!(notify_handle as usize, 0);
+        assert!(!existing_notify_handles.contains(&notify_handle));
+        existing_notify_handles.push(notify_handle);
 
         notify_handle = ptr::null_mut();
         key_data.key.unicode_char = 'b' as u16;
@@ -944,7 +949,9 @@ mod test {
             ptr::addr_of_mut!(notify_handle),
         );
         assert_eq!(status, efi::Status::SUCCESS);
-        assert_eq!(notify_handle as usize, 3);
+        assert_ne!(notify_handle as usize, 0);
+        assert!(!existing_notify_handles.contains(&notify_handle));
+        existing_notify_handles.push(notify_handle);
 
         //send 'b'
         let report: &[u8] = &[0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
@@ -975,7 +982,7 @@ mod test {
         KEY2_NOTIFIED.store(false, Ordering::SeqCst);
 
         //remove the 'a'-only callback
-        let status = SimpleTextInExFfi::simple_text_in_ex_unregister_key_notify(this, ptr::dangling_mut());
+        let status = SimpleTextInExFfi::simple_text_in_ex_unregister_key_notify(this, existing_notify_handles[0]);
         assert_eq!(status, efi::Status::SUCCESS);
 
         //send 'a'


### PR DESCRIPTION
## Description
 
This PR changes how CTRL-ALT-DEL resets are handled by the HID stack. Previously, they were handled by the lower layer key processing code; but this caused them to be handled at an implementation-defined TPL based on what TPL the input reports are generated at by the HID I/O layer. 

This change moves the CTRL-ALT-DEL to use the existing SimpleTextInEx key registration infrastructure to handle the reset logic, effectively moving the reset handling up to a higher level of abstraction.

This also simplifies disabling this capability behind a feature flag should it be desirable in the future to separate reset logic from the HID stack entirely.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified CTRL-ALT-DEL resets system from UEFI shell and that reset occurs at TPL_CALLBACK.

## Integration Instructions

N/A