### PR TITLE
AdvLoggerPkg: Check for migrated buffer on ReadyToLock notification

### DIFF
--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
@@ -13,6 +13,7 @@
 #include <AdvancedLoggerInternal.h>
 
 #include <Protocol/AdvancedLogger.h>
+#include <Protocol/MmReadyToLock.h>
 
 #include <Library/AdvLoggerAccessLib.h>
 #include <Library/BaseLib.h>
@@ -20,6 +21,7 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
+#include <Library/MmServicesTableLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
@@ -27,6 +29,7 @@ STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo        = NULL;
 STATIC UINT32                mBufferSize         = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress         = 0;
 STATIC UINTN                 mLoggerTransferSize = 0;
+STATIC BOOLEAN               mReadyToLock        = FALSE;
 extern UINTN                 mVariableBufferPayloadSize;
 
 /**
@@ -140,6 +143,38 @@ ValidateInfoBlock (
 }
 
 /**
+  MM ReadyToLock notification handler.
+
+  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
+
+  @param[in] Protocol   Protocol GUID pointer.
+  @param[in] Interface  Protocol interface pointer.
+  @param[in] Handle     The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS   The notification handler completed successfully.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+OnMmReadyToLock (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ReadyToLock. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    }
+  }
+
+  mReadyToLock = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
     AdvLoggerInit - Obtain the address of the logger info block.
 
     @param          NONE
@@ -152,6 +187,7 @@ AdvLoggerAccessInit (
   )
 {
   EFI_HOB_GUID_TYPE    *GuidHob;
+  VOID                 *Registration;
   ADVANCED_LOGGER_PTR  *LogPtr;
   EFI_STATUS           Status;
   UINTN                TempSize;
@@ -173,11 +209,11 @@ AdvLoggerAccessInit (
 
   if (mLoggerInfo != NULL) {
     mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
-  }
 
-  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+    if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+      if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+        DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
+      }
     }
   }
 
@@ -208,6 +244,15 @@ AdvLoggerAccessInit (
   //
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, code=%r\n", __FUNCTION__, mLoggerInfo, Status));
+
+  Status = gMmst->MmRegisterProtocolNotify (
+                    &gEfiMmReadyToLockProtocolGuid,
+                    OnMmReadyToLock,
+                    &Registration
+                    );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
+  }
 }
 
 /**
@@ -263,7 +308,7 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
 
-  if ((mLoggerInfo != NULL) && !mLoggerInfo->AtRuntime && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
     if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
       DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
     }
@@ -335,12 +380,6 @@ AdvLoggerAccessAtRuntime (
   VOID
   )
 {
-  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ExitBootServices. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-    }
-  }
-
   if (mLoggerInfo != NULL) {
     mLoggerInfo->AtRuntime = TRUE;
   }

--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.inf
@@ -34,12 +34,16 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MmServicesTableLib
   PcdLib
   SafeIntLib
 
 [Guids]
   gAdvancedLoggerHobGuid
   gAdvLoggerAccessGuid                      ## CONSUMES
+
+[Protocols]
+  gEfiMmReadyToLockProtocolGuid             ## NOTIFY
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
@@ -13,6 +13,7 @@
 #include <Guid/SmmVariableCommon.h>
 
 #include <Protocol/AdvancedLogger.h>
+#include <Protocol/SmmReadyToLock.h>
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Library/AdvLoggerAccessLib.h>
@@ -21,12 +22,14 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/SafeIntLib.h>
+#include <Library/SmmServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
 STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo        = NULL;
 STATIC UINT32                mBufferSize         = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress         = 0;
 STATIC UINTN                 mLoggerTransferSize = 0;
+STATIC BOOLEAN               mReadyToLock        = FALSE;
 extern UINTN                 mVariableBufferPayloadSize;
 
 /**
@@ -142,6 +145,38 @@ ValidateInfoBlock (
 }
 
 /**
+  SMM ReadyToLock notification handler.
+
+  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
+
+  @param[in] Protocol   Protocol GUID pointer.
+  @param[in] Interface  Protocol interface pointer.
+  @param[in] Handle     The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS   The notification handler completed successfully.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+OnSmmReadyToLock (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  if (mLoggerInfo != NULL) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ReadyToLock. LoggerInfo=%p\n", __func__, mLoggerInfo));
+    }
+  }
+
+  mReadyToLock = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
     AdvLoggerInit - Obtain the address of the logger info block.
 
     @param          NONE
@@ -154,8 +189,11 @@ AdvLoggerAccessInit (
   )
 {
   ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
+  VOID                      *Registration;
   UINTN                     TempSize;
   EFI_STATUS                Status;
+
+  Registration = NULL;
 
   if (gBS == NULL) {
     return;
@@ -191,7 +229,7 @@ AdvLoggerAccessInit (
     if (mLoggerInfo != NULL) {
       mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
 
-      if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
         DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
       }
     }
@@ -206,6 +244,17 @@ AdvLoggerAccessInit (
   //
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, code=%r\n", __FUNCTION__, mLoggerInfo, Status));
+
+  if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    Status = gSmst->SmmRegisterProtocolNotify (
+                      &gEfiSmmReadyToLockProtocolGuid,
+                      OnSmmReadyToLock,
+                      &Registration
+                      );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
+    }
+  }
 }
 
 /**
@@ -261,7 +310,7 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
 
-  if ((mLoggerInfo != NULL) && !mLoggerInfo->AtRuntime) {
+  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
     if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
       DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
     }
@@ -333,12 +382,6 @@ AdvLoggerAccessAtRuntime (
   VOID
   )
 {
-  if (mLoggerInfo != NULL) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ExitBootServices. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-    }
-  }
-
   if (mLoggerInfo != NULL) {
     mLoggerInfo->AtRuntime = TRUE;
   }

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   PcdLib
   SafeIntLib
+  SmmServicesTableLib
   UefiBootServicesTableLib
 
 [Guids]
@@ -41,6 +42,7 @@
 
 [Protocols]
   gAdvancedLoggerProtocolGuid               ## CONSUMES
+  gEfiSmmReadyToLockProtocolGuid            ## NOTIFY
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
@@ -11,6 +11,7 @@
 #include <AdvancedLoggerInternal.h>
 
 #include <Protocol/AdvancedLogger.h>
+#include <Protocol/SmmReadyToLock.h>
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Pi/PiSmmCis.h>
@@ -27,6 +28,7 @@ STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo;
 STATIC UINT32                mBufferSize  = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress  = 0;
 STATIC BOOLEAN               mInitialized = FALSE;
+STATIC BOOLEAN               mReadyToLock = FALSE;
 
 VOID
 EFIAPI
@@ -117,6 +119,38 @@ ValidateInfoBlock (
 }
 
 /**
+  SMM ReadyToLock notification handler.
+
+  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
+
+  @param[in] Protocol   Protocol GUID pointer.
+  @param[in] Interface  Protocol interface pointer.
+  @param[in] Handle     The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS   The notification handler completed successfully.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+OnSmmReadyToLock (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  if (mLoggerInfo != NULL) {
+    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+      mAdvLoggerProtocol.LoggerInfo = mLoggerInfo;
+    }
+  }
+
+  mReadyToLock = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
     Get the Logger Information Block published by DxeCore.
  **/
 STATIC
