### PR TITLE
[2502] MsGraphicsPkg/SwmDialogsLib: Show OSK after dialog rendering completes

### DIFF
--- a/MsGraphicsPkg/Library/SwmDialogsLib/PasswordDialog.c
+++ b/MsGraphicsPkg/Library/SwmDialogsLib/PasswordDialog.c
@@ -928,10 +928,6 @@ ProcessDialogInput (
                            CanvasRect
                            );
 
-      // Show the on-screen keyboard for input.
-      //
-      mOSKProtocol->ShowKeyboard (mOSKProtocol, TRUE);
-
       // Render the canvas and continue processing input.
       //
       State = DialogCanvas->Base.Draw (
@@ -940,6 +936,10 @@ ProcessDialogInput (
                                    NULL,
                                    &pContext
                                    );
+
+      // Show the on-screen keyboard for input.
+      //
+      mOSKProtocol->ShowKeyboard (mOSKProtocol, TRUE);
 
       // Indicate that the dialog has been moved up to make room for the OSK.
       //

--- a/MsGraphicsPkg/Library/SwmDialogsLib/SemmUserAuthDialog.c
+++ b/MsGraphicsPkg/Library/SwmDialogsLib/SemmUserAuthDialog.c
@@ -1044,10 +1044,6 @@ ProcessDialogInput (
                            CanvasRect
                            );
 
-      // Show the on-screen keyboard for input.
-      //
-      mOSKProtocol->ShowKeyboard (mOSKProtocol, TRUE);
-
       // Render the canvas and continue processing input.
       //
       State = DialogCanvas->Base.Draw (
@@ -1056,6 +1052,10 @@ ProcessDialogInput (
                                    NULL,
                                    &pContext
                                    );
+
+      // Show the on-screen keyboard for input.
+      //
+      mOSKProtocol->ShowKeyboard (mOSKProtocol, TRUE);
 
       // Indicate that the dialog has been moved up to make room for the OSK.
       //


### PR DESCRIPTION
## Description

Moves the `ShowKeyboard()` call after the canvas `Draw()` call in the `KEYFOCUS` handling block of PasswordDialog and SemmUserAuthDialog.

Previously, the on-screen keyboard was displayed before the dialog finished rendering at its shifted position.

By deferring `ShowKeyboard()` until after `Draw()` completes, the dialog is fully painted in its final position before the keyboard appears.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. Go to the "Security -> UEFI password" page
2. In the "Enter password" screen, touch the blank area on the screen
3. Watch the on-screen keyboard load

## Integration Instructions

- N/A