### PR TITLE
Remove crate versioning from local cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ MuTelemetryHelperLib = { path = "MsWheaPkg/Crates/MuTelemetryHelperLib" }
 RustAdvancedLoggerDxe = { path = "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe" }
 RustBootServicesAllocatorDxe = { path = "MsCorePkg/Crates/RustBootServicesAllocatorDxe" }
 mu_uefi_boot_services = { version = "2" }
+mockall = {version = "0.14.0"}
 
 memoffset = "0.9.0"
 num-traits = { version = "0.2", default-features = false }

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -29,4 +29,4 @@ scroll = {workspace=true}
 RustBootServicesAllocatorDxe = {workspace=true}
 
 [dev-dependencies]
-mockall = "0.14.0"
+mockall = { workspace = true }

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
@@ -14,7 +14,7 @@ r-efi = { workspace = true }
 mu_uefi_boot_services = { workspace = true }
 
 [dev-dependencies]
-mockall = { version = "0.14.0" }
+mockall = { workspace = true }
 mu_uefi_boot_services = { workspace = true, features = ["mockall"] }
 
 [lints.rust]


### PR DESCRIPTION
## Description

Remove crate versioning for mockall from module level cargo.toml

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Moved the versioning to root level cargo.toml and cargo tests run fine.

## Integration Instructions

N/A