@@ -176,7 +210,9 @@ AdvancedLoggerGetLoggerInfo (
 {
   SmmInitializeLoggerInfo ();
 
-  if ((mLoggerInfo != NULL) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
+  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM) &&
+      AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize))
+  {
     DEBUG ((DEBUG_INFO, "MmCore %a: Logger Update. LoggerInfo=%p\n", __func__, mLoggerInfo));
   }
 
@@ -220,6 +256,9 @@ SmmCoreAdvancedLoggerLibConstructor (
 {
   EFI_HANDLE  Handle;
   EFI_STATUS  Status;
+  VOID        *Registration;
+
+  Registration = NULL;
 
   ASSERT ((gBS != NULL) && (gSmst != NULL));
 
@@ -241,6 +280,17 @@ SmmCoreAdvancedLoggerLibConstructor (
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __func__, mLoggerInfo, Status));
   ASSERT_EFI_ERROR (Status);
+
+  if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
+    Status = gSmst->SmmRegisterProtocolNotify (
+                      &gEfiSmmReadyToLockProtocolGuid,
+                      OnSmmReadyToLock,
+                      &Registration
+                      );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
+    }
+  }
 
   return EFI_SUCCESS;
 }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -43,9 +43,11 @@
 
 [Protocols]
   gAdvancedLoggerProtocolGuid                                               ## CONSUMES
+  gEfiSmmReadyToLockProtocolGuid                                            ## NOTIFY
 
 [Pcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel  ## SOMETIMES_CONSUMES
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM


### PR DESCRIPTION
## Description

1. Adds a ReadyToLock handler to ensure that any buffer migration that may not have occurred prior to that point happens at ReadyToLock.
2. Aligns Traditional MM and Standalone MM code on the ReadyToLock boundary.
3. Also ensures all calls to check for a new logger are gated on PcdAdvancedLoggerFixedInRAM to avoid unnecessary checks when the logger won't be migrated.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot Traditional SMM virtual machine platform to Windows with change
- Boot Standalone MM virtual machine platform to Windows with change
- Boot Intel platform to Windows with change (Traditional and Standalone MM)
- Dump log at EFI shell
- Dump log uses the latest decode Python script in Windows

## Integration Instructions

- N/A