### PR TITLE
[REBASE & FF] Copy FltUsedLib to MsCorePkg

### DIFF
--- a/MfciPkg/MfciPkg.dsc
+++ b/MfciPkg/MfciPkg.dsc
@@ -80,7 +80,6 @@
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
 
   # MsWheaEarlyStorageLib|MsWheaPkg/Library/MsWheaEarlyStorageLib/MsWheaEarlyStorageLib.inf
   # CheckHwErrRecHeaderLib|MsWheaPkg/Library/CheckHwErrRecHeaderLib/CheckHwErrRecHeaderLib.inf

--- a/MfciPkg/UnitTests/MfciPkgHostTest.dsc
+++ b/MfciPkg/UnitTests/MfciPkgHostTest.dsc
@@ -61,7 +61,6 @@
   SerialPortLib|MdePkg/Library/BaseSerialPortLibNull/BaseSerialPortLibNull.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
   MuTelemetryHelperLib|MsWheaPkg/Library/MuTelemetryHelperLib/MuTelemetryHelperLib.inf
 
 ################################################################################

--- a/MsCorePkg/Library/FltUsedLib/FltUsedLib.c
+++ b/MsCorePkg/Library/FltUsedLib/FltUsedLib.c
@@ -1,11 +1,13 @@
 /** @file
-  Lib to include if using floats
+  This library provides the _fltused symbol which is required to by MSVC and clang
+  when floating point operations are used. This library should be linked in for
+  any module that uses floating point operations.
 
-Copyright (C) Microsoft Corporation.
-SPDX-License-Identifier: BSD-2-Clause-Patent
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-// create a global to satisfy the compilers insertion of the _fltused
+// create a global to satisfy the compilers insertion of the _fltused symbol
 // in response to detecting floating point type operations.
 int  _fltused = 0x9875;

--- a/MsCorePkg/Library/FltUsedLib/FltUsedLib.c
+++ b/MsCorePkg/Library/FltUsedLib/FltUsedLib.c
@@ -1,0 +1,11 @@
+/** @file
+  Lib to include if using floats
+
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// create a global to satisfy the compilers insertion of the _fltused
+// in response to detecting floating point type operations.
+int  _fltused = 0x9875;

--- a/MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
+++ b/MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  Lib to include if using floats
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FltUsedLib
+  FILE_GUID                      = 73AE6E44-EB12-4CB8-952F-101AC27B0D36
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FltUsedLib
+
+[Sources]
+  FltUsedLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MsCorePkg/MsCorePkg.dec
+
+[BuildOptions]
+  # We cannot build the MSVC version with /GL (whole program optimization) because we run into linker error
+  # LNK1237, which is a failure to link against a symbol from a library compiled with /GL. The whole program
+  # optimization tries to do away with references to this symbol. The solution is to not compile this lib with /GL
+  MSFT:*_*_*_CC_FLAGS = /GL-
+
+  # We cannot build the CLANGPDB version with LTO (link time optimization) because we run into linker errors where
+  # the _fltused variable has been optimized away, as it looks to GCC like the variable is not used, because
+  # the compiler inserts the usage.
+  GCC:*_*_*_CC_FLAGS = -fno-lto

--- a/MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
+++ b/MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
@@ -1,5 +1,7 @@
 ## @file
-#  Lib to include if using floats
+#  This library provides the _fltused symbol which is required to by MSVC and clang
+#  when floating point operations are used. This library should be linked in for
+#  any module that uses floating point operations.
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MsCorePkg/Library/FltUsedLib/Readme.md
+++ b/MsCorePkg/Library/FltUsedLib/Readme.md
@@ -1,0 +1,39 @@
+# FltUsedLib
+
+This library provides a global (`_fltused`) that the compiler generates in response to seeing
+floating point type operations.
+
+Examples are using `float`, `double` or using floating point conversions (assigning integers
+to `0.1` would be a conversion). The compiler generates the `_fltused`, and a CRT type library
+(C Runtime) will checks the value to see if C Floating Point libraries need to be linked in
+final binary generation.
+
+There are only a few places in Edk2/MU today that use float or double, but there are places
+in silicon vendor provided code. The problematic situation that we run into is the libraries.
+If a library knows that it uses floating points, and it defines its own `_fltused` value, then
+it will be able to build by itself. If each library defines their own `_fltused`, it can generate
+another set of linker problems, of duplicate defined symbols. For example, if MathLib (MU_PLUS)
+defines its `_fltused`, and MathLib is linked into a module that also consumes a silicon vendor
+library, the linker will see duplicate defined symbols and fail.
+
+Relying into Edk2's LibraryClasses provides relief for both these scenarios. Each library/module
+that triggers `_fltused` will be satisfied if they all consume the FltUsed library. Modules which
+consume multiple libraries which rely on `_fltused`, will also be satisfied as only one declaration
+of fltused will be linked into the final executable.
+
+## Using
+
+To use FltUsedLib, just include it in the INF of the module containing floating point flagged code.
+
+```inf
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  FltUsedLib
+```
+
+## Copyright & License
+
+Copyright (c) Microsoft Corporation
+
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MsCorePkg/MsCorePkg.ci.yaml
+++ b/MsCorePkg/MsCorePkg.ci.yaml
@@ -54,7 +54,9 @@
 
     ## options defined ci/Plugin/DscCompleteCheck
     "DscCompleteCheck": {
-        "IgnoreInf": [],
+        "IgnoreInf": [
+            "MsCorePkg/Library/FltUsedLib/FltUsedLib.inf"
+        ],
         "DscPath": "MsCorePkg.dsc"
     },
 

--- a/MsCorePkg/MsCorePkg.dsc
+++ b/MsCorePkg/MsCorePkg.dsc
@@ -70,7 +70,7 @@
 
   BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   JsonLiteParserLib|MsCorePkg/Library/JsonLiteParser/JsonLiteParser.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+  FltUsedLib|MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
   MuTelemetryHelperLib|MsWheaPkg/Library/MuTelemetryHelperLib/MuTelemetryHelperLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
 
@@ -161,6 +161,7 @@
   MsCorePkg/Library/BaseSecureBootKeyStoreLib/BaseSecureBootKeyStoreLib.inf
   MsCorePkg/Library/MuSecureBootKeySelectorLib/MuSecureBootKeySelectorLib.inf
   MsCorePkg/HelloWorldRustDxe/HelloWorldRustDxe.inf
+  MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
 
 [Components.IA32]
   MsCorePkg/Core/GuidedSectionExtractPeim/GuidedSectionExtract.inf

--- a/MsGraphicsPkg/MsGraphicsPkg.dsc
+++ b/MsGraphicsPkg/MsGraphicsPkg.dsc
@@ -68,7 +68,7 @@
   #ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
   #FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
-  FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+  FltUsedLib|MsCorePkg/Library/FltUsedLib/FltUsedLib.inf
 
 [LibraryClasses.common.PEIM]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf


### PR DESCRIPTION
## Description

FltUsedLib is a library that has a single line, adding a reference to `_fltused`, which is needed by MSVC and clang when building floating point code.

FltUsedLib is only used in mu_plus, so in order to reduce deltas from edk2, it is moved to mu_plus. This commit then updates references in mu_plus to this new library.

A PR will be put up to mu_basecore to drop the library after this merges.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build testing.

## Integration Instructions

Platforms should update to `FltUsedLib|MsCorePkg/Library/FltUsedLib/FltUsedLib.inf` in their DSCs. This change is not a breaking change, but the removal in mu_basecore will be.
