### PR TITLE
SwmDialog: Fix missing NULL terminator for UninstallMultipleProtocolInterfaces

### DIFF
--- a/MsGraphicsPkg/Library/SwmDialogsLib/SwmDialogs.c
+++ b/MsGraphicsPkg/Library/SwmDialogsLib/SwmDialogs.c
@@ -402,6 +402,7 @@ SwmDialogsDestructor (
     gBS->UninstallMultipleProtocolInterfaces (
            gPriorityHandle,
            &gPriorityGuid,
+           NULL,
            NULL
            );
   }


### PR DESCRIPTION
## Description

SwmDialogsDestructor calls UninstallMultipleProtocolInterfaces() which takes a Null-terminated list of <guid, interface> pairs to uninstall. However, it fails to include the NULL terminator, which causes an attempt to uninstall stack garbage. This PR adds the NULL termination to the call to correctly terminate the list.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unloaded a driver before/after the fix, observed that attempt to uninstall non-existent protocol no longer occurs. 

## Integration Instructions

N/A