### PR TITLE
AdvLoggerPkg/AdvancedLoggerLib: Print to HW if logger info is not available

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -160,34 +160,25 @@ AdvancedLoggerWrite (
   )
 {
   ADVANCED_LOGGER_INFO  *LoggerInfo;
+  UINT32                HwPortDebugLevel;
 
   // All messages go to the in memory log.
   LoggerInfo = AdvancedLoggerMemoryLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
 
+  HwPortDebugLevel = PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+
   // Only selected messages go to the hdw port.
 
- #ifdef ADVANCED_LOGGER_SEC
-  // If LoggerInfo == NULL, assume there is a HdwPort and it has not been disabled. This
-  // does occur in SEC
   if ((LoggerInfo == NULL) || (!LoggerInfo->HdwPortDisabled)) {
-    if (DebugLevel & PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel)) {
-      AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
+ #ifndef ADVANCED_LOGGER_SEC
+    if ((LoggerInfo != NULL) && (LoggerInfo->Version >= ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER)) {
+      HwPortDebugLevel = LoggerInfo->HwPrintLevel;
     }
-  }
-
- #else
-  if ((LoggerInfo != NULL) && (!LoggerInfo->HdwPortDisabled)) {
-    // if we are at a high enough version to support HW_LVL logging, only call the HdwPortWrite if this DebugLevel
-    // is asked to be logged
-    // if we are at an older version, check the PCD to see if we should log this message
-    if (LoggerInfo->Version >= ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER) {
-      if (DebugLevel & LoggerInfo->HwPrintLevel) {
-        AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
-      }
-    } else if (DebugLevel & PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel)) {
-      AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
-    }
-  }
 
  #endif
+
+    if (DebugLevel & HwPortDebugLevel) {
+      AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
+    }
+  }
 }


### PR DESCRIPTION
## Description

In the course of testing advanced logger changes with edk2 Standalone MM on OVMF, there was a change needed in MmPlatformHobProducerLibOvmf in OvmfPkg to account for gAdvancedLoggerHobGuid in the HOBs that are passed to the MM environment.

Prior to this change, the system appeared to hang entering that environment:

```
INFO - Loading PEIM at 0x00005B95000 EntryPoint=0x00005B95340 StandaloneMmIplPei.efi
INFO - StandaloneMM IPL loading MM Core at MMRAM address 7FF0000
INFO - MmCoreImageBase  - 0x0000000007FF0000
INFO - MmCoreImageSize  - 0x0000000000010000
INFO - StandaloneMM IPL calling Standalone MM Core at MMRAM address - 0x0000000007FF1000
```

After the change, the issue is clearly printed to serial output: ("MmCore AdvancedLoggerGetLoggerInfo: Advanced Logger Hob not found")

```
INFO - Loading PEIM at 0x00005B94000 EntryPoint=0x00005B94340 StandaloneMmIplPei.efi
INFO - StandaloneMM IPL loading MM Core at MMRAM address 7FF0000
INFO - MmCoreImageBase  - 0x0000000007FF0000
INFO - MmCoreImageSize  - 0x0000000000010000
INFO - StandaloneMM IPL calling Standalone MM Core at MMRAM address - 0x0000000007FF1000
INFO - MmCore AdvancedLoggerGetLoggerInfo: Advanced Logger Hob not found
INFO - MmMain - 0x5B11000
INFO - MmramRangeCount - 0x4
INFO - MmramRanges[0]: 0x0000000006000000 - 0x1000
INFO - MmramRanges[1]: 0x0000000006001000 - 0xE000
INFO - MmramRanges[2]: 0x000000000600F000 - 0x1FE1000
INFO - MmramRanges[3]: 0x0000000007FF0000 - 0x10000
INFO - MmInitializeMemoryServices
INFO - MmAddMemoryRegion 2 : 0x000000000600F000 - 0x0000000001FE1000
INFO - HobSize - 0x538
INFO - MmHobStart - 0x7FEE810
INFO - MmInstallConfigurationTable For HobList
INFO - ASSERT [StandaloneMmCore] AdvancedLoggerLib.c(164): mLoggerInfo != ((void *) 0)
```

This change allows writes to proceed to hardware output if enabled even if the logger info is not available, to make information such as this available for debugging purposes.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Test MM entry with and without `gAdvancedLoggerHobGuid` in the HOB list.

## Integration Instructions

- N/A