### PR TITLE
UefiTestingPkg: MpManagement clangpdb compatibility

### DIFF
--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/AsmSupport.S
@@ -38,7 +38,7 @@ ASM_PFX(AsmApEntryPoint):
   // Mask the non-affinity bits
   bic x0, x0, 0x00ff000000
   and x0, x0, 0xffffffffff
-  ldr x1, mCpuInfo            // x1 = mCpuInfo
+  LDR_LIT(x1, mCpuInfo)            // x1 = mCpuInfo
   mov x2, 0                   // x2 = processor index
 
 // TODO: This is, again, reverse engineering to correlate the CPU index with the MPIDRs...
@@ -51,7 +51,7 @@ ASM_PFX(AsmApEntryPoint):
   beq JumpToCFunction
   add x1, x1, #40             // x1 = x1 + sizeof (ARM_CORE_INFO)
   add x2, x2, 1               // x2++
-  ldr x3, mNumCpus
+  LDR_LIT(x3, mNumCpus)
   cmp x2, x3                  // check if x2 >= x3, we've reached the end of mCpuInfo
   bge ProcessorNotFound
   b   1b                      // Otherwise, keep looping
@@ -59,8 +59,8 @@ ASM_PFX(AsmApEntryPoint):
 JumpToCFunction:
 // Calculate stack address
   // x2 contains the index for the current processor
-  ldr x0, gApStacksBase
-  ldr x1, gApStackSize
+  LDR_LIT(x0, gApStacksBase)
+  LDR_LIT(x1, gApStackSize)
   add x2, x2, 1               // x2 = ProcessorIndex + 1, preemptively adding 1 so that the calculated sp will be at the bottom of the stack.
   mul x3, x2, x1              // x3 = (ProcessorIndex + 1) * gApStackSize
   add sp, x0, x3              // sp = gApStacksBase + x3

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/AARCH64/SuspendHandling.c
@@ -144,7 +144,8 @@ CpuMpArchInit (
   VOID                    *HobData;
   UINTN                   HobDataSize;
 
-  Status = EFI_SUCCESS;
+  Status  = EFI_SUCCESS;
+  MaxCpus = 0;
 
   /* Query the suspend feature flags during init steps */
   Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/ApFunction.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/ApFunction.c
@@ -40,6 +40,8 @@ ApFunction (
   BOOLEAN                          BreakLoop;
   volatile MP_MANAGEMENT_METADATA  *MyBuffer;
 
+  MyBuffer = NULL;
+
   // First figure who am i.
   Status = mMpServices->WhoAmI (mMpServices, &ProcessorId);
   if (EFI_ERROR (Status)) {
@@ -138,8 +140,10 @@ ApFunction (
 Done:
   RestoreInterruptStatus (ProcessorId);
 
-  MyBuffer->ApStatus = AP_STATE_OFF;
-  MyBuffer->ApTask   = AP_TASK_IDLE;
+  if (MyBuffer != NULL) {
+    MyBuffer->ApStatus = AP_STATE_OFF;
+    MyBuffer->ApTask   = AP_TASK_IDLE;
+  }
 
   return;
 }

--- a/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
+++ b/UefiTestingPkg/FunctionalSystemTests/MpManagement/Driver/MpManagement.c
@@ -179,6 +179,7 @@ MpMgmtBspSuspend (
   EFI_STATUS  Status;
   EFI_HANDLE  Handle;
 
+  Handle = NULL;
   if (BspPowerState >= AP_POWER_NUM) {
     DEBUG ((DEBUG_ERROR, "%a The power state is not supported %d\n", __FUNCTION__, BspPowerState));
     Status = EFI_INVALID_PARAMETER;


### PR DESCRIPTION


## Description

Make the MpManagement FunctionalTest compile with clangpdb.

Correct some uninitialized variable paths, and use macros for 
loading variables it registers in assembly. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
ClangPdb Build.

## Integration Instructions
No integration necessary.