### PR TITLE
MsCorePkg: Remove the non-existent header files in aarch64

### DIFF
--- a/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLibAArch64.c
+++ b/MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLibAArch64.c
@@ -15,7 +15,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Pi/PiStatusCode.h>
 
 #include <Protocol/DebugSupport.h>
-#include <Protocol/MemoryProtectionNonstopMode.h>
 
 #include <Guid/DebugImageInfoTable.h>
 


### PR DESCRIPTION
## Description

As stated in #895, this header file no longer exists, and the issue has been fixed in X64. However, Aarch64 was overlooked, so it should be applied to AArch64 as well.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A