### PR TITLE
[REBASE & FF] Fix Memory Tests to Run on Patina

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/AArch64/PagingAuditProcessor.c
@@ -72,6 +72,9 @@ GetFlatPageTableData (
   UINTN       NumPage1GNotPresent = 0;
   UINT64      RootEntryCount      = 0;
   UINT64      Address;
+  BOOLEAN     SelfMapped;
+
+  SelfMapped = FALSE;
 
   //  Count parameters should be provided.
   if ((Pte1GCount == NULL) || (Pte2MCount == NULL) || (Pte4KCount == NULL) || (GuardCount == NULL)) {
@@ -89,15 +92,27 @@ GetFlatPageTableData (
   Pml0           = (UINT64 *)ArmGetTTBR0BaseAddress ();
   RootEntryCount = ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
 
+  //
+  // Check for the self-map entry as the last entry
+  //
+  if ((Pml0[0x1FF] & TT_ADDRESS_MASK) == (UINT64)Pml0) {
+    SelfMapped = TRUE;
+    Pml0       = (UINT64 *)0xFFFFFFFFF000;
+  }
+
   for (Index0 = 0x0; Index0 < RootEntryCount; Index0++) {
     Index1 = 0;
     Index2 = 0;
     Index3 = 0;
-    if (!IS_TABLE (Pml0[Index0], 0)) {
+    if (!IS_TABLE (Pml0[Index0], 0) || (SelfMapped && ((Index0 == 0x1FF) || (Index0 == 0x1FE)))) {
       continue;
     }
 
-    Pte1G = (UINT64 *)(Pml0[Index0] & TT_ADDRESS_MASK);
+    if (SelfMapped) {
+      Pte1G = (UINT64 *)((0xFFFFFFE00000 + SIZE_4KB * Index0));
+    } else {
+      Pte1G = (UINT64 *)(Pml0[Index0] & TT_ADDRESS_MASK);
+    }
 
     for (Index1 = 0x0; Index1 < TT_ENTRY_COUNT; Index1++ ) {
       Index2 = 0;
@@ -108,7 +123,13 @@ GetFlatPageTableData (
       }
 
       if (!IS_BLOCK (Pte1G[Index1], 1)) {
-        Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
+        if (SelfMapped) {
+          Pte2M = (UINT64 *)(0xFFFFC0000000 +
+                             SIZE_2MB * Index0 +
+                             SIZE_4KB * Index1);
+        } else {
+          Pte2M = (UINT64 *)(Pte1G[Index1] & TT_ADDRESS_MASK);
+        }
 
         for (Index2 = 0x0; Index2 < TT_ENTRY_COUNT; Index2++ ) {
           Index3 = 0;
@@ -118,7 +139,15 @@ GetFlatPageTableData (
           }
 
           if (!IS_BLOCK (Pte2M[Index2], 2)) {
-            Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
+            if (SelfMapped) {
+              Pte4K = (UINT64 *)(0xFF8000000000 +
+                                 SIZE_1GB * Index0 +
+                                 SIZE_2MB * Index1 +
+                                 SIZE_4KB * Index2
+                                 );
+            } else {
+              Pte4K = (UINT64 *)(Pte2M[Index2] & TT_ADDRESS_MASK);
+            }
 
             for (Index3 = 0x0; Index3 < TT_ENTRY_COUNT; Index3++ ) {
               Address = IndexToAddress (Index0, Index1, Index2, Index3);

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -58,7 +58,6 @@
 
 [LibraryClasses.X64]
   CpuLib
-  CpuPageTableLib
 
 [Guids]
   gEfiDebugImageInfoTableGuid                   ## SOMETIMES_CONSUMES ## GUID

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -763,6 +763,10 @@ AllocateMemoryMapBuffer (
       goto FailureFreeMem;
     }
 
+    // ensure we store the unmerged buffer size as that is the required size.
+    // Add some padding.
+    mMemoryMapBufferSize = mMemoryMapSize + (mMemoryMapSize / 5);
+
     Status = gBS->GetMemoryMap (
                     &mMemoryMapSize,
                     mMemoryMap,
@@ -797,11 +801,6 @@ AllocateMemoryMapBuffer (
     goto FailureFreeMem;
   }
 
-  // mMemoryMapSize now contains the size of the filled in memory map. Increase
-  // it by 20% to account for any additional entries that may be required after
-  // other buffers are allocated.
-  mMemoryMapSize      += (mMemoryMapSize / 5);
-  mMemoryMapBufferSize = mMemoryMapSize;
   FreePool (mMemoryMap);
   mMemoryMap = AllocateZeroPool (mMemoryMapBufferSize);
 

--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/X64/PagingAuditProcessor.c
@@ -577,6 +577,9 @@ GetFlatPageTableData (
   UINTN                           NumPage2MNotPresent = 0;
   UINTN                           NumPage1GNotPresent = 0;
   UINT64                          Address;
+  BOOLEAN                         SelfMapped;
+
+  SelfMapped = FALSE;
 
   //
   // First, fail fast if some of the parameters don't look right.
@@ -599,12 +602,27 @@ GetFlatPageTableData (
   //
   Pml4 = (PAGE_MAP_AND_DIRECTORY_POINTER *)AsmReadCr3 ();
 
+  //
+  // Check for the self-map entry as the last entry
+  //
+  if ((Pml4[0x1FF].Bits.PageTableBaseAddress << 12) == (UINTN)Pml4) {
+    SelfMapped = TRUE;
+    Pml4       = (PAGE_MAP_AND_DIRECTORY_POINTER *)0xFFFFFFFFFFFFF000;
+  }
+
   for (Index4 = 0x0; Index4 < 0x200; Index4++) {
-    if (!Pml4[Index4].Bits.Present) {
+    if (!Pml4[Index4].Bits.Present || (((Index4 == 0x1FF) || (Index4 == 0x1FE)) && SelfMapped)) {
       continue;
     }
 
-    Pte1G = (PAGE_TABLE_1G_ENTRY *)(UINTN)(Pml4[Index4].Bits.PageTableBaseAddress << 12);
+    if (SelfMapped) {
+      Pte1G = (PAGE_TABLE_1G_ENTRY *)(UINTN)((0xFFFFFFFFFFE00000 + SIZE_4KB * Index4));
+    } else {
+      //
+      // No self-map entry, so just use the physical address.
+      //
+      Pte1G = (PAGE_TABLE_1G_ENTRY *)(UINTN)(Pml4[Index4].Bits.PageTableBaseAddress << 12);
+    }
 
     for (Index3 = 0x0; Index3 < 0x200; Index3++ ) {
       if (!Pte1G[Index3].Bits.Present) {
@@ -621,8 +639,15 @@ GetFlatPageTableData (
         // We have to cast 1G and 2M directories to this to
         // get all of their address bits.
         //
-        Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte1G;
-        Pte2M = (PAGE_TABLE_ENTRY *)(UINTN)(Work[Index3].Bits.PageTableBaseAddress << 12);
+        if (SelfMapped) {
+          Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte1G;
+          Pte2M = (PAGE_TABLE_ENTRY *)(UINTN)(0xFFFFFFFFC0000000 +
+                                              SIZE_2MB * Index4 +
+                                              SIZE_4KB * Index3);
+        } else {
+          Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte1G;
+          Pte2M = (PAGE_TABLE_ENTRY *)(UINTN)(Work[Index3].Bits.PageTableBaseAddress << 12);
+        }
 
         for (Index2 = 0x0; Index2 < 0x200; Index2++ ) {
           if (!Pte2M[Index2].Bits.Present) {
@@ -631,8 +656,16 @@ GetFlatPageTableData (
           }
 
           if (!(Pte2M[Index2].Bits.MustBe1)) {
-            Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte2M;
-            Pte4K = (PAGE_TABLE_4K_ENTRY *)(UINTN)(Work[Index2].Bits.PageTableBaseAddress << 12);
+            if (SelfMapped) {
+              Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte2M;
+              Pte4K = (PAGE_TABLE_4K_ENTRY *)(UINTN)(0xFFFFFF8000000000 +
+                                                     SIZE_1GB * Index4 +
+                                                     SIZE_2MB * Index3 +
+                                                     SIZE_4KB * Index2);
+            } else {
+              Work  = (PAGE_MAP_AND_DIRECTORY_POINTER *)Pte2M;
+              Pte4K = (PAGE_TABLE_4K_ENTRY *)(UINTN)(Work[Index2].Bits.PageTableBaseAddress << 12);
+            }
 
             for (Index1 = 0x0; Index1 < 0x200; Index1++ ) {
               if (!Pte4K[Index1].Bits.Present) {

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_AArch64.html
@@ -633,22 +633,6 @@
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({
-                "Name": "Check Memory Not in EFI Memory Map is Inaccessible",
-                "Description": "Memory not in the EFI memory map should cause a fault if accessed",
-                "Filter": function (mrObject) {
-                    var isTargetType = mrObject["Memory Type"] === "None";
-                    var hasInvalidAttributes = mrObject["Access Flag"] !== "No";
-                    return isTargetType && hasInvalidAttributes;
-                }, //end of Filter function
-                "ConfigureFilter": function () {
-                    $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("MemoryTypeFilter", ["None"]);
-                    SetMultiselectTo("AccessFlagFilter", ["Yes"]);
-                    return true;
-                } //end of configuring filter inputs
-            });
-
             //Fill in the test results tab
             SavedFilters.forEach(function (TestObject) {
                 var FailedCount = EmbeddedJd.MemoryRanges.filter(TestObject.Filter);

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/DxePaging_template_X64.html
@@ -654,22 +654,6 @@
                 } //end of configuring filter inputs
             });
 
-            SavedFilters.push({
-                "Name": "Check Memory Not in EFI Memory Map is Inaccessible",
-                "Description": "Memory not in the EFI memory map should cause a fault if accessed",
-                "Filter": function (mrObject) {
-                    var isTargetType = mrObject["Memory Type"] === "None";
-                    var hasInvalidAttributes = mrObject["Present"] !== "No";
-                    return isTargetType && hasInvalidAttributes;
-                }, //end of Filter function
-                "ConfigureFilter": function () {
-                    $("button#ClearAllFilter").click();  //clear the filters
-                    SetMultiselectTo("MemoryTypeFilter", ["None"]);
-                    SetMultiselectTo("PresentFilter", ["Yes"]);
-                    return true;
-                } //end of configuring filter inputs
-            });
-
             //Fill in the test results tab
             SavedFilters.forEach(function (TestObject) {
                 var FailedCount = EmbeddedJd.MemoryRanges.filter(TestObject.Filter);

--- a/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
+++ b/UefiTestingPkg/AuditTests/PagingAudit/Windows/MemoryRangeObjects.py
@@ -315,7 +315,7 @@ class MemoryRange(object):
                     if ("GDT" in self.ImageName or "IDT" in self.ImageName):
                         section_type = "Descriptor Table"
                     else:
-                        section_type = "ERROR"
+                        section_type = "RODATA"
                 elif self.Nx == 1:
                     section_type = "DATA"
                 elif self.ReadWrite == 0:
@@ -342,10 +342,8 @@ class MemoryRange(object):
             if self.ImageName == None:
                 section_type = "Not Tracked"
             else:
-                # if an image range can't be read or executed, this is almost certainly
-                # an error.
                 if self.Ux == 0 and self.ReadWrite == 0:
-                    section_type = "ERROR"
+                    section_type = "RODATA"
                 elif self.Ux == 0:
                     section_type = "DATA"
                 elif self.ReadWrite == 0:

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/DxeMemoryProtectionTestApp.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/DxeMemoryProtectionTestApp.c
@@ -34,6 +34,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/ExceptionPersistenceLib.h>
 
 #include <Guid/DxeMemoryProtectionSettings.h>
+#include <Guid/DebugImageInfoTable.h>
+
+#include <IndustryStandard/PeImage.h>
+
+#include <Library/PeCoffGetEntryPointLib.h>
 
 #include "../MemoryProtectionTestCommon.h"
 #include "ArchSpecificFunctions.h"
@@ -1531,88 +1536,219 @@ ImageProtection (
   IN UNIT_TEST_CONTEXT  Context
   )
 {
-  EFI_STATUS              Status;
-  IMAGE_RANGE_DESCRIPTOR  *ImageRangeDescriptorHead = NULL;
-  LIST_ENTRY              *ImageRangeDescriptorLink = NULL;
-  IMAGE_RANGE_DESCRIPTOR  *ImageRangeDescriptor     = NULL;
-  BOOLEAN                 TestFailed                = FALSE;
-  UINT64                  Attributes                = 0;
+  EFI_STATUS                           Status;
+  IMAGE_RANGE_DESCRIPTOR               *ImageRangeDescriptorHead = NULL;
+  LIST_ENTRY                           *ImageRangeDescriptorLink = NULL;
+  IMAGE_RANGE_DESCRIPTOR               *ImageRangeDescriptor     = NULL;
+  BOOLEAN                              TestFailed                = FALSE;
+  UINT64                               Attributes                = 0;
+  EFI_DEBUG_IMAGE_INFO_TABLE_HEADER    *DebugTableHeader;
+  EFI_DEBUG_IMAGE_INFO                 *DebugTable;
+  UINTN                                Entry;
+  EFI_LOADED_IMAGE_PROTOCOL            *LoadedImage;
+  EFI_IMAGE_DOS_HEADER                 *DosHdr;
+  UINT32                               PeCoffHeaderOffset;
+  EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION  Hdr;
+  EFI_IMAGE_SECTION_HEADER             *Section;
+  UINT32                               SectionAlignment;
+  UINTN                                SectionIndex;
+  UINT64                               SectionStart;
+  UINT64                               SectionEnd;
+  CHAR8                                *PdbFileName;
 
   DEBUG ((DEBUG_INFO, "%a() - Enter\n", __FUNCTION__));
 
-  // Ensure the Memory Protection Protocol and Memory Attribute Protocol are available.
-  UT_ASSERT_NOT_NULL (mMemoryProtectionProtocol);
   UT_ASSERT_NOT_NULL (mMemoryAttributeProtocol);
 
   // Use the Memory Protection Protocol to get a list of protected images. Each descriptor in the
   // output list will be a code or data section of a protected image.
-  UT_ASSERT_NOT_EFI_ERROR (mMemoryProtectionProtocol->GetImageList (&ImageRangeDescriptorHead, Protected));
+  if (mMemoryProtectionProtocol != NULL) {
+    UT_ASSERT_NOT_EFI_ERROR (mMemoryProtectionProtocol->GetImageList (&ImageRangeDescriptorHead, Protected));
 
-  // Walk through each image
-  for (ImageRangeDescriptorLink = ImageRangeDescriptorHead->Link.ForwardLink;
-       ImageRangeDescriptorLink != &ImageRangeDescriptorHead->Link;
-       ImageRangeDescriptorLink = ImageRangeDescriptorLink->ForwardLink)
-  {
-    ImageRangeDescriptor = CR (
-                             ImageRangeDescriptorLink,
-                             IMAGE_RANGE_DESCRIPTOR,
-                             Link,
-                             IMAGE_RANGE_DESCRIPTOR_SIGNATURE
-                             );
-    if (ImageRangeDescriptor != NULL) {
-      // Get the attributes of the image range.
-      Status = mMemoryAttributeProtocol->GetMemoryAttributes (
-                                           mMemoryAttributeProtocol,
-                                           ImageRangeDescriptor->Base,
-                                           ImageRangeDescriptor->Length,
-                                           &Attributes
-                                           );
+    // Walk through each image
+    for (ImageRangeDescriptorLink = ImageRangeDescriptorHead->Link.ForwardLink;
+         ImageRangeDescriptorLink != &ImageRangeDescriptorHead->Link;
+         ImageRangeDescriptorLink = ImageRangeDescriptorLink->ForwardLink)
+    {
+      ImageRangeDescriptor = CR (
+                               ImageRangeDescriptorLink,
+                               IMAGE_RANGE_DESCRIPTOR,
+                               Link,
+                               IMAGE_RANGE_DESCRIPTOR_SIGNATURE
+                               );
+      if (ImageRangeDescriptor != NULL) {
+        // Get the attributes of the image range.
+        Status = mMemoryAttributeProtocol->GetMemoryAttributes (
+                                             mMemoryAttributeProtocol,
+                                             ImageRangeDescriptor->Base,
+                                             ImageRangeDescriptor->Length,
+                                             &Attributes
+                                             );
 
-      if (EFI_ERROR (Status)) {
-        UT_LOG_ERROR (
-          "Unable to get attributes of memory range 0x%llx - 0x%llx! Status: %r\n",
-          ImageRangeDescriptor->Base,
-          ImageRangeDescriptor->Base + ImageRangeDescriptor->Length,
-          Status
-          );
-        TestFailed = TRUE;
+        if (EFI_ERROR (Status)) {
+          UT_LOG_ERROR (
+            "Unable to get attributes of memory range 0x%llx - 0x%llx! Status: %r\n",
+            ImageRangeDescriptor->Base,
+            ImageRangeDescriptor->Base + ImageRangeDescriptor->Length,
+            Status
+            );
+          TestFailed = TRUE;
+          continue;
+        }
+
+        // Check that the code sections have the EFI_MEMORY_RO attribute and the data sections have
+        // the EFI_MEMORY_XP attribute.
+        if ((ImageRangeDescriptor->Type == Code) && ((Attributes & EFI_MEMORY_RO) == 0)) {
+          TestFailed = TRUE;
+          UT_LOG_ERROR (
+            "Memory Range 0x%llx - 0x%llx should be non-writeable!\n",
+            ImageRangeDescriptor->Base,
+            ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
+            );
+        } else if ((ImageRangeDescriptor->Type == Data) && ((Attributes & EFI_MEMORY_XP) == 0)) {
+          TestFailed = TRUE;
+          UT_LOG_ERROR (
+            "Memory Range 0x%llx - 0x%llx should be non-executable!\n",
+            ImageRangeDescriptor->Base,
+            ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
+            );
+        }
+      }
+    }
+
+    // Free the list of image range descriptors.
+    while (!IsListEmpty (&ImageRangeDescriptorHead->Link)) {
+      ImageRangeDescriptor = CR (
+                               ImageRangeDescriptorHead->Link.ForwardLink,
+                               IMAGE_RANGE_DESCRIPTOR,
+                               Link,
+                               IMAGE_RANGE_DESCRIPTOR_SIGNATURE
+                               );
+
+      RemoveEntryList (&ImageRangeDescriptor->Link);
+      FreePool (ImageRangeDescriptor);
+    }
+
+    FreePool (ImageRangeDescriptorHead);
+  } else {
+    // if the Mu protocol isn't produced, walk the debug image info table
+    // and verify section attributes directly
+    Status = EfiGetSystemConfigurationTable (&gEfiDebugImageInfoTableGuid, (VOID **)&DebugTableHeader);
+    if (EFI_ERROR (Status) || (DebugTableHeader == NULL)) {
+      UT_LOG_ERROR ("Unable to get Debug Image Info Table\n");
+      return UNIT_TEST_ERROR_TEST_FAILED;
+    }
+
+    DebugTable = DebugTableHeader->EfiDebugImageInfoTable;
+    if (DebugTable == NULL) {
+      UT_LOG_ERROR ("Debug Image Info Table is NULL\n");
+      return UNIT_TEST_ERROR_TEST_FAILED;
+    }
+
+    for (Entry = 0; Entry < DebugTableHeader->TableSize; Entry++, DebugTable++) {
+      if (DebugTable->NormalImage == NULL) {
         continue;
       }
 
-      // Check that the code sections have the EFI_MEMORY_RO attribute and the data sections have
-      // the EFI_MEMORY_XP attribute.
-      if ((ImageRangeDescriptor->Type == Code) && ((Attributes & EFI_MEMORY_RO) == 0)) {
-        TestFailed = TRUE;
-        UT_LOG_ERROR (
-          "Memory Range 0x%llx - 0x%llx should be non-writeable!\n",
-          ImageRangeDescriptor->Base,
-          ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
-          );
-      } else if ((ImageRangeDescriptor->Type == Data) && ((Attributes & EFI_MEMORY_XP) == 0)) {
-        TestFailed = TRUE;
-        UT_LOG_ERROR (
-          "Memory Range 0x%llx - 0x%llx should be non-executable!\n",
-          ImageRangeDescriptor->Base,
-          ImageRangeDescriptor->Base + ImageRangeDescriptor->Length
-          );
+      if ((DebugTable->NormalImage->ImageInfoType != EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL) ||
+          (DebugTable->NormalImage->LoadedImageProtocolInstance == NULL))
+      {
+        continue;
+      }
+
+      LoadedImage = DebugTable->NormalImage->LoadedImageProtocolInstance;
+      PdbFileName = PeCoffLoaderGetPdbPointer (LoadedImage->ImageBase);
+
+      // Parse PE/COFF header
+      DosHdr             = (EFI_IMAGE_DOS_HEADER *)(UINTN)LoadedImage->ImageBase;
+      PeCoffHeaderOffset = 0;
+      if (DosHdr->e_magic == EFI_IMAGE_DOS_SIGNATURE) {
+        PeCoffHeaderOffset = DosHdr->e_lfanew;
+      }
+
+      Hdr.Pe32 = (EFI_IMAGE_NT_HEADERS32 *)((UINT8 *)(UINTN)LoadedImage->ImageBase + PeCoffHeaderOffset);
+
+      // Get SectionAlignment
+      if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+        SectionAlignment = Hdr.Pe32->OptionalHeader.SectionAlignment;
+      } else {
+        SectionAlignment = Hdr.Pe32Plus->OptionalHeader.SectionAlignment;
+      }
+
+      // Get pointer to first section header
+      Section = (EFI_IMAGE_SECTION_HEADER *)(
+                                             (UINT8 *)(UINTN)LoadedImage->ImageBase +
+                                             PeCoffHeaderOffset +
+                                             sizeof (UINT32) +
+                                             sizeof (EFI_IMAGE_FILE_HEADER) +
+                                             Hdr.Pe32->FileHeader.SizeOfOptionalHeader
+                                             );
+
+      // Walk through each section
+      for (SectionIndex = 0; SectionIndex < Hdr.Pe32->FileHeader.NumberOfSections; SectionIndex++) {
+        SectionStart = (UINT64)(UINTN)LoadedImage->ImageBase + Section[SectionIndex].VirtualAddress;
+        SectionEnd   = SectionStart + ALIGN_VALUE (Section[SectionIndex].Misc.VirtualSize, SectionAlignment);
+
+        Attributes = 0;
+        Status     = mMemoryAttributeProtocol->GetMemoryAttributes (
+                                                 mMemoryAttributeProtocol,
+                                                 SectionStart,
+                                                 SectionEnd - SectionStart,
+                                                 &Attributes
+                                                 );
+        if (EFI_ERROR (Status)) {
+          UT_LOG_WARNING (
+            "Unable to get attributes for image %a section %.8a (0x%llx - 0x%llx): %r\n",
+            PdbFileName != NULL ? PdbFileName : "Unknown",
+            Section[SectionIndex].Name,
+            SectionStart,
+            SectionEnd,
+            Status
+            );
+          continue;
+        }
+
+        // Code sections should be RO+X (i.e., EFI_MEMORY_RO set, EFI_MEMORY_XP not set)
+        if ((Section[SectionIndex].Characteristics & EFI_IMAGE_SCN_CNT_CODE) != 0) {
+          // Check that code section is read-only (RO)
+          if ((Attributes & EFI_MEMORY_RO) == 0) {
+            UT_LOG_ERROR (
+              "Image %a: Code section %.8a (0x%llx - 0x%llx) is not read-only!\n",
+              PdbFileName != NULL ? PdbFileName : "Unknown",
+              Section[SectionIndex].Name,
+              SectionStart,
+              SectionEnd
+              );
+            TestFailed = TRUE;
+          }
+
+          // Check that code section is executable (XP bit NOT set)
+          if ((Attributes & EFI_MEMORY_XP) != 0) {
+            UT_LOG_ERROR (
+              "Image %a: Code section %.8a (0x%llx - 0x%llx) is non-executable!\n",
+              PdbFileName != NULL ? PdbFileName : "Unknown",
+              Section[SectionIndex].Name,
+              SectionStart,
+              SectionEnd
+              );
+            TestFailed = TRUE;
+          }
+        } else {
+          // Data sections should be non-executable (EFI_MEMORY_XP set)
+          if ((Attributes & EFI_MEMORY_XP) == 0) {
+            UT_LOG_ERROR (
+              "Image %a: Data section %.8a (0x%llx - 0x%llx) is executable!\n",
+              PdbFileName != NULL ? PdbFileName : "Unknown",
+              Section[SectionIndex].Name,
+              SectionStart,
+              SectionEnd
+              );
+            TestFailed = TRUE;
+          }
+        }
       }
     }
   }
-
-  // Free the list of image range descriptors.
-  while (!IsListEmpty (&ImageRangeDescriptorHead->Link)) {
-    ImageRangeDescriptor = CR (
-                             ImageRangeDescriptorHead->Link.ForwardLink,
-                             IMAGE_RANGE_DESCRIPTOR,
-                             Link,
-                             IMAGE_RANGE_DESCRIPTOR_SIGNATURE
-                             );
-
-    RemoveEntryList (&ImageRangeDescriptor->Link);
-    FreePool (ImageRangeDescriptor);
-  }
-
-  FreePool (ImageRangeDescriptorHead);
 
   // If TestFailed is TRUE, the test has failed.
   UT_ASSERT_FALSE (TestFailed);

--- a/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/DxeMemoryProtectionTestApp.inf
+++ b/UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/DxeMemoryProtectionTestApp.inf
@@ -51,6 +51,7 @@
   UefiLib
   HobLib
   ExceptionPersistenceLib
+  PeCoffGetEntryPointLib
 
 [LibraryClasses.X64]
   HwResetSystemLib

--- a/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/AArch64/FlatPageTableAArch64.c
@@ -24,6 +24,7 @@
 #define ROOT_TABLE_LEN(T0SZ)           (TT_ENTRY_COUNT >> ((T0SZ) - 16) % 9)
 #define ARM_TT_BASE_ADDRESS(page)      (page & TT_ADDRESS_MASK_BLOCK_ENTRY)
 #define ARM_TT_BLOCK_ATTRIBUTES(page)  (page & AARCH64_ATTRIBUTES_MASK)
+#define TT_ADDRESS_MASK  (0xFFFFFFFFFULL << 12)
 
 // All translation table bit definitions were taken from the Armv8 A
 // Architecture Manual version H.a.
@@ -141,6 +142,7 @@ IsHierarchicalControlEnabled (
   @param[in]      LastEntry                   Pointer to last map entry.
   @param[in]      OneEntry                    Pointer to a library internal storage that holds one map entry which is
                                               used when Map array is at capacity.
+  @param[in]      SelfMapped                  TRUE if the page tables are self-mapped, FALSE otherwise.
 **/
 STATIC
 VOID
@@ -153,7 +155,8 @@ TranslationTableParseRecursive (
   IN OUT UINTN                              *MapCount,
   IN     UINTN                              MapCapacity,
   IN     PAGE_MAP_ENTRY                     **LastEntry,
-  IN     PAGE_MAP_ENTRY                     *OneEntry
+  IN     PAGE_MAP_ENTRY                     *OneEntry,
+  IN     BOOLEAN                            SelfMapped
   )
 {
   TRANSLATION_TABLE_ENTRY_UNION  *PagingEntry;
@@ -166,7 +169,30 @@ TranslationTableParseRecursive (
     return;
   }
 
-  PagingEntry  = (TRANSLATION_TABLE_ENTRY_UNION *)(UINTN)PageTableBaseAddress;
+  if (SelfMapped) {
+    switch (Level) {
+      case 0:
+        PagingEntry = (TRANSLATION_TABLE_ENTRY_UNION *)0xFFFFFFFFF000;
+        break;
+      case 1:
+        PagingEntry = (TRANSLATION_TABLE_ENTRY_UNION *)(0xFFFFFFE00000 + SIZE_4KB * ((RegionStart >> 39) & 0x1FF));
+        break;
+      case 2:
+        PagingEntry = (TRANSLATION_TABLE_ENTRY_UNION *)(0xFFFFC0000000 +
+                                                        SIZE_2MB * ((RegionStart >> 39) & 0x1FF) +
+                                                        SIZE_4KB * ((RegionStart >> 30) & 0x1FF));
+        break;
+      case 3:
+        PagingEntry = (TRANSLATION_TABLE_ENTRY_UNION *)(0xFF8000000000 +
+                                                        SIZE_1GB * ((RegionStart >> 39) & 0x1FF) +
+                                                        SIZE_2MB * ((RegionStart >> 30) & 0x1FF) +
+                                                        SIZE_4KB * ((RegionStart >> 21) & 0x1FF));
+        break;
+    }
+  } else {
+    PagingEntry = (TRANSLATION_TABLE_ENTRY_UNION *)(UINTN)PageTableBaseAddress;
+  }
+
   RegionLength = TT_BLOCK_ENTRY_SIZE_AT_LEVEL (Level);
   if (Level == 0) {
     EntryCount = ROOT_TABLE_LEN (ArmGetTCR () & TCR_T0SZ_MASK);
@@ -177,6 +203,11 @@ TranslationTableParseRecursive (
   for (Index = 0; Index < EntryCount; Index++, RegionStart += RegionLength) {
     // Skip unmapped entries
     if (!IS_VALID (PagingEntry[Index].Uint64)) {
+      continue;
+    }
+
+    if ((Level == 0) && ((Index == 0x1FF) || (Index == 0x1FE)) && SelfMapped) {
+      // Skip self-map entries in root table
       continue;
     }
 
@@ -220,15 +251,15 @@ TranslationTableParseRecursive (
         // 0b01 -> Access from EL0 is not allowed, no effect on write permissions
         if ((ParentHeritableAttributes.Bits.ApTable & TT_TABLE_AP_MASK) == TT_TABLE_AP_EL0_NO_ACCESS) {
           // BIT6 toggles access from EL0
-          ScratchEntry.Tteb.Bits.AccessPermissions &= ~((UINT64)BIT6); // Clear BIT6
+          ScratchEntry.Tteb.Bits.AccessPermissions &= ~((UINT64)BIT6);   // Clear BIT6
           // 0b10 -> Access from EL0 is read-only, no write permissions at any EL
         } else if ((ParentHeritableAttributes.Bits.ApTable & TT_TABLE_AP_MASK) == TT_TABLE_AP_NO_WRITE_ACCESS) {
           // BIT7 toggles write access for all ELs
-          ScratchEntry.Tteb.Bits.AccessPermissions |= BIT7; // Set BIT7
+          ScratchEntry.Tteb.Bits.AccessPermissions |= BIT7;   // Set BIT7
           // 0b11 -> Access from EL0 is not allowed, no write permissions at any EL
         } else if ((ParentHeritableAttributes.Bits.ApTable & TT_TABLE_AP_MASK) == TT_TABLE_AP_MASK) {
-          ScratchEntry.Tteb.Bits.AccessPermissions |= BIT7;            // Set BIT7
-          ScratchEntry.Tteb.Bits.AccessPermissions &= ~((UINT64)BIT6); // Clear BIT6
+          ScratchEntry.Tteb.Bits.AccessPermissions |= BIT7;              // Set BIT7
+          ScratchEntry.Tteb.Bits.AccessPermissions &= ~((UINT64)BIT6);   // Clear BIT6
         }
       }
 
@@ -273,7 +304,8 @@ TranslationTableParseRecursive (
         MapCount,
         MapCapacity,
         LastEntry,
-        OneEntry
+        OneEntry,
+        SelfMapped
         );
     }
   }
@@ -301,6 +333,8 @@ CreateFlatPageTable (
   PAGE_MAP_ENTRY                     OneEntry;
   TRANSLATION_TABLE_ENTRY_HERITABLE  HeritableAttributes;
   UINTN                              T0SZ;
+  BOOLEAN                            SelfMapped;
+  UINT64                             Base;
 
   ASSERT (sizeof (OneEntry.PageEntry) == sizeof (AARCH64_PAGE_MAP_ENTRY));
 
@@ -317,6 +351,9 @@ CreateFlatPageTable (
   LastEntry                   = NULL;
   LocalEntryCount             = 0;
 
+  Base       = (UINT64)(UINTN)ArmGetTTBR0BaseAddress ();
+  SelfMapped = (((UINT64 *)Base)[0x1FF] & TT_ADDRESS_MASK) == Base ? TRUE : FALSE;
+
   TranslationTableParseRecursive (
     (UINTN)ArmGetTTBR0BaseAddress (),
     0,
@@ -326,7 +363,8 @@ CreateFlatPageTable (
     &LocalEntryCount,
     Map->EntryCount,
     &LastEntry,
-    &OneEntry
+    &OneEntry,
+    SelfMapped
     );
 
   if (LocalEntryCount > Map->EntryCount) {

--- a/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.inf
+++ b/UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.inf
@@ -46,11 +46,9 @@
 
 [LibraryClasses]
   BaseLib
+  BaseMemoryLib
   SafeIntLib
   DebugLib
-
-[LibraryClasses.X64]
-  CpuPageTableLib
 
 [LibraryClasses.AARCH64]
   ArmLib

--- a/UefiTestingPkg/Library/FlatPageTableLib/X64/FlatPageTableX64.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/X64/FlatPageTableX64.c
@@ -8,6 +8,7 @@
 
 #include <Uefi.h>
 #include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/CpuPageTableLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FlatPageTableLib.h>
@@ -15,6 +16,386 @@
 #define X64_PRESENT_BIT  BIT0
 #define X64_RW_BIT       BIT1
 #define X64_NX_BIT       BIT63
+
+#define REGION_LENGTH(l)  LShiftU64 (1, (l) * 9 + 3)
+
+/**
+  Return TRUE when the page table entry is a leaf entry that points to the physical address memory.
+  Return FALSE when the page table entry is a non-leaf entry that points to the page table entries.
+
+  @param[in] PagingEntry Pointer to the page table entry.
+  @param[in] Level       Page level where the page table entry resides in.
+
+  @retval TRUE  It's a leaf entry.
+  @retval FALSE It's a non-leaf entry.
+**/
+BOOLEAN
+IsPle (
+  IN IA32_PAGING_ENTRY  *PagingEntry,
+  IN UINTN              Level
+  )
+{
+  //
+  // PML5E and PML4E are always non-leaf entries.
+  //
+  if (Level == 1) {
+    return TRUE;
+  }
+
+  if (((Level == 3) || (Level == 2))) {
+    if (PagingEntry->PleB.Bits.MustBeOne == 1) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Return the attribute of a non-leaf page table entry.
+
+  @param[in] Pnle               Pointer to a non-leaf page table entry.
+  @param[in] ParentMapAttribute Pointer to the parent attribute.
+
+  @return Attribute of the non-leaf page table entry.
+**/
+UINT64
+PageTableLibGetPnleMapAttribute (
+  IN IA32_PAGE_NON_LEAF_ENTRY  *Pnle,
+  IN IA32_MAP_ATTRIBUTE        *ParentMapAttribute
+  )
+{
+  IA32_MAP_ATTRIBUTE  MapAttribute;
+
+  MapAttribute.Uint64 = Pnle->Uint64;
+
+  MapAttribute.Bits.Present        = ParentMapAttribute->Bits.Present & Pnle->Bits.Present;
+  MapAttribute.Bits.ReadWrite      = ParentMapAttribute->Bits.ReadWrite & Pnle->Bits.ReadWrite;
+  MapAttribute.Bits.UserSupervisor = ParentMapAttribute->Bits.UserSupervisor & Pnle->Bits.UserSupervisor;
+  MapAttribute.Bits.Nx             = ParentMapAttribute->Bits.Nx | Pnle->Bits.Nx;
+  MapAttribute.Bits.WriteThrough   = Pnle->Bits.WriteThrough;
+  MapAttribute.Bits.CacheDisabled  = Pnle->Bits.CacheDisabled;
+  MapAttribute.Bits.Accessed       = Pnle->Bits.Accessed;
+  return MapAttribute.Uint64;
+}
+
+/**
+  Return the attribute of a 2M/1G page table entry.
+
+  @param[in] PleB               Pointer to a 2M/1G page table entry.
+  @param[in] ParentMapAttribute Pointer to the parent attribute.
+
+  @return Attribute of the 2M/1G page table entry.
+**/
+UINT64
+PageTableLibGetPleBMapAttribute (
+  IN IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE  *PleB,
+  IN IA32_MAP_ATTRIBUTE                 *ParentMapAttribute
+  )
+{
+  IA32_MAP_ATTRIBUTE  MapAttribute;
+
+  //
+  // PageTableBaseAddress cannot be assigned field to field
+  // because their bit positions are different in IA32_MAP_ATTRIBUTE and IA32_PAGE_LEAF_ENTRY_BIG_PAGESIZE.
+  //
+  MapAttribute.Uint64 = IA32_PLEB_PAGE_TABLE_BASE_ADDRESS (PleB);
+
+  MapAttribute.Bits.Present        = ParentMapAttribute->Bits.Present & PleB->Bits.Present;
+  MapAttribute.Bits.ReadWrite      = ParentMapAttribute->Bits.ReadWrite & PleB->Bits.ReadWrite;
+  MapAttribute.Bits.UserSupervisor = ParentMapAttribute->Bits.UserSupervisor & PleB->Bits.UserSupervisor;
+  MapAttribute.Bits.Nx             = ParentMapAttribute->Bits.Nx | PleB->Bits.Nx;
+  MapAttribute.Bits.WriteThrough   = PleB->Bits.WriteThrough;
+  MapAttribute.Bits.CacheDisabled  = PleB->Bits.CacheDisabled;
+  MapAttribute.Bits.Accessed       = PleB->Bits.Accessed;
+
+  MapAttribute.Bits.Pat           = PleB->Bits.Pat;
+  MapAttribute.Bits.Dirty         = PleB->Bits.Dirty;
+  MapAttribute.Bits.Global        = PleB->Bits.Global;
+  MapAttribute.Bits.ProtectionKey = PleB->Bits.ProtectionKey;
+
+  return MapAttribute.Uint64;
+}
+
+/**
+  Return the attribute of a 4K page table entry.
+
+  @param[in] Pte4K              Pointer to a 4K page table entry.
+  @param[in] ParentMapAttribute Pointer to the parent attribute.
+
+  @return Attribute of the 4K page table entry.
+**/
+UINT64
+PageTableLibGetPte4KMapAttribute (
+  IN IA32_PTE_4K         *Pte4K,
+  IN IA32_MAP_ATTRIBUTE  *ParentMapAttribute
+  )
+{
+  IA32_MAP_ATTRIBUTE  MapAttribute;
+
+  MapAttribute.Uint64 = IA32_PTE4K_PAGE_TABLE_BASE_ADDRESS (Pte4K);
+
+  MapAttribute.Bits.Present        = ParentMapAttribute->Bits.Present & Pte4K->Bits.Present;
+  MapAttribute.Bits.ReadWrite      = ParentMapAttribute->Bits.ReadWrite & Pte4K->Bits.ReadWrite;
+  MapAttribute.Bits.UserSupervisor = ParentMapAttribute->Bits.UserSupervisor & Pte4K->Bits.UserSupervisor;
+  MapAttribute.Bits.Nx             = ParentMapAttribute->Bits.Nx | Pte4K->Bits.Nx;
+  MapAttribute.Bits.WriteThrough   = Pte4K->Bits.WriteThrough;
+  MapAttribute.Bits.CacheDisabled  = Pte4K->Bits.CacheDisabled;
+  MapAttribute.Bits.Accessed       = Pte4K->Bits.Accessed;
+
+  MapAttribute.Bits.Pat           = Pte4K->Bits.Pat;
+  MapAttribute.Bits.Dirty         = Pte4K->Bits.Dirty;
+  MapAttribute.Bits.Global        = Pte4K->Bits.Global;
+  MapAttribute.Bits.ProtectionKey = Pte4K->Bits.ProtectionKey;
+
+  return MapAttribute.Uint64;
+}
+
+/**
+  Recursively parse the non-leaf page table entries.
+
+  @param[in]      PageTableBaseAddress The base address of the 512 non-leaf page table entries in the specified level.
+  @param[in]      Level                Page level. Could be 5, 4, 3, 2, 1.
+  @param[in]      RegionStart          The base linear address of the region covered by the non-leaf page table entries.
+  @param[in]      ParentMapAttribute   The mapping attribute of the parent entries.
+  @param[in, out] Map                  Pointer to an array that describes multiple linear address ranges.
+  @param[in, out] MapCount             Pointer to a UINTN that hold the actual number of entries in the Map.
+  @param[in]      MapCapacity          The maximum number of entries the Map can hold.
+  @param[in]      LastEntry            Pointer to last map entry.
+  @param[in]      OneEntry             Pointer to a library internal storage that holds one map entry.
+                                       It's used when Map array is used up.
+**/
+VOID
+PageTableLibParsePnle (
+  IN     UINT64              PageTableBaseAddress,
+  IN     UINTN               Level,
+  IN     UINTN               MaxLevel,
+  IN     UINT64              RegionStart,
+  IN     IA32_MAP_ATTRIBUTE  *ParentMapAttribute,
+  IN OUT IA32_MAP_ENTRY      *Map,
+  IN OUT UINTN               *MapCount,
+  IN     UINTN               MapCapacity,
+  IN     IA32_MAP_ENTRY      **LastEntry,
+  IN     IA32_MAP_ENTRY      *OneEntry,
+  IN    BOOLEAN              SelfMapped
+  )
+{
+  IA32_PAGING_ENTRY   *PagingEntry;
+  UINTN               Index;
+  IA32_MAP_ATTRIBUTE  MapAttribute;
+  UINT64              RegionLength;
+  UINTN               PagingEntryNumber;
+
+  ASSERT (OneEntry != NULL);
+
+  if (SelfMapped) {
+    switch (Level) {
+      case 4:
+        PagingEntry = (IA32_PAGING_ENTRY *)(UINTN)0xFFFFFFFFFFFFF000;
+        break;
+      case 3:
+        PagingEntry = (IA32_PAGING_ENTRY *)(UINTN)(0xFFFFFFFFFFE00000 + SIZE_4KB * ((RegionStart >> 39) & 0x1FF));
+        break;
+      case 2:
+        PagingEntry = (IA32_PAGING_ENTRY *)(UINTN)(0xFFFFFFFFC0000000 +
+                                                   SIZE_2MB * ((RegionStart >> 39) & 0x1FF) +
+                                                   SIZE_4KB * ((RegionStart >> 30) & 0x1FF));
+        break;
+      case 1:
+        PagingEntry = (IA32_PAGING_ENTRY *)(UINTN)(0xFFFFFF8000000000 +
+                                                   SIZE_1GB * ((RegionStart >> 39) & 0x1FF) +
+                                                   SIZE_2MB * ((RegionStart >> 30) & 0x1FF) +
+                                                   SIZE_4KB * ((RegionStart >> 21) & 0x1FF));
+        break;
+    }
+  } else {
+    PagingEntry = (IA32_PAGING_ENTRY *)(UINTN)PageTableBaseAddress;
+  }
+
+  RegionLength      = REGION_LENGTH (Level);
+  PagingEntryNumber = ((MaxLevel == 3) && (Level == 3)) ? MAX_PAE_PDPTE_NUM : 512;
+
+  for (Index = 0; Index < PagingEntryNumber; Index++, RegionStart += RegionLength) {
+    if ((Level == 4) && ((Index == 0x1FF) || (Index == 0x1FE)) && SelfMapped) {
+      // Skip self-map entries in root table
+      continue;
+    }
+
+    if (PagingEntry[Index].Pce.Present == 0) {
+      continue;
+    }
+
+    if (IsPle (&PagingEntry[Index], Level)) {
+      ASSERT (Level == 1 || Level == 2 || Level == 3);
+
+      if (Level == 1) {
+        MapAttribute.Uint64 = PageTableLibGetPte4KMapAttribute (&PagingEntry[Index].Pte4K, ParentMapAttribute);
+      } else {
+        MapAttribute.Uint64 = PageTableLibGetPleBMapAttribute (&PagingEntry[Index].PleB, ParentMapAttribute);
+      }
+
+      if ((*LastEntry != NULL) &&
+          ((*LastEntry)->LinearAddress + (*LastEntry)->Length == RegionStart) &&
+          (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (&(*LastEntry)->Attribute) + (*LastEntry)->Length
+           == IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (&MapAttribute)) &&
+          (IA32_MAP_ATTRIBUTE_ATTRIBUTES (&(*LastEntry)->Attribute) == IA32_MAP_ATTRIBUTE_ATTRIBUTES (&MapAttribute))
+          )
+      {
+        //
+        // Extend LastEntry.
+        //
+        (*LastEntry)->Length += RegionLength;
+      } else {
+        if (*MapCount < MapCapacity) {
+          //
+          // LastEntry points to next map entry in the array.
+          //
+          *LastEntry = &Map[*MapCount];
+        } else {
+          //
+          // LastEntry points to library internal map entry.
+          //
+          *LastEntry = OneEntry;
+        }
+
+        //
+        // Set LastEntry.
+        //
+        (*LastEntry)->LinearAddress    = RegionStart;
+        (*LastEntry)->Length           = RegionLength;
+        (*LastEntry)->Attribute.Uint64 = MapAttribute.Uint64;
+        (*MapCount)++;
+      }
+    } else {
+      MapAttribute.Uint64 = PageTableLibGetPnleMapAttribute (&PagingEntry[Index].Pnle, ParentMapAttribute);
+      PageTableLibParsePnle (
+        IA32_PNLE_PAGE_TABLE_BASE_ADDRESS (&PagingEntry[Index].Pnle),
+        Level - 1,
+        MaxLevel,
+        RegionStart,
+        &MapAttribute,
+        Map,
+        MapCount,
+        MapCapacity,
+        LastEntry,
+        OneEntry,
+        SelfMapped
+        );
+    }
+  }
+}
+
+/**
+  Parse page table.
+
+  @param[in]      PageTable  Pointer to the page table.
+  @param[in]      PagingMode The paging mode.
+  @param[out]     Map        Return an array that describes multiple linear address ranges.
+  @param[in, out] MapCount   On input, the maximum number of entries that Map can hold.
+                             On output, the number of entries in Map.
+
+  @retval RETURN_UNSUPPORTED       PageLevel is not 5 or 4.
+  @retval RETURN_INVALID_PARAMETER MapCount is NULL.
+  @retval RETURN_INVALID_PARAMETER *MapCount is not 0 but Map is NULL.
+  @retval RETURN_BUFFER_TOO_SMALL  *MapCount is too small.
+  @retval RETURN_SUCCESS           Page table is parsed successfully.
+**/
+RETURN_STATUS
+EFIAPI
+PageTableParse (
+  IN     UINTN         PageTable,
+  IN     PAGING_MODE   PagingMode,
+  OUT  IA32_MAP_ENTRY  *Map,
+  IN OUT UINTN         *MapCount
+  )
+{
+  UINTN               MapCapacity;
+  IA32_MAP_ATTRIBUTE  NopAttribute;
+  IA32_MAP_ENTRY      *LastEntry;
+  IA32_MAP_ENTRY      OneEntry;
+  UINTN               MaxLevel;
+  UINTN               Index;
+  IA32_PAGING_ENTRY   BufferInStack[MAX_PAE_PDPTE_NUM];
+  BOOLEAN             SelfMapped;
+
+  if ((PagingMode == Paging32bit) || (PagingMode >= PagingModeMax)) {
+    //
+    // 32bit paging is never supported.
+    //
+    return RETURN_UNSUPPORTED;
+  }
+
+  if (MapCount == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if ((*MapCount != 0) && (Map == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if (PageTable == 0) {
+    *MapCount = 0;
+    return RETURN_SUCCESS;
+  }
+
+  SelfMapped = IA32_PNLE_PAGE_TABLE_BASE_ADDRESS (&((IA32_PAGE_NON_LEAF_ENTRY *)PageTable)[0x1FF]) == PageTable ? TRUE : FALSE;
+
+  if (SelfMapped) {
+    PageTable = 0xFFFFFFFFFFFFF000;
+
+    if (PagingMode == Paging5Level) {
+      return RETURN_UNSUPPORTED;
+    }
+  }
+
+  if (PagingMode == PagingPae) {
+    CopyMem (BufferInStack, (VOID *)PageTable, sizeof (BufferInStack));
+    for (Index = 0; Index < MAX_PAE_PDPTE_NUM; Index++) {
+      BufferInStack[Index].Pnle.Bits.ReadWrite      = 1;
+      BufferInStack[Index].Pnle.Bits.UserSupervisor = 1;
+      BufferInStack[Index].Pnle.Bits.Nx             = 0;
+    }
+
+    PageTable = (UINTN)BufferInStack;
+  }
+
+  //
+  // Page table layout is as below:
+  //
+  // [IA32_CR3]
+  //     |
+  //     |
+  //     V
+  // [IA32_PML5E]
+  // ...
+  // [IA32_PML5E] --> [IA32_PML4E]
+  //                  ...
+  //                  [IA32_PML4E] --> [IA32_PDPTE_1G] --> 1G aligned physical address
+  //                                   ...
+  //                                   [IA32_PDPTE] --> [IA32_PDE_2M] --> 2M aligned physical address
+  //                                                    ...
+  //                                                    [IA32_PDE] --> [IA32_PTE_4K]  --> 4K aligned physical address
+  //                                                                   ...
+  //                                                                   [IA32_PTE_4K]  --> 4K aligned physical address
+  //
+
+  NopAttribute.Uint64              = 0;
+  NopAttribute.Bits.Present        = 1;
+  NopAttribute.Bits.ReadWrite      = 1;
+  NopAttribute.Bits.UserSupervisor = 1;
+
+  MaxLevel    = (UINT8)(PagingMode >> 8);
+  MapCapacity = *MapCount;
+  *MapCount   = 0;
+  LastEntry   = NULL;
+  PageTableLibParsePnle ((UINT64)PageTable, MaxLevel, MaxLevel, 0, &NopAttribute, Map, MapCount, MapCapacity, &LastEntry, &OneEntry, SelfMapped);
+
+  if (*MapCount > MapCapacity) {
+    return RETURN_BUFFER_TOO_SMALL;
+  }
+
+  return RETURN_SUCCESS;
+}
 
 /**
   Populate the input page/translation table map.


### PR DESCRIPTION
## Description

See individual commit descriptions for full details. This changeset updates the paging audit simple test, full audit, and memory protections test app to run on Patina.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Tested on physical Intel, Q35, and SBSA.

## Integration Instructions

Ensure the platform is producing the memory protection HOB with:

```c
DxeSettings.HeapGuardPolicy.Fields.UefiPageGuard = 0;
DxeSettings.HeapGuardPolicy.Fields.UefiPoolGuard = 0;
```
Until Patina enables those features, otherwise those tests will execute and will fail due to no guard pages enabled.

This is a breaking change because it depends on mu_basecore version >= v2025020003.0.2 as some header definitions are depended on in that release.