### PR TITLE
[2502] AdvLoggerPkg: Drop buffer migration

### DIFF
--- a/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
+++ b/AdvLoggerPkg/Include/AdvancedLoggerInternal.h
@@ -46,11 +46,6 @@
 #define ADVANCED_LOGGER_PHASE_CNT          11
 
 //
-// The maximum depth to follow when traversing chains of advanced logger info structures
-//
-#define ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH  3
-
-//
 // These Pcds are used to carve out a PEI memory buffer from the temporary RAM.
 //
 //  PcdAdvancedLoggerBase -        NULL = UEFI starts with PEI, and SEC provides no memory log buffer
@@ -84,7 +79,9 @@ typedef volatile struct {
   EFI_TIME                Time;                   // Uefi Time Field
   UINT32                  HwPrintLevel;           // Logging level to be printed at hw port
   UINT32                  Reserved3;              //
-  EFI_PHYSICAL_ADDRESS    NewLoggerInfoAddress;   // If non-zero, this field holds the address of new logger info that should be used
+  EFI_PHYSICAL_ADDRESS    Deprecated;             // Deprecated field that should be preserved for binary compatibility
+                                                  // and not reused. Previous description: If non-zero, this field
+                                                  // holds the address of new logger info that should be used
 } ADVANCED_LOGGER_INFO;
 
 typedef struct {

--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.c
@@ -13,7 +13,6 @@
 #include <AdvancedLoggerInternal.h>
 
 #include <Protocol/AdvancedLogger.h>
-#include <Protocol/MmReadyToLock.h>
 
 #include <Library/AdvLoggerAccessLib.h>
 #include <Library/BaseLib.h>
@@ -21,7 +20,6 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
-#include <Library/MmServicesTableLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
@@ -29,71 +27,7 @@ STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo        = NULL;
 STATIC UINT32                mBufferSize         = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress         = 0;
 STATIC UINTN                 mLoggerTransferSize = 0;
-STATIC BOOLEAN               mReadyToLock        = FALSE;
 extern UINTN                 mVariableBufferPayloadSize;
-
-/**
-  Follow the logger info redirection chain and update the provided logger info pointer.
-
-  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
-  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
-  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
-
-  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
-  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
-**/
-STATIC
-BOOLEAN
-AdvancedLoggerCheckForNewerLogger (
-  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
-  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
-  OUT    UINT32                *BufferSize  OPTIONAL
-  )
-{
-  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
-  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
-  UINTN                 Depth;
-
-  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
-    return FALSE;
-  }
-
-  CurrentLoggerInfo = *LoggerInfo;
-  Depth             = 0;
-
-  // Follow the chain to find the current logger
-  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
-    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
-
-    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
-      return FALSE;
-    }
-
-    CurrentLoggerInfo = NextLoggerInfo;
-    Depth++;
-  }
-
-  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
-    return FALSE;
-  }
-
-  // Update if we found a newer logger
-  if (CurrentLoggerInfo != *LoggerInfo) {
-    *LoggerInfo = CurrentLoggerInfo;
-
-    if (MaxAddress != NULL) {
-      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
-    }
-
-    if (BufferSize != NULL) {
-      *BufferSize = CurrentLoggerInfo->LogBufferSize;
-    }
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
 
 /**
     CheckAddress
@@ -143,38 +77,6 @@ ValidateInfoBlock (
 }
 
 /**
-  MM ReadyToLock notification handler.
-
-  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
-
-  @param[in] Protocol   Protocol GUID pointer.
-  @param[in] Interface  Protocol interface pointer.
-  @param[in] Handle     The handle on which the interface was installed.
-
-  @retval EFI_SUCCESS   The notification handler completed successfully.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-OnMmReadyToLock (
-  IN CONST EFI_GUID  *Protocol,
-  IN VOID            *Interface,
-  IN EFI_HANDLE      Handle
-  )
-{
-  if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ReadyToLock. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-    }
-  }
-
-  mReadyToLock = TRUE;
-
-  return EFI_SUCCESS;
-}
-
-/**
     AdvLoggerInit - Obtain the address of the logger info block.
 
     @param          NONE
@@ -187,7 +89,6 @@ AdvLoggerAccessInit (
   )
 {
   EFI_HOB_GUID_TYPE    *GuidHob;
-  VOID                 *Registration;
   ADVANCED_LOGGER_PTR  *LogPtr;
   EFI_STATUS           Status;
   UINTN                TempSize;
@@ -209,12 +110,6 @@ AdvLoggerAccessInit (
 
   if (mLoggerInfo != NULL) {
     mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
-
-    if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-      if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-        DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-      }
-    }
   }
 
   //
@@ -244,15 +139,6 @@ AdvLoggerAccessInit (
   //
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, code=%r\n", __FUNCTION__, mLoggerInfo, Status));
-
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEfiMmReadyToLockProtocolGuid,
-                    OnMmReadyToLock,
-                    &Registration
-                    );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
-  }
 }
 
 /**
@@ -307,12 +193,6 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferStart;
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
-
-  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-    }
-  }
 
   if ((!ValidateInfoBlock ()) || (mLoggerTransferSize == 0)) {
     return EFI_UNSUPPORTED;

--- a/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerMmAccessLib/AdvLoggerMmAccessLib.inf
@@ -34,16 +34,12 @@
   BaseMemoryLib
   DebugLib
   HobLib
-  MmServicesTableLib
   PcdLib
   SafeIntLib
 
 [Guids]
   gAdvancedLoggerHobGuid
   gAdvLoggerAccessGuid                      ## CONSUMES
-
-[Protocols]
-  gEfiMmReadyToLockProtocolGuid             ## NOTIFY
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.c
@@ -13,7 +13,6 @@
 #include <Guid/SmmVariableCommon.h>
 
 #include <Protocol/AdvancedLogger.h>
-#include <Protocol/SmmReadyToLock.h>
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Library/AdvLoggerAccessLib.h>
@@ -22,78 +21,13 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/SafeIntLib.h>
-#include <Library/SmmServicesTableLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
 STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo        = NULL;
 STATIC UINT32                mBufferSize         = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress         = 0;
 STATIC UINTN                 mLoggerTransferSize = 0;
-STATIC BOOLEAN               mReadyToLock        = FALSE;
 extern UINTN                 mVariableBufferPayloadSize;
-
-/**
-  Follow the logger info redirection chain and update the provided logger info pointer.
-
-  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
-  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
-  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
-
-  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
-  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
-**/
-STATIC
-BOOLEAN
-AdvancedLoggerCheckForNewerLogger (
-  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
-  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
-  OUT    UINT32                *BufferSize  OPTIONAL
-  )
-{
-  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
-  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
-  UINTN                 Depth;
-
-  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
-    return FALSE;
-  }
-
-  CurrentLoggerInfo = *LoggerInfo;
-  Depth             = 0;
-
-  // Follow the chain to find the current logger
-  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
-    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
-
-    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
-      return FALSE;
-    }
-
-    CurrentLoggerInfo = NextLoggerInfo;
-    Depth++;
-  }
-
-  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
-    return FALSE;
-  }
-
-  // Update if we found a newer logger
-  if (CurrentLoggerInfo != *LoggerInfo) {
-    *LoggerInfo = CurrentLoggerInfo;
-
-    if (MaxAddress != NULL) {
-      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
-    }
-
-    if (BufferSize != NULL) {
-      *BufferSize = CurrentLoggerInfo->LogBufferSize;
-    }
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
 
 /**
     CheckAddress
@@ -145,38 +79,6 @@ ValidateInfoBlock (
 }
 
 /**
-  SMM ReadyToLock notification handler.
-
-  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
-
-  @param[in] Protocol   Protocol GUID pointer.
-  @param[in] Interface  Protocol interface pointer.
-  @param[in] Handle     The handle on which the interface was installed.
-
-  @retval EFI_SUCCESS   The notification handler completed successfully.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-OnSmmReadyToLock (
-  IN CONST EFI_GUID  *Protocol,
-  IN VOID            *Interface,
-  IN EFI_HANDLE      Handle
-  )
-{
-  if (mLoggerInfo != NULL) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated at ReadyToLock. LoggerInfo=%p\n", __func__, mLoggerInfo));
-    }
-  }
-
-  mReadyToLock = TRUE;
-
-  return EFI_SUCCESS;
-}
-
-/**
     AdvLoggerInit - Obtain the address of the logger info block.
 
     @param          NONE
@@ -189,11 +91,8 @@ AdvLoggerAccessInit (
   )
 {
   ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
-  VOID                      *Registration;
   UINTN                     TempSize;
   EFI_STATUS                Status;
-
-  Registration = NULL;
 
   if (gBS == NULL) {
     return;
@@ -228,10 +127,6 @@ AdvLoggerAccessInit (
     mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     if (mLoggerInfo != NULL) {
       mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
-
-      if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-        DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-      }
     }
 
     if (!ValidateInfoBlock ()) {
@@ -244,17 +139,6 @@ AdvLoggerAccessInit (
   //
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, code=%r\n", __FUNCTION__, mLoggerInfo, Status));
-
-  if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    Status = gSmst->SmmRegisterProtocolNotify (
-                      &gEfiSmmReadyToLockProtocolGuid,
-                      OnSmmReadyToLock,
-                      &Registration
-                      );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
-    }
-  }
 }
 
 /**
@@ -309,12 +193,6 @@ AdvLoggerAccessGetVariable (
   UINT8       *LogBufferStart;
   UINT8       *LogBufferEnd;
   UINTN       LogBufferSize;
-
-  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      DEBUG ((DEBUG_INFO, "%a: Logger buffer migrated during access. LoggerInfo=%p\n", __FUNCTION__, mLoggerInfo));
-    }
-  }
 
   if ((!ValidateInfoBlock ()) || (mLoggerTransferSize == 0)) {
     return EFI_UNSUPPORTED;

--- a/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
+++ b/AdvLoggerPkg/Library/AdvLoggerSmmAccessLib/AdvLoggerSmmAccessLib.inf
@@ -34,7 +34,6 @@
   DebugLib
   PcdLib
   SafeIntLib
-  SmmServicesTableLib
   UefiBootServicesTableLib
 
 [Guids]
@@ -42,12 +41,8 @@
 
 [Protocols]
   gAdvancedLoggerProtocolGuid               ## CONSUMES
-  gEfiSmmReadyToLockProtocolGuid            ## NOTIFY
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize
-
-[FeaturePcd]
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
 
 [Depex]

--- a/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerAccessLib/AdvancedLoggerAccessLib.c
@@ -40,69 +40,6 @@ CONST   CHAR8                 *AdvMsgEntryPrefix[ADVANCED_LOGGER_PHASE_CNT] = {
   "[TFA  ]",
 };
 
-/**
-  Follow the logger info redirection chain and update the provided logger info pointer.
-
-  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
-  @param[out]     LowAddress    Optional pointer to update with the low address of the current logger.
-  @param[out]     HighAddress   Optional pointer to update with the high address of the current logger.
-
-  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
-  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
-**/
-STATIC
-BOOLEAN
-AdvancedLoggerCheckForNewerLogger (
-  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
-  OUT    EFI_PHYSICAL_ADDRESS  *LowAddress  OPTIONAL,
-  OUT    EFI_PHYSICAL_ADDRESS  *HighAddress  OPTIONAL
-  )
-{
-  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
-  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
-  UINTN                 Depth;
-
-  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
-    return FALSE;
-  }
-
-  CurrentLoggerInfo = *LoggerInfo;
-  Depth             = 0;
-
-  // Follow the chain to find the current logger
-  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
-    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
-
-    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
-      return FALSE;
-    }
-
-    CurrentLoggerInfo = NextLoggerInfo;
-    Depth++;
-  }
-
-  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
-    return FALSE;
-  }
-
-  // Update if we found a newer logger
-  if (CurrentLoggerInfo != *LoggerInfo) {
-    *LoggerInfo = CurrentLoggerInfo;
-
-    if (LowAddress != NULL) {
-      *LowAddress = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (CurrentLoggerInfo));
-    }
-
-    if (HighAddress != NULL) {
-      *HighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (CurrentLoggerInfo));
-    }
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
 // Define a structure to hold debug level information
 typedef struct {
   CONST CHAR8    *Name;
@@ -316,8 +253,6 @@ AdvancedLoggerAccessLibGetNextMessageBlock (
   if (BlockEntry == NULL) {
     return EFI_INVALID_PARAMETER;
   }
-
-  AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mLowAddress, &mHighAddress);
 
   if (mLoggerInfo->LogCurrentOffset == mLoggerInfo->LogBufferOffset) {
     return EFI_END_OF_FILE;
@@ -617,8 +552,6 @@ AdvancedLoggerAccessLibConstructor (
     mLoggerInfo  = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
     mLowAddress  = PA_FROM_PTR (LOG_BUFFER_FROM_ALI (mLoggerInfo));
     mHighAddress = PA_FROM_PTR (LOG_MAX_ADDRESS (mLoggerInfo));
-
-    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mLowAddress, &mHighAddress);
 
     // Leave this debug message as ERROR.
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -20,101 +20,6 @@
 #include "../AdvancedLoggerCommon.h"
 
 /**
-  Follow the logger info redirection chain to find the current logger info.
-
-  This is primarily used to support migrating an advanced logger buffer to a new location.
-
-  @param[in]  LoggerInfo    Pointer to a logger info structure to start the chain walk.
-
-  @return               Pointer to the current logger info structure (with NewLoggerInfoAddress == 0).
-                        Returns NULL if the input is NULL or if the chain is invalid.
-**/
-ADVANCED_LOGGER_INFO *
-AdvancedLoggerGetCurrentLoggerInfo (
-  IN ADVANCED_LOGGER_INFO  *LoggerInfo
-  )
-{
-  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
-  ADVANCED_LOGGER_INFO  *NextLoggerInfo;
-  UINTN                 Depth;
-
-  if (LoggerInfo == NULL) {
-    return NULL;
-  }
-
-  CurrentLoggerInfo = LoggerInfo;
-  Depth             = 0;
-
-  while ((CurrentLoggerInfo->NewLoggerInfoAddress != 0) && (Depth < ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH)) {
-    NextLoggerInfo = ALI_FROM_PA (CurrentLoggerInfo->NewLoggerInfoAddress);
-
-    if (NextLoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
-      return CurrentLoggerInfo;
-    }
-
-    CurrentLoggerInfo = NextLoggerInfo;
-    Depth++;
-  }
-
-  if (Depth >= ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH) {
-    return NULL;
-  }
-
-  return CurrentLoggerInfo;
-}
-
-/**
-  Follow the logger info redirection chain and update the provided logger info pointer.
-
-  This function follows the logger address chain to find the current logger info
-  and updates the input pointer if a new logger is found.
-
-  The function does not attempt to make any validation statement about the logger info
-  structures and it is expected NULL may be provided as input.
-
-  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
-  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
-  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
-
-  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
-  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
-**/
-BOOLEAN
-AdvancedLoggerCheckForNewerLogger (
-  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
-  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
-  OUT    UINT32                *BufferSize  OPTIONAL
-  )
-{
-  ADVANCED_LOGGER_INFO  *CurrentLoggerInfo;
-
-  if ((LoggerInfo == NULL) || (*LoggerInfo == NULL)) {
-    return FALSE;
-  }
-
-  CurrentLoggerInfo = AdvancedLoggerGetCurrentLoggerInfo (*LoggerInfo);
-  if (CurrentLoggerInfo == NULL) {
-    return FALSE;
-  }
-
-  if (CurrentLoggerInfo != *LoggerInfo) {
-    *LoggerInfo = CurrentLoggerInfo;
-
-    if (MaxAddress != NULL) {
-      *MaxAddress = LOG_MAX_ADDRESS (CurrentLoggerInfo);
-    }
-
-    if (BufferSize != NULL) {
-      *BufferSize = CurrentLoggerInfo->LogBufferSize;
-    }
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-/**
   Write data from buffer into the in memory logging buffer.
 
   Writes NumberOfBytes data bytes from Buffer to the logging buffer.
@@ -154,8 +59,6 @@ AdvancedLoggerMemoryLoggerWrite (
   }
 
   LoggerInfo = AdvancedLoggerGetLoggerInfo ();
-
-  LoggerInfo = AdvancedLoggerGetCurrentLoggerInfo (LoggerInfo);
 
   if (LoggerInfo != NULL) {
     EntrySize = MESSAGE_ENTRY_SIZE_V2 (OFFSET_OF (ADVANCED_LOGGER_MESSAGE_ENTRY_V2, MessageText), NumberOfBytes);

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -10,49 +10,6 @@
 #ifndef __ADVANCED_LOGGER_COMMON_H__
 #define __ADVANCED_LOGGER_COMMON_H__
 
-//
-// The maximum depth to follow when traversing chains of advanced logger info structures
-//
-#define ADVANCED_LOGGER_MAX_LOGGER_CHAIN_DEPTH  3
-
-/**
-  Follow the logger info redirection chain to find the current logger info.
-
-  This is primarily used to support migrating an advanced logger buffer to a new location.
-
-  @param[in]  LoggerInfo    Pointer to a logger info structure to start the chain walk.
-
-  @return               Pointer to the current logger info structure (with NewLoggerInfoAddress == 0).
-                        Returns NULL if the input is NULL or if the chain is invalid.
-**/
-ADVANCED_LOGGER_INFO *
-AdvancedLoggerGetCurrentLoggerInfo (
-  IN ADVANCED_LOGGER_INFO  *LoggerInfo
-  );
-
-/**
-  Follow the logger info redirection chain and update the provided logger info pointer.
-
-  This function follows the logger address chain to find the current logger info
-  and updates the input pointer if a new logger is found.
-
-  The function does not attempt to make any validation statement about the logger info
-  structures and it is expected NULL may be provided as input.
-
-  @param[in,out]  LoggerInfo    Pointer to a logger info pointer to update.
-  @param[out]     MaxAddress    Optional pointer to update with the max address of the current logger.
-  @param[out]     BufferSize    Optional pointer to update with the buffer size of the current logger.
-
-  @retval         TRUE          A new logger was found and LoggerInfo was updated to the new address.
-  @retval         FALSE         A new logger was not found and no modification was made to LoggerInfo.
-**/
-BOOLEAN
-AdvancedLoggerCheckForNewerLogger (
-  IN OUT ADVANCED_LOGGER_INFO  **LoggerInfo,
-  OUT    EFI_PHYSICAL_ADDRESS  *MaxAddress  OPTIONAL,
-  OUT    UINT32                *BufferSize  OPTIONAL
-  );
-
 /**
     Write data from buffer into the in memory logging buffer.
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.c
@@ -111,8 +111,6 @@ AdvancedLoggerGetLoggerInfo (
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
     DEBUG ((DEBUG_ERROR, "%a: LoggerInfo marked invalid\n", __func__));
-  } else if ((mLoggerInfo != NULL) && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize);
   }
 
   return mLoggerInfo;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -42,7 +42,6 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.c
@@ -17,7 +17,6 @@
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Library/AdvancedLoggerHdwPortLib.h>
-#include <Library/MmUnblockMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
@@ -33,12 +32,10 @@
 //
 // Protocol interface that connects the DXE library instances with the AdvancedLogger
 //
-STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo  = NULL;
-STATIC UINT32                mBufferSize   = 0;
-STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress   = 0;
-STATIC BOOLEAN               mInitialized  = FALSE;
-STATIC EFI_SYSTEM_TABLE      *mSystemTable = NULL;
-STATIC EFI_HANDLE            mImageHandle  = NULL;
+STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo = NULL;
+STATIC UINT32                mBufferSize  = 0;
+STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress  = 0;
+STATIC BOOLEAN               mInitialized = FALSE;
 
 VOID
 EFIAPI
@@ -166,8 +163,6 @@ AdvancedLoggerGetLoggerInfo (
 
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
-  } else if ((mLoggerInfo != NULL) && AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-    DEBUG ((DEBUG_INFO, "DxeCore %a: Logger Update. LoggerInfo=%p\n", __func__, mLoggerInfo));
   }
 
   return mLoggerInfo;
@@ -432,141 +427,6 @@ InitializeTimerFrequency (
 }
 
 /**
-  Migrate the PEI logger buffer to a new DXE reserved buffer.
-
-  Called at End of DXE to ensure all MM services are available to unblock the new logger buffer.
-
-  @param[in] Event    Event whose notification function is being invoked.
-  @param[in] Context  The pointer to the notification function's context.
-**/
-STATIC
-VOID
-EFIAPI
-OnEndOfDxe (
-  IN  EFI_EVENT  Event,
-  IN  VOID       *Context
-  )
-{
-  EFI_STATUS            Status;
-  EFI_TPL               OldTpl;
-  ADVANCED_LOGGER_INFO  *ExistingLoggerInfo;
-  ADVANCED_LOGGER_INFO  *NewLoggerInfo;
-  EFI_BOOT_SERVICES     *BootServices;
-
-  DEBUG ((DEBUG_INFO, "%a: Migrating logger buffer\n", __func__));
-
-  BootServices = (EFI_BOOT_SERVICES *)Context;
-  if (BootServices == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Boot services context is null, the logger buffer will not be migrated.\n", __func__));
-    return;
-  }
-
-  ExistingLoggerInfo = AdvancedLoggerGetLoggerInfo ();
-
-  //
-  // Allocate new reserved buffer for the logger
-  //
-  NewLoggerInfo = (ADVANCED_LOGGER_INFO *)AllocateReservedPages (FixedPcdGet32 (PcdAdvancedLoggerPages));
-  if (NewLoggerInfo == NULL) {
-    ASSERT (NewLoggerInfo != NULL);
-    return;
-  }
-
-  //
-  // Unblock the new buffer for MM access
-  // If this is not needed on a platform, the null instance of MmUnblockMemoryLib can be used.
-  //
-  Status = MmUnblockMemoryRequest (
-             (EFI_PHYSICAL_ADDRESS)(UINTN)NewLoggerInfo,
-             FixedPcdGet32 (PcdAdvancedLoggerPages)
-             );
-  if (EFI_ERROR (Status) && (Status != EFI_UNSUPPORTED)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to unblock advanced logger buffer for MM access - %r\n", __func__, Status));
-  }
-
-  //
-  // Prevent other notifications at TPL NOTIFY or lower from interrupting the overall migration flow.
-  // First, check that raising to TPL_NOTIFY is successful.
-  //
-  OldTpl = BootServices->RaiseTPL (TPL_NOTIFY);
-
-  //
-  // Raise to TPL_HIGH_LEVEL during the main copy operation so interrupts are disabled.
-  // No need to store the current TPL since was just set to TPL_NOTIFY.
-  //
-  BootServices->RaiseTPL (TPL_HIGH_LEVEL);
-
-  InitializeLoggerInfoStructure (NewLoggerInfo);
-
-  //
-  // If a pre-existing buffer was provided, copy its contents to the new buffer
-  //
-  if (ExistingLoggerInfo != NULL) {
-    NewLoggerInfo->TimerFrequency = ExistingLoggerInfo->TimerFrequency;
-    NewLoggerInfo->TicksAtTime    = ExistingLoggerInfo->TicksAtTime;
-    CopyMem ((VOID *)&NewLoggerInfo->Time, (VOID *)&ExistingLoggerInfo->Time, sizeof (NewLoggerInfo->Time));
-
-    if (ExistingLoggerInfo->LogCurrentOffset > ExistingLoggerInfo->LogBufferOffset) {
-      CopyMem (
-        LOG_BUFFER_FROM_ALI (NewLoggerInfo),
-        LOG_BUFFER_FROM_ALI (ExistingLoggerInfo),
-        USED_LOG_SIZE (ExistingLoggerInfo)
-        );
-      NewLoggerInfo->LogCurrentOffset = NewLoggerInfo->LogBufferOffset + USED_LOG_SIZE (ExistingLoggerInfo);
-    }
-
-    NewLoggerInfo->DiscardedSize = ExistingLoggerInfo->DiscardedSize;
-
-    //
-    // Set the old logger info's NewLoggerInfoAddress to redirect to the new buffer
-    //
-    ExistingLoggerInfo->NewLoggerInfoAddress = PA_FROM_PTR (NewLoggerInfo);
-  }
-
-  //
-  // Update module state to use the new buffer
-  //
-  mMaxAddress                   = LOG_MAX_ADDRESS (NewLoggerInfo);
-  mBufferSize                   = NewLoggerInfo->LogBufferSize;
-  mLoggerInfo                   = NewLoggerInfo;
-  mAdvLoggerProtocol.LoggerInfo = NewLoggerInfo;
-
-  //
-  // Restore back to TPL_NOTIFY before calling functions with level restrictions.
-  //
-  BootServices->RestoreTPL (TPL_NOTIFY);
-
-  //
-  // Initialize the hardware port if not already done
-  //
-  if (!NewLoggerInfo->HdwPortInitialized) {
-    AdvancedLoggerHdwPortInitialize ();
-    NewLoggerInfo->HdwPortInitialized = TRUE;
-  }
-
-  //
-  // Reinstall protocol with the new buffer information.
-  // This updates any existing protocol installation to point to the migrated buffer.
-  //
-  Status = mSystemTable->BootServices->ReinstallProtocolInterface (
-                                         mImageHandle,
-                                         &gAdvancedLoggerProtocolGuid,
-                                         &mAdvLoggerProtocol.AdvLoggerProtocol,
-                                         &mAdvLoggerProtocol.AdvLoggerProtocol
-                                         );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Error reinstalling advanced logger protocol - %r\n", __func__, Status));
-  }
-
-  BootServices->RestoreTPL (OldTpl);
-
-  //
-  // Close the event as we only need to migrate once
-  //
-  mSystemTable->BootServices->CloseEvent (Event);
-}
-
-/**
   DxeCore Advanced Logger initialization.
 **/
 EFI_STATUS
@@ -577,11 +437,7 @@ DxeCoreAdvancedLoggerLibConstructor (
   )
 {
   EFI_STATUS            Status;
-  EFI_EVENT             EndOfDxeEvent;
   ADVANCED_LOGGER_INFO  *LoggerInfo;
-
-  mSystemTable = SystemTable;
-  mImageHandle = ImageHandle;
 
   LoggerInfo = AdvancedLoggerGetLoggerInfo ();
 
@@ -631,28 +487,6 @@ DxeCoreAdvancedLoggerLibConstructor (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Error installing protocol - %r\n", __func__, Status));
       // If the protocol doesn't install, don't fail.
-    }
-
-    //
-    // Only allocate a new reserved buffer and migrate when the address was not designated
-    // to be fixed in RAM.
-    //
-    if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-      //
-      // Migrate the advanced logger buffer at End of DXE.
-      // This allows the migrated buffer to be unblocked for MM access.
-      //
-      Status = SystemTable->BootServices->CreateEventEx (
-                                            EVT_NOTIFY_SIGNAL,
-                                            TPL_CALLBACK,
-                                            OnEndOfDxe,
-                                            SystemTable->BootServices,
-                                            &gEfiEndOfDxeEventGroupGuid,
-                                            &EndOfDxeEvent
-                                            );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to create End of DXE event - %r\n", __func__, Status));
-      }
     }
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -38,7 +38,6 @@
   DebugLib
   HobLib
   MemoryAllocationLib
-  MmUnblockMemoryLib
   PcdLib
   SynchronizationLib
   TimerLib

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.c
@@ -117,13 +117,6 @@ AdvancedLoggerGetLoggerInfo (
     //
   }
 
-  //
-  // Check for buffer migration before validation, as migration changes buffer size/address.
-  //
-  if (mLoggerInfo != NULL) {
-    AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize);
-  }
-
   if (((mLoggerInfo) != NULL) && !ValidateInfoBlock ()) {
     mLoggerInfo = NULL;
     DEBUG ((DEBUG_ERROR, "MmCore %a: LoggerInfo marked invalid\n", __func__));

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.c
@@ -207,7 +207,7 @@ InstallPermanentMemoryBuffer (
       // Must be PeiCore allocated small memory buffer
       //
       Status = PeiServicesAllocatePages (
-                 EfiBootServicesData,
+                 EfiRuntimeServicesData,
                  FixedPcdGet32 (PcdAdvancedLoggerPages),
                  &NewLogBuffer
                  );

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -20,13 +20,11 @@
 
 #include "../AdvancedLoggerCommon.h"
 
-STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo                 = NULL;
-STATIC UINT32                mBufferSize                  = 0;
-STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress                  = 0;
-STATIC EFI_BOOT_SERVICES     *mBS                         = NULL;
-STATIC EFI_EVENT             mExitBootServicesEvent       = NULL;
-STATIC EFI_EVENT             mAdvancedLoggerProtocolEvent = NULL;
-STATIC VOID                  *mAdvancedLoggerProtocolReg  = NULL;
+STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo           = NULL;
+STATIC UINT32                mBufferSize            = 0;
+STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress            = 0;
+STATIC EFI_BOOT_SERVICES     *mBS                   = NULL;
+STATIC EFI_EVENT             mExitBootServicesEvent = NULL;
 
 /**
     CheckAddress
@@ -78,60 +76,8 @@ ValidateInfoBlock (
 }
 
 /**
-  Update cached logger info from the first Advanced Logger Protocol instance found.
-
-  @retval EFI_SUCCESS           Logger info successfully updated.
-  @retval EFI_NOT_FOUND         The advanced logger protocol was not found.
-  @retval EFI_INVALID_PARAMETER Invalid protocol signature or version.
-
-**/
-STATIC
-EFI_STATUS
-UpdateLoggerInfoFromProtocol (
-  VOID
-  )
-{
-  ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
-  EFI_STATUS                Status;
-
-  if (mBS == NULL) {
-    return EFI_NOT_READY;
-  }
-
-  Status = mBS->LocateProtocol (
-                  &gAdvancedLoggerProtocolGuid,
-                  NULL,
-                  (VOID **)&LoggerProtocol
-                  );
-  if (EFI_ERROR (Status) || (LoggerProtocol == NULL)) {
-    return EFI_NOT_FOUND;
-  }
-
-  ASSERT (LoggerProtocol->Signature == ADVANCED_LOGGER_PROTOCOL_SIGNATURE);
-  ASSERT (LoggerProtocol->Version == ADVANCED_LOGGER_PROTOCOL_VERSION);
-
-  if ((LoggerProtocol->Signature != ADVANCED_LOGGER_PROTOCOL_SIGNATURE) ||
-      (LoggerProtocol->Version != ADVANCED_LOGGER_PROTOCOL_VERSION))
-  {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
-
-  if (mLoggerInfo != NULL) {
-    mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
-    // Force the buffer size to be reevaluated
-    mBufferSize = 0;
-  }
-
-  return EFI_SUCCESS;
-}
-
-/**
     Get the Logger Information block
 
-    @return   A pointer to the active advanced logger info structure or NULL if the structure is
-              invalid.
  **/
 ADVANCED_LOGGER_INFO *
 EFIAPI
@@ -139,8 +85,25 @@ AdvancedLoggerGetLoggerInfo (
   VOID
   )
 {
-  if (mLoggerInfo == NULL) {
-    UpdateLoggerInfoFromProtocol ();
+  ADVANCED_LOGGER_PROTOCOL  *LoggerProtocol;
+  EFI_STATUS                Status;
+
+  if ((mLoggerInfo == NULL) && (mBS != NULL)) {
+    Status = mBS->LocateProtocol (
+                    &gAdvancedLoggerProtocolGuid,
+                    NULL,
+                    (VOID **)&LoggerProtocol
+                    );
+    if (!EFI_ERROR (Status) && (LoggerProtocol != NULL)) {
+      ASSERT (LoggerProtocol->Signature == ADVANCED_LOGGER_PROTOCOL_SIGNATURE);
+      ASSERT (LoggerProtocol->Version == ADVANCED_LOGGER_PROTOCOL_VERSION);
+
+      mLoggerInfo = LOGGER_INFO_FROM_PROTOCOL (LoggerProtocol);
+
+      if (mLoggerInfo != NULL) {
+        mMaxAddress = LOG_MAX_ADDRESS (mLoggerInfo);
+      }
+    }
   }
 
   if (!ValidateInfoBlock ()) {
@@ -165,25 +128,6 @@ AdvancedLoggerGetPhase (
   )
 {
   return ADVANCED_LOGGER_PHASE_RUNTIME;
-}
-
-/**
-  Notification function for Advanced Logger Protocol installation.
-
-  This function is called when the Advanced Logger Protocol is installed or reinstalled
-  (e.g., during buffer migration). It updates the globally cached logger to the new logger buffer.
-
-  @param[in]  Event    Event whose notification function is being invoked.
-  @param[in]  Context  Pointer to the notification function's context.
-**/
-VOID
-EFIAPI
-OnAdvancedLoggerProtocolNotification (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  UpdateLoggerInfoFromProtocol ();
 }
 
 /**
@@ -233,34 +177,9 @@ DxeRuntimeAdvancedLoggerLibConstructor (
   mBS = SystemTable->BootServices;
   AdvancedLoggerGetLoggerInfo ();
 
-  //
-  // Register a notification function for Advanced Logger Protocol installation.
-  //
-  Status = mBS->CreateEvent (
-                  EVT_NOTIFY_SIGNAL,
-                  TPL_CALLBACK,
-                  OnAdvancedLoggerProtocolNotification,
-                  NULL,
-                  &mAdvancedLoggerProtocolEvent
-                  );
+  ASSERT (mLoggerInfo != NULL);
 
-  if (!EFI_ERROR (Status)) {
-    Status = mBS->RegisterProtocolNotify (
-                    &gAdvancedLoggerProtocolGuid,
-                    mAdvancedLoggerProtocolEvent,
-                    &mAdvancedLoggerProtocolReg
-                    );
-
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a - Register Protocol Notify failed. Code = %r\n", __func__, Status));
-      mBS->CloseEvent (mAdvancedLoggerProtocolEvent);
-      mAdvancedLoggerProtocolEvent = NULL;
-    }
-  } else {
-    DEBUG ((DEBUG_ERROR, "%a - Create Event for Protocol Notify failed. Code = %r\n", __func__, Status));
-  }
-
-  if (mLoggerInfo != NULL) {
+  if (mLoggerInfo != 0) {
     //
     // Register notify function for ExitBootServices.
     //
@@ -298,10 +217,6 @@ DxeRuntimeAdvancedLoggerLibDestructor (
 {
   if (mExitBootServicesEvent != NULL) {
     mBS->CloseEvent (mExitBootServicesEvent);
-  }
-
-  if (mAdvancedLoggerProtocolEvent != NULL) {
-    mBS->CloseEvent (mAdvancedLoggerProtocolEvent);
   }
 
   return EFI_SUCCESS;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.c
@@ -11,7 +11,6 @@
 #include <AdvancedLoggerInternal.h>
 
 #include <Protocol/AdvancedLogger.h>
-#include <Protocol/SmmReadyToLock.h>
 #include <AdvancedLoggerInternalProtocol.h>
 
 #include <Pi/PiSmmCis.h>
@@ -28,7 +27,6 @@ STATIC ADVANCED_LOGGER_INFO  *mLoggerInfo;
 STATIC UINT32                mBufferSize  = 0;
 STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress  = 0;
 STATIC BOOLEAN               mInitialized = FALSE;
-STATIC BOOLEAN               mReadyToLock = FALSE;
 
 VOID
 EFIAPI
@@ -119,38 +117,6 @@ ValidateInfoBlock (
 }
 
 /**
-  SMM ReadyToLock notification handler.
-
-  Ensures any move needed to the new logger buffer is done before ReadyToLock completes.
-
-  @param[in] Protocol   Protocol GUID pointer.
-  @param[in] Interface  Protocol interface pointer.
-  @param[in] Handle     The handle on which the interface was installed.
-
-  @retval EFI_SUCCESS   The notification handler completed successfully.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-OnSmmReadyToLock (
-  IN CONST EFI_GUID  *Protocol,
-  IN VOID            *Interface,
-  IN EFI_HANDLE      Handle
-  )
-{
-  if (mLoggerInfo != NULL) {
-    if (AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize)) {
-      mAdvLoggerProtocol.LoggerInfo = mLoggerInfo;
-    }
-  }
-
-  mReadyToLock = TRUE;
-
-  return EFI_SUCCESS;
-}
-
-/**
     Get the Logger Information Block published by DxeCore.
  **/
 STATIC
@@ -210,12 +176,6 @@ AdvancedLoggerGetLoggerInfo (
 {
   SmmInitializeLoggerInfo ();
 
-  if ((mLoggerInfo != NULL) && !mReadyToLock && !FeaturePcdGet (PcdAdvancedLoggerFixedInRAM) &&
-      AdvancedLoggerCheckForNewerLogger (&mLoggerInfo, &mMaxAddress, &mBufferSize))
-  {
-    DEBUG ((DEBUG_INFO, "MmCore %a: Logger Update. LoggerInfo=%p\n", __func__, mLoggerInfo));
-  }
-
   return mLoggerInfo;
 }
 
@@ -256,9 +216,6 @@ SmmCoreAdvancedLoggerLibConstructor (
 {
   EFI_HANDLE  Handle;
   EFI_STATUS  Status;
-  VOID        *Registration;
-
-  Registration = NULL;
 
   ASSERT ((gBS != NULL) && (gSmst != NULL));
 
@@ -280,17 +237,6 @@ SmmCoreAdvancedLoggerLibConstructor (
 
   DEBUG ((DEBUG_INFO, "%a: LoggerInfo=%p, Code=%r\n", __func__, mLoggerInfo, Status));
   ASSERT_EFI_ERROR (Status);
-
-  if (!FeaturePcdGet (PcdAdvancedLoggerFixedInRAM)) {
-    Status = gSmst->SmmRegisterProtocolNotify (
-                      &gEfiSmmReadyToLockProtocolGuid,
-                      OnSmmReadyToLock,
-                      &Registration
-                      );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to register ReadyToLock notify - %r\n", __func__, Status));
-    }
-  }
 
   return EFI_SUCCESS;
 }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -43,11 +43,9 @@
 
 [Protocols]
   gAdvancedLoggerProtocolGuid                                               ## CONSUMES
-  gEfiSmmReadyToLockProtocolGuid                                            ## NOTIFY
 
 [Pcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel  ## SOMETIMES_CONSUMES
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM


### PR DESCRIPTION
## Description

Effectively reverts commits af0f64c and 9fc8521 preserving structure compatibility and general cleanup.

The advanced logger buffer starts accumulating messages in the first phase advanced logger is active, and the buffer continues to be used throughout remaining phases. Each phase has to account for either allocating or using an existing logger buffer. Due to the persistent nature of the buffer throughout boot, it is allocated as a runtime memory type early in boot to support its preservation and access at OS runtime.

However, S4 resume relies upon a stable memory map across suspend and resume. Since the advanced logger buffer is allocated as a runtime memory type prior to DXE, it is in a buffer outside the DXE memory bins. This leads to an increased likelihood of the buffer being at a different address across suspend and resume affecting hibernate resume. Advanced logger buffer migration was a mechanism to address this but doing so complicates MM treatment of the buffer.

Because a single advanced logger buffer is used across all phases, including a shared buffer between PEI and MM and DXE and MM, the buffer must be unlocked for MM access to accommodate a PEI MM IPL. This creates a problem where both requirements cannot simultaneously be met without additional complexity in MM access code. In addition, MM environments are inconsistent in their support for memory unlocking.

In the end, hibernation has always been a best effort scenario with this flow and other MM solutions already require runtime allocations outside of DXE memory bins, so this change removes the functional logic for migration.

The memory bin scenario will be addressed in the future when the bins are allocated in a pre-DXE phase (e.g. PEI) and picked up by DXE.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- AdvLoggerPkg CI
- Boot to OS on Intel physical platform and dump in-memory log to file

## Integration Instructions

- N/A