### PR TITLE
Fix missing UefiLib dependency in MfciPolicyParsingUnitTestApp

### DIFF
--- a/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
+++ b/MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
@@ -40,5 +40,6 @@
   BaseMemoryLib
   DebugLib
   UefiApplicationEntryPoint
+  UefiLib
   UnitTestLib
   MfciPolicyParsingLib


### PR DESCRIPTION
## Description

  Added the missing UefiLib library class dependency to MfciPolicyParsingUnitTestApp.inf. The module uses UefiLib APIs but did not declare the dependency in its [LibraryClasses] section, causing build failures when the library was not implicitly pulled in by the platform DSC.
The module uses AsciiPrint() from UefiLib but did not declare the dependency in its LibraryClasses section.

   - [X]  Impacts functionality? No — build fix only; no logic changes.
   - [ ]  Impacts security?
   - [ ]  Breaking change?
   - [ ]  Includes tests? N/A — fixes the test app itself so it builds correctly.
   - [ ]  Includes documentation?

 ## How This Was Tested

  Built MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf and confirmed the build completes without missing library errors.

 ## Integration Instructions

  N/A — consumers of MfciPkg do not need any changes; this only affects the unit test app build.
