### PR TITLE
Update Adv Logger Info to V6 [Rebase & FF]

### DIFF
--- a/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
+++ b/AdvLoggerPkg/Application/DecodeUefiLog/DecodeUefiLog.py
@@ -216,8 +216,33 @@ class AdvLogParser ():
     # EFI_PHYSICAL_ADDRESS    NewLoggerInfoAddress;   // If non-zero, this field holds the address of new logger info (added in later V5 revision, may not be present in older logs)
     # } ADVANCED_LOGGER_INFO;
     V5_LOGGER_INFO_SIZE = 80
-    V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS = 88
+    V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS = 88         # Note: This was shortly released in V5 but soon after in v6
     V5_LOGGER_INFO_VERSION = 5
+
+    # typedef volatile struct {
+    # UINT32      Signature;                          // Signature 'ALOG'
+    # UINT16      Version;                            // Current Version
+    # UINT16      Reserved[3];                        // Reserved for future
+    # UINT32      LogBufferOffset;                    // Offset from LoggerInfo to start of log, expected to be the size of this structure, 8 byte aligned
+    # UINT32      Reserved4;
+    # UINT32      LogCurrentOffset;                   // Offset from LoggerInfo to where to store next log entry.
+    # UINT32      DiscardedSize;                      // Number of bytes of messages missed
+    # UINT32      LogBufferSize;                      // Size of allocated buffer
+    # BOOLEAN     InPermanentRAM;                     // Log in permanent RAM
+    # BOOLEAN     AtRuntime;                          // After ExitBootServices
+    # BOOLEAN     GoneVirtual;                        // After VirtualAddressChange
+    # BOOLEAN     HdwPortInitialized;                 // HdwPort initialized
+    # BOOLEAN     HdwPortDisabled;                    // HdwPort is Disabled
+    # BOOLEAN     Reserved2[3];                       //
+    # UINT64      TimerFrequency;                     // Ticks per second for log timing
+    # UINT64      TicksAtTime;                        // Ticks when Time Acquired
+    # EFI_TIME    Time;                               // Uefi Time Field
+    # UINT32      HwPrintLevel;                       // Logging level to be printed at hw port
+    # UINT32      Reserved3;                          //
+    # EFI_PHYSICAL_ADDRESS    NewLoggerInfoAddress;   // If non-zero, this field holds the address of new logger info
+    # } ADVANCED_LOGGER_INFO;
+    V6_LOGGER_INFO_SIZE = 88
+    V6_LOGGER_INFO_VERSION = 6
 
     # ---------------------------------------------------------------------- #
     #
@@ -458,26 +483,40 @@ class AdvLogParser ():
             if InFile.tell() != (Size):
                 raise Exception('Error initializing logger info. AmountRead: %d' % InFile.tell())
 
-        elif Version == self.V5_LOGGER_INFO_VERSION:
-            InFile.read(4)  # skip over rest of reserved section
-            # V5 can be either 80 bytes or 88 bytes (minor version 1 update with NewLoggerInfoAddress)
+        elif (Version == self.V5_LOGGER_INFO_VERSION or
+              Version == self.V6_LOGGER_INFO_VERSION):
+            # skip over rest of reserved section
+            InFile.read(4)
+
+            # V5 can be either 80 bytes or 88 bytes
+            LoggerInfo["LogBufferOffset"] = struct.unpack(
+                "=I", InFile.read(4))[0]
+
             BaseAddress = 0
-            LoggerInfo["LogBufferOffset"] = struct.unpack("=I", InFile.read(4))[0]
             Size = LoggerInfo["LogBufferOffset"]
 
-            # Determine if this has the NewLoggerInfoAddress field based on structure size
-            if Size == self.V5_LOGGER_INFO_SIZE:
-                HasNewLoggerInfoAddress = False
-            elif Size == self.V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS:
+            print("Logger Info:")
+            print(f"  Version: {Version}")
+            print(f"  Size: {Size}")
+
+            # For V5, determine if this has the NewLoggerInfoAddress field
+            # based on structure size
+            if Version == self.V5_LOGGER_INFO_VERSION:
+                if Size == self.V5_LOGGER_INFO_SIZE:
+                    HasNewLoggerInfoAddress = False
+                elif Size == self.V5_LOGGER_INFO_SIZE_WITH_NEW_ADDRESS:
+                    HasNewLoggerInfoAddress = True
+                else:
+                    raise Exception(
+                        'Error initializing logger info. '
+                        'Unexpected V5 structure size: %d' % Size)
+            if Version == self.V6_LOGGER_INFO_VERSION:
                 HasNewLoggerInfoAddress = True
