### PR TITLE
UefiTestingPkg: FlatPageTableLib: Include Public Page Table Defs

### DIFF
--- a/UefiTestingPkg/Library/FlatPageTableLib/X64/FlatPageTableX64.c
+++ b/UefiTestingPkg/Library/FlatPageTableLib/X64/FlatPageTableX64.c
@@ -12,10 +12,13 @@
 #include <Library/CpuPageTableLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FlatPageTableLib.h>
+#include <Register/X86/CpuPageTable.h>
 
 #define X64_PRESENT_BIT  BIT0
 #define X64_RW_BIT       BIT1
 #define X64_NX_BIT       BIT63
+
+#define MAX_PAE_PDPTE_NUM  4
 
 #define REGION_LENGTH(l)  LShiftU64 (1, (l) * 9 + 3)
 


### PR DESCRIPTION
## Description

In mu_basecore commit 5ba3221588832c47249a6db1f38b490f034e07ca the X86 Page Table definitions were moved from CpuPageTableLib to MdePkg. Consume these from the new location and define a macro that remained in the private header in edk2.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built.

## Integration Instructions

N/A.
