### PR TITLE
MsCorePkg: Fix double components specifier for AARCH64

### DIFF
--- a/MsCorePkg/MsCorePkg.dsc
+++ b/MsCorePkg/MsCorePkg.dsc
@@ -200,7 +200,7 @@
   MsCorePkg/MacAddressEmulationDxe/MacAddressEmulationDxe.inf
   MsCorePkg/Library/MacAddressEmulationPlatformLibNull/MacAddressEmulationPlatformLibNull.inf
 
-[Components.AARCH64, Components.AARCH64]
+[Components.AARCH64]
   MsCorePkg/Library/MemoryProtectionExceptionHandlerLib/MemoryProtectionExceptionHandlerLib.inf
   MsCorePkg/Library/MuArmGicExLib/MuArmGicExLib.inf
 


### PR DESCRIPTION
## Description

`[Components.AARCH64, Components.AARCH64]` should just be `[Components.AARCH64]` in `MsCorePkg.dsc`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Local MsCorePkg CI build

## Integration Instructions

- N/A