### PR TITLE
AdvancedFileLogger: Filter log file output by PcdDebugPrintErrorLevel

### DIFF
--- a/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
+++ b/AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
@@ -63,6 +63,7 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerPages            ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedFileLoggerForceEnable  ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedFileLoggerFlush        ## CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel              ## CONSUMES
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
+++ b/AdvLoggerPkg/AdvancedFileLogger/FileAccess.c
@@ -531,6 +531,17 @@ WriteALogFile (
   Status   = AdvancedLoggerAccessLibGetNextFormattedLine (&LogDevice->AccessEntry);
 
   while (Status == EFI_SUCCESS) {
+    //
+    // Filter messages by PcdDebugPrintErrorLevel before writing to the log file.
+    // This ensures the file logger respects the same debug level mask as DebugPrint(),
+    // filtering out messages (e.g. DEBUG_VERBOSE from Rust drivers) that bypass the
+    // DebugLib level check.
+    //
+    if ((LogDevice->AccessEntry.DebugLevel & PcdGet32 (PcdDebugPrintErrorLevel)) == 0) {
+      Status = AdvancedLoggerAccessLibGetNextFormattedLine (&LogDevice->AccessEntry);
+      continue;
+    }
+
     WriteSize = LogDevice->AccessEntry.MessageLen;
     if (WriteSize > RoomLeft) {
       WriteSize = RoomLeft;


### PR DESCRIPTION
## Description

AdvancedFileLogger: Filter log file output by PcdDebugPrintErrorLevel

Rust UEFI drivers (e.g., UefiHidDxeV2) use the AdvancedLogger protocol directly via the [debugln!] macro, bypassing the C DebugLib layer. Unlike C drivers, where DebugPrint() checks PcdDebugPrintErrorLevel via BaseDebugPrintErrorLevelLib before any message enters the AdvancedLogger pipeline, Rust drivers write to the protocol with no level filtering. This causes DEBUG_VERBOSE messages (e.g., [VERB] usage 0x42 inserted) to appear in the file logger output, even though they are correctly filtered from serial output by PcdAdvancedLoggerHdwPortDebugPrintErrorLevel.

## How This Was Tested

Tested with AdvancedFileLogger, no more verbose level log from rust driver is seen, matches the behavior of c drivers.