### PR TITLE
Skip Mu PR validation for PRs targeting non-default branches

### DIFF
--- a/.github/workflows/mu-pr-validation.yml
+++ b/.github/workflows/mu-pr-validation.yml
@@ -80,12 +80,25 @@ jobs:
             exit 0
           fi
 
+          base_ref=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+            --jq '.base.ref')
+          default_branch=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
+
+          if [[ "$base_ref" != "$default_branch" ]]; then
+            echo "::notice::PR #${pr_number} targets ${base_ref}, not ${default_branch}. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=wrong_target_branch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
           echo "::group::PR Information"
           echo "  - PR Number: $pr_number"
           echo "  - Head SHA:  $HEAD_SHA"
           echo "  - Head Ref:  $HEAD_REF"
+          echo "  - Target:    $base_ref"
           echo "  - Source:    $HEAD_REPO"
           echo "::endgroup::"
 


### PR DESCRIPTION
## Description

Because mu-pr-validation.yml is in the default branch (release/202511) and runs on a workflow_run trigger for the CodeQL workflow where the CodeQL workflow runs for all release branches, the Mu PR Validation workflow will run for all PRs targeting any release branch.

Because mu_tiano_platforms is only compatible with default branches, we want to skip Mu PR Validation targeting those non-default branches.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified for PRs against the default on non-default branch on my fork.

**Non-Default Case (Skip)**

<img width="1513" height="994" alt="image" src="https://github.com/user-attachments/assets/5c36af3b-13b5-45ce-a202-2fb61f313cad" />

**Default Case (Run)**

<img width="1499" height="596" alt="image" src="https://github.com/user-attachments/assets/8980f038-b500-4aed-b924-1b6252659925" />

## Integration Instructions

- N/A