-            else:
-                raise Exception('Error initializing logger info. Unexpected V5 structure size: %d' % Size)
+                assert Size == self.V6_LOGGER_INFO_SIZE
 
             # we no longer have this field in the struct but for compatibility can calculate it
             # to be used
             LoggerInfo["LogBuffer"] = Size
-            # this is only used to calculate LogCurrent as an offset, but V5 uses
-            # LogCurrentOffset already, so we do this just to share the common code
             InFile.read(4)  # skip over reserved4 field
             LoggerInfo["LogCurrentOffset"] = struct.unpack("=I", InFile.read(4))[0]
             # we don't have this field anymore, but to share the common code we
@@ -521,6 +560,7 @@ class AdvLogParser ():
 
             if InFile.tell() != (Size):
                 raise Exception('Error initializing logger info. AmountRead: %d, Expected: %d' % (InFile.tell(), Size))
+
 
         else:
             raise Exception('Error initializing logger info. Unsupported version: 0x%X' % LoggerInfo["Version"])
@@ -698,7 +738,7 @@ class AdvLogParser ():
             Nanosecond = int((Ticks / Frequency) * 1000000000)
         else:
             Nanosecond = 0
-            
+
         return Nanosecond
 
     #

--- a/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
+++ b/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
@@ -14,12 +14,14 @@
 #define ADVANCED_LOGGER_SIGNATURE  SIGNATURE_32('A','L','O','G')
 
 //
-// Advanced Logger Hardware Port Level Support Version
+// Advanced Logger Information Structure Version
 //
-// Writing to hardware port based on message DebugLevel is supported
-// (AdvancedLoggerHdwPortWrite()).
+#define ADVANCED_LOGGER_INFO_VER  5
+
 //
-#define ADVANCED_LOGGER_HW_LVL_VER  5
+// The Advanced Logger Information Structure Version that supports HW_LVL logging
+//
+#define ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER  5
 
 //
 // Advanced Logger Message structure versions
@@ -29,8 +31,6 @@
 //
 #define ADVANCED_LOGGER_MSG_MAJ_VER  2
 #define ADVANCED_LOGGER_MSG_MIN_VER  1
-
-#define ADVANCED_LOGGER_VERSION  ADVANCED_LOGGER_HW_LVL_VER
 
 #define ADVANCED_LOGGER_PHASE_UNSPECIFIED  0
 #define ADVANCED_LOGGER_PHASE_SEC          1

--- a/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
+++ b/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
@@ -16,7 +16,7 @@
 //
 // Advanced Logger Information Structure Version
 //
