### PR TITLE
AdvLoggerPkg: DecodeUefiLog handle frequency errors.

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -694,8 +694,11 @@ class AdvLogParser ():
     #   Convert Ticks to approximate time based of Frequency setting
     #
     def _GetTimeInNanoSecond(self, Ticks, Frequency):
-        Nanosecond = int((Ticks / Frequency) * 1000000000)
-
+        if Frequency != 0:
+            Nanosecond = int((Ticks / Frequency) * 1000000000)
+        else:
+            Nanosecond = 0
+            
         return Nanosecond
 
     #


### PR DESCRIPTION
## Description

When calling DecodeUefiLog, if the system was not able to provide a frequency in the log, it will be reported as 0. With no verification check of a zero frequency, DecodeUefiLog would attempt a divide by zero when converting time to nano seconds.

Add a check that prevents divide by zero. This will report times of 0 for all timestamps in the decoded log.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
On a physical platform where no timer frequency was reported, encountered a python exception.
After change, log was correctly retrieved and displays a timestamp of 0.

## Integration Instructions
No integration necessary. 