### PR TITLE
Fix SWM init retry when SRE is not ready

### DIFF
--- a/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
+++ b/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
@@ -1531,6 +1531,7 @@ GopRegisteredCallback (
                   );
 
   if (EFI_ERROR (Status)) {
+    mGop = NULL;
     goto Exit;
   }
 

--- a/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
+++ b/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
@@ -1518,9 +1518,6 @@ GopRegisteredCallback (
     goto Exit;
   }
 
-  mAbsPointerMode.AbsoluteMaxX = mGop->Mode->Info->HorizontalResolution;
-  mAbsPointerMode.AbsoluteMaxY = mGop->Mode->Info->VerticalResolution;
-
   // Determine if the Simple Rendering Engine Protocol is available on the same Console Out handle.  The
   // Rendering Engine driver provides both Graphics Output and Rendering Engine protocols.
   //
@@ -1534,6 +1531,9 @@ GopRegisteredCallback (
     mGop = NULL;
     goto Exit;
   }
+
+  mAbsPointerMode.AbsoluteMaxX = mGop->Mode->Info->HorizontalResolution;
+  mAbsPointerMode.AbsoluteMaxY = mGop->Mode->Info->VerticalResolution;
 
   // Now that we found the Graphics Output Protocol, complete the second half of driver initialization.
   //


### PR DESCRIPTION
## Description

GopRegisteredCallback sets mGop when it finds GOP but exits early if SRE is not available yet. Because mGop remains set, the callback never retries on subsequent GOP notifications, so SWM never initializes.

Reset mGop to NULL when SRE is not found so the callback can retry.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on:

 - ARM64 platform with GPU driver that installs GOP during early display enumeration, before GopOverrideDxe and SRE have processed it
 - Verified SWM callback retries and completes Stage2 initialization after SRE becomes available
 - Confirmed Front Page and on-screen keyboard render correctly
 - Verified no regression when GOP and SRE appear simultaneously (standard boot path)

## Integration Instructions

N/A