-#define ADVANCED_LOGGER_INFO_VER  5
+#define ADVANCED_LOGGER_INFO_VER  6
 
 //
 // The Advanced Logger Information Structure Version that supports HW_LVL logging

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -277,7 +277,7 @@ AdvancedLoggerWrite (
     // if we are at a high enough version to support HW_LVL logging, only call the HdwPortWrite if this DebugLevel
     // is asked to be logged
     // if we are at an older version, check the PCD to see if we should log this message
-    if (LoggerInfo->Version >= ADVANCED_LOGGER_HW_LVL_VER) {
+    if (LoggerInfo->Version >= ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER) {
       if (DebugLevel & LoggerInfo->HwPrintLevel) {
         AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
       }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -383,7 +383,7 @@ InitializeLoggerInfoStructure (
 
   ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
   LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
-  LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+  LoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
   LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
   LoggerInfo->LogBufferSize    = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages)) - sizeof (ADVANCED_LOGGER_INFO);
   LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/GoogleTest/AdvancedLoggerDxeCoreGoogleTest.cpp
@@ -69,7 +69,7 @@ protected:
     mInitialized                    = FALSE;
     ImageHandle                     = (EFI_HANDLE)0x12345678;
     testLoggerInfo.Signature        = ADVANCED_LOGGER_SIGNATURE;
-    testLoggerInfo.Version          = ADVANCED_LOGGER_VERSION;
+    testLoggerInfo.Version          = ADVANCED_LOGGER_INFO_VER;
     testLoggerInfo.LogBufferOffset  = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     testLoggerInfo.LogCurrentOffset = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     mLoggerInfo                     = NULL;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
@@ -50,7 +50,7 @@ ValidateInfoBlock (
     return FALSE;
   }
 
-  if (mLoggerInfo->Version != ADVANCED_LOGGER_VERSION) {
+  if (mLoggerInfo->Version != ADVANCED_LOGGER_INFO_VER) {
     return FALSE;
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/GoogleTest/AdvancedLoggerMmCoreGoogleTest.cpp
@@ -56,7 +56,7 @@ protected:
     DebugLevel                      = DEBUG_ERROR;
     ImageHandle                     = (EFI_HANDLE)0x12345678;
     testLoggerInfo.Signature        = ADVANCED_LOGGER_SIGNATURE;
-    testLoggerInfo.Version          = ADVANCED_LOGGER_VERSION;
+    testLoggerInfo.Version          = ADVANCED_LOGGER_INFO_VER;
     testLoggerInfo.LogBufferOffset  = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     testLoggerInfo.LogCurrentOffset = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
   }
@@ -78,10 +78,10 @@ TEST_F (AdvancedLoggerMmCoreTest, AdvLoggerGetInfoFail) {
   mLoggerInfo->Signature = ADVANCED_LOGGER_SIGNATURE;
 
   // Invalid Version
-  mLoggerInfo->Version = (UINT32)ADVANCED_LOGGER_VERSION + 1;
+  mLoggerInfo->Version = (UINT32)ADVANCED_LOGGER_INFO_VER + 1;
   Status               = ValidateInfoBlock ();
   EXPECT_EQ (Status, FALSE);
-  mLoggerInfo->Version = ADVANCED_LOGGER_VERSION;
+  mLoggerInfo->Version = ADVANCED_LOGGER_INFO_VER;
 
   // Invalid Buffer Offset
   mLoggerInfo->LogBufferOffset = (UINT32)0;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -512,7 +512,7 @@ AdvancedLoggerGetLoggerInfo (
     BufferSize = sizeof (ADVANCED_LOGGER_INFO) + ADVANCED_LOGGER_MAX_MESSAGE_SIZE;
     ZeroMem ((VOID *)LoggerInfo, BufferSize);
     LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
-    LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+    LoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
     LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
     LoggerInfo->LogBufferSize    = (UINT32)(BufferSize - sizeof (ADVANCED_LOGGER_INFO));
     LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
@@ -565,7 +565,7 @@ AdvancedLoggerGetLoggerInfo (
         LoggerInfo = ALI_FROM_PA (NewLoggerInfo);
         ZeroMem ((VOID *)LoggerInfo, BufferSize);
         LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
-        LoggerInfo->Version          = ADVANCED_LOGGER_VERSION;
+        LoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
         LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
         LoggerInfo->LogBufferSize    = (UINT32)(BufferSize - sizeof (ADVANCED_LOGGER_INFO));
         LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/GoogleTest/AdvancedLoggerPeiCoreGoogleTest.cpp
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/GoogleTest/AdvancedLoggerPeiCoreGoogleTest.cpp
@@ -68,7 +68,7 @@ protected:
     DebugLevel                      = DEBUG_ERROR;
     ImageHandle                     = (EFI_HANDLE)0x12345678;
     testLoggerInfo.Signature        = ADVANCED_LOGGER_SIGNATURE;
-    testLoggerInfo.Version          = ADVANCED_LOGGER_VERSION;
+    testLoggerInfo.Version          = ADVANCED_LOGGER_INFO_VER;
     testLoggerInfo.LogBufferOffset  = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     testLoggerInfo.LogCurrentOffset = (ALIGN_VALUE (sizeof (testLoggerInfo), 8));
     ZeroMem (SourceBuf, NumberOfBytes);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
@@ -39,7 +39,7 @@ AdvancedLoggerLibConstructor (
   if (LoggerInfo != NULL) {
     ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
     LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
-    LoggerInfo->Version            = ADVANCED_LOGGER_VERSION;
+    LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;
     LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
     LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
     LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;

--- a/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
@@ -126,7 +126,7 @@ InitializeDebugAgent (
       LoggerInfo = ALI_FROM_PA (NewLogBuffer);
       ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
       LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
-      LoggerInfo->Version            = ADVANCED_LOGGER_VERSION;
+      LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;
       LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
       LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
       LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;


### PR DESCRIPTION
## Description

**AdvLoggerPkg: Define a single advanced logger info version**

Currrently, ADVANCED_LOGGER_INFO_VER is being used to set and check
the version field in the ADVANCED_LOGGER_INFO struct.

This more clearly defines that version to be associated with the
log info structure and breaks out the Hardware Level version to a
macro (ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER) that clearly shows
that is an identifier for hardware level support being present in
the logger info version.

---

**AdvLoggerPkg: Bump ADVANCED_LOGGER_INFO_VER to 6**

Updates the major version to 6 to account for the `NewLoggerInfoAddress`
field that was added to `ADVANCED_LOGGER_INFO`.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- AdvLoggerPkg CI build
- AdvLoggerPkg QEMU Q35 boot to EFI shell and dump log with EFI app
- Intel physical platform boot to OS and decode log (in progress)
- Arm platform test (todo)

## Integration Instructions

- Ensure all adv logger code is updated to the same version and you're using the latest version of the applications in AdvLoggerPkg.