### PR TITLE
[2502] MsGraphicsPkg: Prevent TPL inversion in SRESetMode()

### DIFF
--- a/MsGraphicsPkg/RenderingEngineDxe/RenderingEngine.c
+++ b/MsGraphicsPkg/RenderingEngineDxe/RenderingEngine.c
@@ -432,7 +432,10 @@ SRESetMode (
 
   // Raise the TPL to avoid getting interrupted while we access shared data structures.
   //
-  PreviousTPL = gBS->RaiseTPL (TPL_CALLBACK);
+  PreviousTPL = EfiGetCurrentTpl ();
+  if (PreviousTPL < TPL_CALLBACK) {
+    PreviousTPL = gBS->RaiseTPL (TPL_CALLBACK);
+  }
 
   Status = mParentGop->SetMode (
                          mParentGop,


### PR DESCRIPTION
## Description

It has been observed on some platforms that SRESetMode() is invoked at a TPL greater than TPL_CALLBACK, which leads to TPL inversion when SRESetMode() unconditionally raises the TPL to TPL_CALLBACK.

The platform behavior seems reasonable given there are no apparent caller restrictions on GOP so it would default to <= TPL_NOTIFY.

I believe that the better solution is to change this code to raise to TPL_NOTIFY instead of TPL_CALLBACK.

That is not done for a couple of reasons:

1. SRESetMode() is the RenderingEngineDxe wrapper around the real GOP SetMode(). Because many GOP implementations are closed source, it is difficult to determine what the impact would be to raise to TPL_NOTIFY. For example, they could similarly raise to TPL_CALLBACK (though unlikely), and this would move the TPL inversion to the GOP driver.
2. Every other SRE function raises to TPL_NOTIFY. Doing so here would provide consistent TPL expectations in the implementation. However, this leads me to believe this specific call was raised to TPL_CALLBACK intentionally, so I am hesitant to change it without more background on why it was done.

In the end, this change balances the risk of not breaking existing implementations while addressing the TPL inversion issue by simply maintaining the same behavior as before conditionally to avoid TPL inversion.

Note: GOP SetMode() implementations can raise to TPL >TPL_CALLBACK to actually protect its critical section before and after this change.

This is not a recent regression, SRESetMode() has always been implemented this way.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Qemu Q35 and SBSA boot to shell
- Boot Intel physical platform that encountered TPL inversion with the change

## Integration Instructions

- N/A