### PR TITLE
Replace memcpy with CopyGuid.

### DIFF
--- a/MsGraphicsPkg/MsUiTheme/Pei/MsUiThemePpi.c
+++ b/MsGraphicsPkg/MsUiTheme/Pei/MsUiThemePpi.c
@@ -109,7 +109,7 @@ MsUiThemePpiEntry (
   }
 
   DEBUG ((DEBUG_VERBOSE, "Font Hob=%p\n", GuidHob));
-  GuidHob->Name = gMsUiThemeHobGuid;
+  CopyGuid (&GuidHob->Name, &gMsUiThemeHobGuid);
 
   HobData  = (EFI_PHYSICAL_ADDRESS *)(GuidHob+1);
   *HobData = (EFI_PHYSICAL_ADDRESS)(UINTN)NewFonts;


### PR DESCRIPTION
There is a link error here, due to struct assignment being memcpy with some compilers.

Replace struct assignment with CopyGuid.