### PR TITLE
AdvLoggerPkg: Update functionality for PeilessSec

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
@@ -37,15 +37,20 @@ AdvancedLoggerLibConstructor (
 
   LoggerInfo = ALI_FROM_PA (FixedPcdGet64 (PcdAdvancedLoggerBase));
   if (LoggerInfo != NULL) {
-    ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
-    LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
-    LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;
-    LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
-    LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-    LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
+    // Check if the LoggerInfo has already been initalized in a previous phase to
+    //  prevent overwritting any logs already collected
+    if (LoggerInfo->Signature != ADVANCED_LOGGER_SIGNATURE) {
+      ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
+      LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+      LoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
+      LoggerInfo->LogBufferSize    = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
+      LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+      LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
+      LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+      LoggerInfo->InPermanentRAM   = TRUE;
+    }
+
     LoggerInfo->HdwPortInitialized = TRUE;
-    LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-    LoggerInfo->InPermanentRAM     = TRUE;
     AdvancedLoggerHdwPortInitialize ();
     DEBUG ((DEBUG_INFO, "%a: Advanced Logger initialized at fixed RAM address %p\n", __func__, LoggerInfo));
 


### PR DESCRIPTION

## Description

In PeilessSec platforms using a PcdAdvancedLoggerBase at a fixed location, there are other firmware components which may run prior to Uefi and create log messages.

Perform a check at the fixed location for a valid log signature. If the valid log signature is found, treat the log buffer as already initialized and then reinitialize the hwdport.

Found in a platform where pre UEFI firmware is initializing the log buffer, but using a different serial port from what the Uefi code uses.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Physical Platform

## Integration Instructions
No integration necessary (changes are backward compatible with existing implementation)