### PR TITLE
AdvLoggerPkg: Initialize structures in LineParserTestApp

### DIFF
--- a/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
+++ b/AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.c
@@ -408,7 +408,9 @@ InitializeInMemoryLog (
     UT_ASSERT_TRUE (FALSE);
   }
 
+  ZeroMem ((VOID *)mLoggerInfo, sizeof (*mLoggerInfo));
   mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
   mLoggerInfo->GoneVirtual      = FALSE;
   mLoggerInfo->AtRuntime        = FALSE;
   mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
@@ -457,7 +459,9 @@ InitializeInMemoryLogV2 (
     UT_ASSERT_TRUE (FALSE);
   }
 
+  ZeroMem ((VOID *)mLoggerInfo, sizeof (*mLoggerInfo));
   mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
   mLoggerInfo->GoneVirtual      = FALSE;
   mLoggerInfo->AtRuntime        = FALSE;
   mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);
@@ -507,7 +511,9 @@ InitializeInMemoryLogV2Hybrid (
     UT_ASSERT_TRUE (FALSE);
   }
 
+  ZeroMem ((VOID *)mLoggerInfo, sizeof (*mLoggerInfo));
   mLoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  mLoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
   mLoggerInfo->GoneVirtual      = FALSE;
   mLoggerInfo->AtRuntime        = FALSE;
   mLoggerInfo->LogBufferSize    = EFI_PAGE_SIZE * IN_MEMORY_PAGES - sizeof (*mLoggerInfo);


### PR DESCRIPTION
## Description

Logger info structures are not zeroed and initialized right now, causing garbage data to be read in some fields and impact test results.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run LineParserTestApp on QEMU Q35

## Integration Instructions

- N/A