### PR TITLE
AdvancedLoggerPkg/MmCoreArm: Initialize LoggerInfo if not already set by earlier firmware phase

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -24,6 +24,43 @@
 //
 
 /**
+  Initialize the AdvancedLogger header at PcdAdvancedLoggerBase if a previous
+  firmware phase has not already done so.
+
+  On boot flows where StandaloneMM runs before any phase that would normally
+  lay down the ADVANCED_LOGGER_INFO header (e.g. BL31 -> StMM -> BL33/UEFI),
+  the buffer signature will be invalid on first entry. This routine performs
+  a one-time initialization of the header so that subsequent logging calls
+  have a valid buffer to write into.
+
+  @param  LoggerInfo  Caller-supplied non-NULL pointer to the fixed buffer.
+**/
+STATIC
+VOID
+InitializeLoggerHeaderIfNeeded (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  )
+{
+  UINTN  LogBufferSize;
+
+  if (LoggerInfo->Signature == ADVANCED_LOGGER_SIGNATURE) {
+    return;
+  }
+
+  LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages));
+
+  ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
+  LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
+  LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;
+  LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
+  LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+  LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
+  LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+  LoggerInfo->HdwPortInitialized = TRUE;
+  LoggerInfo->InPermanentRAM     = TRUE;
+}
+
+/**
   The logger Information Block is carved from the Trust Zone at a specific fixed address.
 
   This address is obtained from the PcdAdvancedLoggerBase.  The size of the Advanced Logger
@@ -63,6 +100,12 @@ AdvancedLoggerGetLoggerInfo (
   if (LoggerInfo == NULL) {
     return NULL;
   }
+
+  //
+  // First StMM caller in a boot lays down the header; subsequent callers
+  // (re-entries, DxeCore, etc.) find a valid signature and skip init.
+  //
+  InitializeLoggerHeaderIfNeeded (LoggerInfo);
 
   //
   // LogBuffer and LogCurrent, and LogBufferSize, could be written

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -43,6 +43,10 @@ InitializeLoggerHeaderIfNeeded (
 {
   UINTN  LogBufferSize;
 
+  if (LoggerInfo == NULL) {
+    return;
+  }
+
   if (LoggerInfo->Signature == ADVANCED_LOGGER_SIGNATURE) {
     return;
   }
@@ -56,8 +60,8 @@ InitializeLoggerHeaderIfNeeded (
   LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
   LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
   LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-      AdvancedLoggerHdwPortInitialize ();
-      LoggerInfo->HdwPortInitialized = TRUE;
+  AdvancedLoggerHdwPortInitialize ();
+  LoggerInfo->HdwPortInitialized = TRUE;
   LoggerInfo->InPermanentRAM     = TRUE;
 }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -61,12 +61,12 @@ InitializeLoggerHeaderIfNeeded (
   }
 
   ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
-  LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
-  LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;
-  LoggerInfo->LogBufferSize      = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
-  LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
-  LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
-  LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+  LoggerInfo->Signature        = ADVANCED_LOGGER_SIGNATURE;
+  LoggerInfo->Version          = ADVANCED_LOGGER_INFO_VER;
+  LoggerInfo->LogBufferSize    = (UINT32)(LogBufferSize - sizeof (ADVANCED_LOGGER_INFO));
+  LoggerInfo->LogBufferOffset  = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
+  LoggerInfo->LogCurrentOffset = LoggerInfo->LogBufferOffset;
+  LoggerInfo->HwPrintLevel     = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
   AdvancedLoggerHdwPortInitialize ();
   LoggerInfo->HdwPortInitialized = TRUE;
   LoggerInfo->InPermanentRAM     = TRUE;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -56,7 +56,8 @@ InitializeLoggerHeaderIfNeeded (
   LoggerInfo->LogBufferOffset    = EXPECTED_LOG_BUFFER_OFFSET (LoggerInfo);
   LoggerInfo->LogCurrentOffset   = LoggerInfo->LogBufferOffset;
   LoggerInfo->HwPrintLevel       = FixedPcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-  LoggerInfo->HdwPortInitialized = TRUE;
+      AdvancedLoggerHdwPortInitialize ();
+      LoggerInfo->HdwPortInitialized = TRUE;
   LoggerInfo->InPermanentRAM     = TRUE;
 }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -103,8 +103,8 @@ AdvancedLoggerGetLoggerInfo (
   }
 
   //
-  // First StMM caller in a boot lays down the header; subsequent callers
-  // (re-entries, DxeCore, etc.) find a valid signature and skip init.
+  // Check if the log has been initialized by a previous entity (e.g. TF-A)
+  // or a previous log in StMM. If not, initialize.
   //
   InitializeLoggerHeaderIfNeeded (LoggerInfo);
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -53,6 +53,13 @@ InitializeLoggerHeaderIfNeeded (
 
   LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet32 (PcdAdvancedLoggerPages));
 
+  //
+  // Buffer must be large enough to hold the header plus some payload
+  //
+  if (LogBufferSize <= sizeof (ADVANCED_LOGGER_INFO)) {
+    return;
+  }
+
   ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
   LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
   LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.c
@@ -33,7 +33,7 @@
   a one-time initialization of the header so that subsequent logging calls
   have a valid buffer to write into.
 
-  @param  LoggerInfo  Caller-supplied non-NULL pointer to the fixed buffer.
+  @param[in]  LoggerInfo  Caller-supplied non-NULL pointer to the fixed buffer.
 **/
 STATIC
 VOID

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
@@ -36,7 +36,10 @@ AdvancedLoggerLibConstructor (
   LogBufferSize = EFI_PAGES_TO_SIZE (FixedPcdGet64 (PcdAdvancedLoggerPages));
 
   LoggerInfo = ALI_FROM_PA (FixedPcdGet64 (PcdAdvancedLoggerBase));
-  if (LoggerInfo != NULL) {
+  //
+  // Buffer must be large enough to hold the header plus some payload.INFO).
+  //
+  if ((LoggerInfo != NULL) && (LogBufferSize > sizeof (ADVANCED_LOGGER_INFO))) {
     ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
     LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;
     LoggerInfo->Version            = ADVANCED_LOGGER_INFO_VER;

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
@@ -37,7 +37,7 @@ AdvancedLoggerLibConstructor (
 
   LoggerInfo = ALI_FROM_PA (FixedPcdGet64 (PcdAdvancedLoggerBase));
   //
-  // Buffer must be large enough to hold the header plus some payload.INFO).
+  // Buffer must be large enough to hold the header plus some payload.
   //
   if ((LoggerInfo != NULL) && (LogBufferSize > sizeof (ADVANCED_LOGGER_INFO))) {
     ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));

--- a/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
@@ -122,7 +122,10 @@ InitializeDebugAgent (
     CarBase       = (EFI_PHYSICAL_ADDRESS)FixedPcdGet64 (PcdAdvancedLoggerCarBase);
 
     NewLogBuffer = AllocateRamForSEC (CarBase, LogBufferSize);
-    if (NewLogBuffer != 0ULL) {
+    //
+    // Buffer must be large enough to hold the header plus some payload.INFO).
+    //
+    if ((NewLogBuffer != 0ULL) && (LogBufferSize > sizeof (ADVANCED_LOGGER_INFO))) {
       LoggerInfo = ALI_FROM_PA (NewLogBuffer);
       ZeroMem ((VOID *)LoggerInfo, sizeof (ADVANCED_LOGGER_INFO));
       LoggerInfo->Signature          = ADVANCED_LOGGER_SIGNATURE;

--- a/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
@@ -123,7 +123,7 @@ InitializeDebugAgent (
 
     NewLogBuffer = AllocateRamForSEC (CarBase, LogBufferSize);
     //
-    // Buffer must be large enough to hold the header plus some payload.INFO).
+    // Buffer must be large enough to hold the header plus some payload.
     //
     if ((NewLogBuffer != 0ULL) && (LogBufferSize > sizeof (ADVANCED_LOGGER_INFO))) {
       LoggerInfo = ALI_FROM_PA (NewLogBuffer);


### PR DESCRIPTION
## Description

In the MmCoreArm instance of AdvancedLoggerLib, AdvancedLoggerGetLoggerInfo() previously assumed that an earlier firmware phase (e.g. BL31 prior to StandaloneMM) had already initialized the ADVANCED_LOGGER_INFO header at PcdAdvancedLoggerBase. On ARM boot flows where StandaloneMM is the first phase to touch this buffer, the signature check in subsequent logger calls fails and no log records are written.

This change adds a one-time, in-place initialization of the ADVANCED_LOGGER_INFO header inside AdvancedLoggerGetLoggerInfo() when the signature is not already valid:

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified on an ARM platform where no pre-StandaloneMM entity initializes the AdvancedLogger buffer

## Integration Instructions

N/A