### PR TITLE
AdvLoggerPkg: Gate hardware port writes at OS runtime

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -99,14 +99,14 @@
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable|FALSE|BOOLEAN|0x00010188
 
-  ## PcdAdvancedLoggerHdwPortRuntimeDisable - Suppress hardware (serial) port writes at OS
+  ## PcdAdvancedLoggerHdwPortOsRuntimeDisable - Suppress hardware port writes at OS
   # runtime (after ExitBootServices). By default (FALSE), behavior is unchanged: hardware port
   # writes remain enabled at runtime, matching the historical default. Set to TRUE only on a
-  # platform whose underlying serial implementation cannot be safely called after
+  # platform whose underlying hardware port implementation cannot be safely called after
   # ExitBootServices; this restricts hardware port writes to boot time while preserving
-  # early-boot and boot-time serial output.
+  # early-boot and boot-time hardware port output.
   #
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable|FALSE|BOOLEAN|0x0001018A
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable|FALSE|BOOLEAN|0x0001018A
 
 
 [PcdsFixedAtBuild]

--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -100,11 +100,9 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable|FALSE|BOOLEAN|0x00010188
 
   ## PcdAdvancedLoggerHdwPortOsRuntimeDisable - Suppress hardware port writes at OS
-  # runtime (after ExitBootServices). By default (FALSE), behavior is unchanged: hardware port
-  # writes remain enabled at runtime, matching the historical default. Set to TRUE only on a
-  # platform whose underlying hardware port implementation cannot be safely called after
-  # ExitBootServices; this restricts hardware port writes to boot time while preserving
-  # early-boot and boot-time hardware port output.
+  # runtime (after ExitBootServices). By default (FALSE), hardware port writes remain
+  # enabled at runtime. Set to TRUE on a platform whose underlying hardware port
+  # implementation cannot be safely called after ExitBootServices.
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable|FALSE|BOOLEAN|0x0001018A
 

--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -99,6 +99,15 @@
   #
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable|FALSE|BOOLEAN|0x00010188
 
+  ## PcdAdvancedLoggerHdwPortRuntimeDisable - Suppress hardware (serial) port writes at OS
+  # runtime (after ExitBootServices). By default (FALSE), behavior is unchanged: hardware port
+  # writes remain enabled at runtime, matching the historical default. Set to TRUE only on a
+  # platform whose underlying serial implementation cannot be safely called after
+  # ExitBootServices; this restricts hardware port writes to boot time while preserving
+  # early-boot and boot-time serial output.
+  #
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable|FALSE|BOOLEAN|0x0001018A
+
 
 [PcdsFixedAtBuild]
   ## Advanced Logger Base - NULL = UEFI starts with PEI or DXE, and there is no SEC, or SEC

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -136,6 +136,38 @@ AdvancedLoggerMemoryLoggerWrite (
 }
 
 /**
+  Returns whether the given message's debug level is enabled for the hardware port.
+
+  This is the generic hardware port debug level policy shared by the Advanced Logger instances
+  that honor the logger info block's dynamic level. Instances that must not consult the dynamic
+  level (such as SEC instances) provide their own AdvancedLoggerPrintToHwPort instead of using
+  this helper.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
+
+  @retval TRUE   The message's debug level is enabled for the hardware port.
+  @retval FALSE  The message's debug level is not enabled for the hardware port.
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerHwPortLevelEnabled (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
+  )
+{
+  UINT32  HwPortDebugLevel;
+
+  HwPortDebugLevel = PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
+
+  if ((LoggerInfo != NULL) && (LoggerInfo->Version >= ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER)) {
+    HwPortDebugLevel = LoggerInfo->HwPrintLevel;
+  }
+
+  return (BOOLEAN)((DebugLevel & HwPortDebugLevel) != 0);
+}
+
+/**
   Write data from buffer to possible debugging devices.
 
   This is the interface from PeiCore
@@ -160,25 +192,12 @@ AdvancedLoggerWrite (
   )
 {
   ADVANCED_LOGGER_INFO  *LoggerInfo;
-  UINT32                HwPortDebugLevel;
 
   // All messages go to the in memory log.
   LoggerInfo = AdvancedLoggerMemoryLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
 
-  HwPortDebugLevel = PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel);
-
-  // Only selected messages go to the hdw port.
-
-  if ((LoggerInfo == NULL) || (!LoggerInfo->HdwPortDisabled)) {
- #ifndef ADVANCED_LOGGER_SEC
-    if ((LoggerInfo != NULL) && (LoggerInfo->Version >= ADVANCED_LOGGER_INFO_HW_LVL_SUPPORTED_VER)) {
-      HwPortDebugLevel = LoggerInfo->HwPrintLevel;
-    }
-
- #endif
-
-    if ((DebugLevel & HwPortDebugLevel) && AdvancedLoggerPrintToHwPort (LoggerInfo)) {
-      AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
-    }
+  // Only selected messages go to the hardware port.
+  if (AdvancedLoggerPrintToHwPort (LoggerInfo, DebugLevel)) {
+    AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
   }
 }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -19,6 +19,13 @@
 
 #include "../AdvancedLoggerCommon.h"
 
+#ifdef ADVANCED_LOGGER_RUNTIME
+//
+// Defined by the DXE runtime AdvancedLoggerLib instance; TRUE after ExitBootServices.
+//
+extern BOOLEAN  gAdvancedLoggerAtRuntime;
+#endif
+
 /**
   Write data from buffer into the in memory logging buffer.
 
@@ -161,6 +168,8 @@ AdvancedLoggerWrite (
 {
   ADVANCED_LOGGER_INFO  *LoggerInfo;
   UINT32                HwPortDebugLevel;
+  BOOLEAN               HwPortWriteAllowed;
+  BOOLEAN               AtRuntime;
 
   // All messages go to the in memory log.
   LoggerInfo = AdvancedLoggerMemoryLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
@@ -177,7 +186,50 @@ AdvancedLoggerWrite (
 
  #endif
 
-    if (DebugLevel & HwPortDebugLevel) {
+    //
+    // By default hardware port writes are always allowed, preserving the historical
+    // behavior of writing debug output to the serial port at both boot time and OS runtime.
+    //
+    // The underlying hardware serial port implementation on some platforms cannot be safely
+    // called at OS runtime (after ExitBootServices). Such a platform sets the FeatureFlag PCD
+    // PcdAdvancedLoggerHdwPortRuntimeDisable to TRUE to restrict hardware port writes to boot
+    // time only. The runtime detection below is therefore only needed for those opt-in
+    // platforms; for everyone else the PCD is a compile-time FALSE and this whole block is
+    // optimized away, leaving behavior and code size unchanged.
+    //
+    HwPortWriteAllowed = TRUE;
+    if (FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable)) {
+      //
+      // Determine whether we are at OS runtime using whichever signal is available, so that
+      // hardware port writes are suppressed only at runtime and early-boot serial output is
+      // preserved.
+      //
+      // When the logger info block is available, its AtRuntime field is authoritative.
+      // A NULL block usually indicates very early boot (before the block is locatable);
+      // the exception is the DXE runtime instance, which also returns NULL at runtime
+      // because it clears its logger info pointer at ExitBootServices.
+      //
+      if (LoggerInfo != NULL) {
+        AtRuntime = LoggerInfo->AtRuntime;
+      } else {
+ #ifdef ADVANCED_LOGGER_RUNTIME
+        //
+        // The DXE runtime instance clears its logger info pointer at ExitBootServices, so a
+        // NULL block is ambiguous between early boot and runtime; consult the runtime flag.
+        //
+        AtRuntime = gAdvancedLoggerAtRuntime;
+ #else
+        //
+        // For all other instances a NULL block indicates very early boot.
+        //
+        AtRuntime = FALSE;
+ #endif
+      }
+
+      HwPortWriteAllowed = (BOOLEAN)(!AtRuntime);
+    }
+
+    if ((DebugLevel & HwPortDebugLevel) && HwPortWriteAllowed) {
       AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
     }
   }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.c
@@ -19,13 +19,6 @@
 
 #include "../AdvancedLoggerCommon.h"
 
-#ifdef ADVANCED_LOGGER_RUNTIME
-//
-// Defined by the DXE runtime AdvancedLoggerLib instance; TRUE after ExitBootServices.
-//
-extern BOOLEAN  gAdvancedLoggerAtRuntime;
-#endif
-
 /**
   Write data from buffer into the in memory logging buffer.
 
@@ -168,8 +161,6 @@ AdvancedLoggerWrite (
 {
   ADVANCED_LOGGER_INFO  *LoggerInfo;
   UINT32                HwPortDebugLevel;
-  BOOLEAN               HwPortWriteAllowed;
-  BOOLEAN               AtRuntime;
 
   // All messages go to the in memory log.
   LoggerInfo = AdvancedLoggerMemoryLoggerWrite (DebugLevel, Buffer, NumberOfBytes);
@@ -186,50 +177,7 @@ AdvancedLoggerWrite (
 
  #endif
 
-    //
-    // By default hardware port writes are always allowed, preserving the historical
-    // behavior of writing debug output to the serial port at both boot time and OS runtime.
-    //
-    // The underlying hardware serial port implementation on some platforms cannot be safely
-    // called at OS runtime (after ExitBootServices). Such a platform sets the FeatureFlag PCD
-    // PcdAdvancedLoggerHdwPortRuntimeDisable to TRUE to restrict hardware port writes to boot
-    // time only. The runtime detection below is therefore only needed for those opt-in
-    // platforms; for everyone else the PCD is a compile-time FALSE and this whole block is
-    // optimized away, leaving behavior and code size unchanged.
-    //
-    HwPortWriteAllowed = TRUE;
-    if (FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable)) {
-      //
-      // Determine whether we are at OS runtime using whichever signal is available, so that
-      // hardware port writes are suppressed only at runtime and early-boot serial output is
-      // preserved.
-      //
-      // When the logger info block is available, its AtRuntime field is authoritative.
-      // A NULL block usually indicates very early boot (before the block is locatable);
-      // the exception is the DXE runtime instance, which also returns NULL at runtime
-      // because it clears its logger info pointer at ExitBootServices.
-      //
-      if (LoggerInfo != NULL) {
-        AtRuntime = LoggerInfo->AtRuntime;
-      } else {
- #ifdef ADVANCED_LOGGER_RUNTIME
-        //
-        // The DXE runtime instance clears its logger info pointer at ExitBootServices, so a
-        // NULL block is ambiguous between early boot and runtime; consult the runtime flag.
-        //
-        AtRuntime = gAdvancedLoggerAtRuntime;
- #else
-        //
-        // For all other instances a NULL block indicates very early boot.
-        //
-        AtRuntime = FALSE;
- #endif
-      }
-
-      HwPortWriteAllowed = (BOOLEAN)(!AtRuntime);
-    }
-
-    if ((DebugLevel & HwPortDebugLevel) && HwPortWriteAllowed) {
+    if ((DebugLevel & HwPortDebugLevel) && AdvancedLoggerPrintToHwPort (LoggerInfo)) {
       AdvancedLoggerHdwPortWrite (DebugLevel, (UINT8 *)Buffer, NumberOfBytes);
     }
   }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -79,24 +79,46 @@ AdvancedLoggerMemoryLoggerWrite (
   );
 
 /**
-  Returns whether the current Advanced Logger instance permits writing debug output to the
-  hardware port.
+  Returns whether the given message should be written to the hardware port for this
+  Advanced Logger instance.
 
-  Each library instance that links AdvancedLoggerCommon.c provides this function. The default
-  implementation (AdvancedLoggerHwPort.c) permits hardware port writes at boot time, and at OS
-  runtime unless the platform sets PcdAdvancedLoggerHdwPortOsRuntimeDisable. The DXE runtime
-  instance overrides the default implementation because it clears its logger info block at
-  ExitBootServices.
+  Each library instance provides this function so that instances with special hardware port
+  considerations can override the default behavior. The implementation owns the full hardware
+  port decision, including debug level filtering, so callers write to the hardware port
+  whenever this returns TRUE.
 
   @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
 
-  @retval TRUE   Hardware port writes are permitted.
-  @retval FALSE  Hardware port writes are currently suppressed.
+  @retval TRUE   The message should be written to the hardware port.
+  @retval FALSE  The message should not be written to the hardware port.
 **/
 BOOLEAN
 EFIAPI
 AdvancedLoggerPrintToHwPort (
-  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
+  );
+
+/**
+  Returns whether the given message's debug level is enabled for the hardware port.
+
+  This is the generic hardware port debug level policy shared by the Advanced Logger instances
+  that honor the logger info block's dynamic level. Instances that must not consult the dynamic
+  level (such as SEC instances) provide their own AdvancedLoggerPrintToHwPort instead of using
+  this helper.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
+
+  @retval TRUE   The message's debug level is enabled for the hardware port.
+  @retval FALSE  The message's debug level is not enabled for the hardware port.
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerHwPortLevelEnabled (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
   );
 
 #endif // __ADVANCED_LOGGER_COMMON_H__

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -78,4 +78,25 @@ AdvancedLoggerMemoryLoggerWrite (
   IN       UINTN  NumberOfBytes
   );
 
+/**
+  Returns whether the current Advanced Logger instance permits writing debug output to the
+  hardware port.
+
+  Each library instance that links AdvancedLoggerCommon.c provides this function. The default
+  implementation (AdvancedLoggerHwPort.c) permits hardware port writes at boot time, and at OS
+  runtime unless the platform sets PcdAdvancedLoggerHdwPortRuntimeDisable. The DXE runtime
+  instance overrides the default implementation because it clears its logger info block at
+  ExitBootServices.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+
+  @retval TRUE   Hardware port writes are permitted.
+  @retval FALSE  Hardware port writes are currently suppressed.
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerPrintToHwPort (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  );
+
 #endif // __ADVANCED_LOGGER_COMMON_H__

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerCommon.h
@@ -84,7 +84,7 @@ AdvancedLoggerMemoryLoggerWrite (
 
   Each library instance that links AdvancedLoggerCommon.c provides this function. The default
   implementation (AdvancedLoggerHwPort.c) permits hardware port writes at boot time, and at OS
-  runtime unless the platform sets PcdAdvancedLoggerHdwPortRuntimeDisable. The DXE runtime
+  runtime unless the platform sets PcdAdvancedLoggerHdwPortOsRuntimeDisable. The DXE runtime
   instance overrides the default implementation because it clears its logger info block at
   ExitBootServices.
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
@@ -1,0 +1,50 @@
+/** @file
+  Default AdvancedLoggerPrintToHwPort implementation, shared by the Advanced Logger library
+  instances that do not override it for special hardware port handling at OS runtime.
+
+  Permits hardware port writes at boot time, and at OS runtime unless a platform
+  opts in to PcdAdvancedLoggerHdwPortRuntimeDisable. The DXE runtime instance provides its
+  own implementation (it clears its logger info block at ExitBootServices) instead of using
+  this file.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+
+#include <AdvancedLoggerInternal.h>
+
+#include <Library/PcdLib.h>
+
+#include "AdvancedLoggerCommon.h"
+
+/**
+  Returns whether this Advanced Logger instance permits writing debug output to the
+  hardware port.
+
+  Hardware port writes are always permitted unless the platform sets
+  PcdAdvancedLoggerHdwPortRuntimeDisable, in which case they are suppressed once at OS
+  runtime (after ExitBootServices), as reported by the logger info block's AtRuntime field.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+
+  @retval TRUE   Hardware port writes are permitted.
+  @retval FALSE  Hardware port writes are currently suppressed (OS runtime, opt-in platform).
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerPrintToHwPort (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  )
+{
+  if (FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable) &&
+      (LoggerInfo != NULL) &&
+      (LoggerInfo->AtRuntime))
+  {
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
@@ -1,13 +1,11 @@
 /** @file
   Default AdvancedLoggerPrintToHwPort implementation, shared by the Advanced Logger library
-  instances that do not override it for special hardware port handling at OS runtime.
+  instances that do not override it for special hardware port handling.
 
-  Permits hardware port writes at boot time, and at OS runtime unless a platform
-  opts in to PcdAdvancedLoggerHdwPortOsRuntimeDisable. The DXE runtime instance provides its
-  own implementation (it clears its logger info block at ExitBootServices) instead of using
-  this file.
+  Decides whether a message should be written to the hardware port based on the logger info
+  block and the configured hardware port debug level.
 
-  Copyright (C) Microsoft Corporation. All rights reserved.
+  Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -16,35 +14,28 @@
 
 #include <AdvancedLoggerInternal.h>
 
-#include <Library/PcdLib.h>
-
 #include "AdvancedLoggerCommon.h"
 
 /**
-  Returns whether this Advanced Logger instance permits writing debug output to the
-  hardware port.
-
-  Hardware port writes are always permitted unless the platform sets
-  PcdAdvancedLoggerHdwPortOsRuntimeDisable, in which case they are suppressed once at OS
-  runtime (after ExitBootServices), as reported by the logger info block's AtRuntime field.
+  Returns whether the given message should be written to the hardware port for this
+  Advanced Logger instance.
 
   @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
 
-  @retval TRUE   Hardware port writes are permitted.
-  @retval FALSE  Hardware port writes are currently suppressed (OS runtime, opt-in platform).
+  @retval TRUE   The message should be written to the hardware port.
+  @retval FALSE  The message should not be written to the hardware port.
 **/
 BOOLEAN
 EFIAPI
 AdvancedLoggerPrintToHwPort (
-  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
   )
 {
-  if (FeaturePcdGet (PcdAdvancedLoggerHdwPortOsRuntimeDisable) &&
-      (LoggerInfo != NULL) &&
-      (LoggerInfo->AtRuntime))
-  {
+  if ((LoggerInfo != NULL) && (LoggerInfo->HdwPortDisabled)) {
     return FALSE;
   }
 
-  return TRUE;
+  return AdvancedLoggerHwPortLevelEnabled (LoggerInfo, DebugLevel);
 }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/AdvancedLoggerHwPort.c
@@ -3,7 +3,7 @@
   instances that do not override it for special hardware port handling at OS runtime.
 
   Permits hardware port writes at boot time, and at OS runtime unless a platform
-  opts in to PcdAdvancedLoggerHdwPortRuntimeDisable. The DXE runtime instance provides its
+  opts in to PcdAdvancedLoggerHdwPortOsRuntimeDisable. The DXE runtime instance provides its
   own implementation (it clears its logger info block at ExitBootServices) instead of using
   this file.
 
@@ -25,7 +25,7 @@
   hardware port.
 
   Hardware port writes are always permitted unless the platform sets
-  PcdAdvancedLoggerHdwPortRuntimeDisable, in which case they are suppressed once at OS
+  PcdAdvancedLoggerHdwPortOsRuntimeDisable, in which case they are suppressed once at OS
   runtime (after ExitBootServices), as reported by the logger info block's AtRuntime field.
 
   @param  LoggerInfo  The logger info block, or NULL if it is not available.
@@ -39,7 +39,7 @@ AdvancedLoggerPrintToHwPort (
   IN ADVANCED_LOGGER_INFO  *LoggerInfo
   )
 {
-  if (FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable) &&
+  if (FeaturePcdGet (PcdAdvancedLoggerHdwPortOsRuntimeDisable) &&
       (LoggerInfo != NULL) &&
       (LoggerInfo->AtRuntime))
   {

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -42,6 +42,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -43,7 +43,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -25,6 +25,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/BaseArm/AdvancedLoggerLib.inf
@@ -43,7 +43,6 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -64,4 +64,4 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerLocator
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -64,4 +64,3 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerLocator
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -63,3 +63,4 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerLocator
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/DxeCore/AdvancedLoggerLib.inf
@@ -25,6 +25,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
@@ -46,7 +46,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
@@ -25,6 +25,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
@@ -46,7 +46,6 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCore/AdvancedLoggerLib.inf
@@ -45,6 +45,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [Depex]
   TRUE

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
@@ -43,6 +43,7 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
@@ -44,7 +44,6 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
@@ -25,6 +25,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/MmCoreArm/AdvancedLoggerLib.inf
@@ -44,7 +44,7 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
@@ -42,4 +42,4 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel  ## SOMETIMES_CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable              ## SOMETIMES_CONSUMES
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable        ## SOMETIMES_CONSUMES
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable        ## SOMETIMES_CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
@@ -42,4 +42,3 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel  ## SOMETIMES_CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable              ## SOMETIMES_CONSUMES
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable        ## SOMETIMES_CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
@@ -24,6 +24,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Pei64/AdvancedLoggerLib.inf
@@ -41,3 +41,4 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortDebugPrintErrorLevel  ## SOMETIMES_CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable              ## SOMETIMES_CONSUMES
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable        ## SOMETIMES_CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -57,7 +57,6 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM                   ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -56,6 +56,7 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM                   ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -57,7 +57,7 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerFixedInRAM                   ## CONSUMES
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [FixedPcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerBase                         ## CONSUMES

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -24,6 +24,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.c
@@ -114,3 +114,30 @@ AdvancedLoggerGetPhase (
 {
   return ADVANCED_LOGGER_PHASE_SEC;
 }
+
+/**
+  Returns whether the given message should be written to the hardware port for this SEC
+  Advanced Logger instance.
+
+  SEC instances use only the static hardware port debug level and do not consult the logger
+  info block's dynamic hardware port level.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
+
+  @retval TRUE   The message should be written to the hardware port.
+  @retval FALSE  The message should not be written to the hardware port.
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerPrintToHwPort (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
+  )
+{
+  if ((LoggerInfo != NULL) && (LoggerInfo->HdwPortDisabled)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)((DebugLevel & PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel)) != 0);
+}

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
@@ -27,7 +27,6 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
-  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -51,7 +50,3 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
-
-[BuildOptions]
-  *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
@@ -51,7 +51,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
@@ -50,6 +50,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeilessArm/AdvancedLoggerLib.inf
@@ -27,6 +27,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -139,35 +139,39 @@ AdvancedLoggerGetPhase (
 }
 
 /**
-  Returns whether this (DXE runtime) Advanced Logger instance permits writing debug output to
-  the hardware port.
+  Returns whether the given message should be written to the hardware port for the DXE
+  runtime Advanced Logger instance.
 
-  Hardware port writes are always permitted unless the platform sets
-  PcdAdvancedLoggerHdwPortOsRuntimeDisable, in which case they are suppressed once at OS runtime
-  (after ExitBootServices). The runtime status is taken from the logger info block's AtRuntime
-  field when available; this instance clears that block at ExitBootServices, so it falls back
-  to mAdvancedLoggerAtRuntime once the block is no longer available.
+  In addition to the common hardware port gating, this instance suppresses hardware port
+  writes at OS runtime when platform configuration enables OS-runtime suppression.
 
   @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
 
-  @retval TRUE   Hardware port writes are permitted.
-  @retval FALSE  Hardware port writes are currently suppressed (OS runtime, opt-in platform).
+  @retval TRUE   The message should be written to the hardware port.
+  @retval FALSE  The message should not be written to the hardware port.
 **/
 BOOLEAN
 EFIAPI
 AdvancedLoggerPrintToHwPort (
-  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
   )
 {
   BOOLEAN  AtOsRuntime;
 
-  if (!FeaturePcdGet (PcdAdvancedLoggerHdwPortOsRuntimeDisable)) {
-    return TRUE;
+  if ((LoggerInfo != NULL) && (LoggerInfo->HdwPortDisabled)) {
+    return FALSE;
   }
 
-  AtOsRuntime = (LoggerInfo != NULL) ? LoggerInfo->AtRuntime : mAdvancedLoggerAtRuntime;
+  if (FeaturePcdGet (PcdAdvancedLoggerHdwPortOsRuntimeDisable)) {
+    AtOsRuntime = (LoggerInfo != NULL) ? LoggerInfo->AtRuntime : mAdvancedLoggerAtRuntime;
+    if (AtOsRuntime) {
+      return FALSE;
+    }
+  }
 
-  return (BOOLEAN)(!AtOsRuntime);
+  return AdvancedLoggerHwPortLevelEnabled (LoggerInfo, DebugLevel);
 }
 
 /**

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -17,6 +17,7 @@
 
 #include <Library/DebugLib.h>
 #include <Library/BaseLib.h>
+#include <Library/PcdLib.h>
 
 #include "../AdvancedLoggerCommon.h"
 
@@ -28,13 +29,10 @@ STATIC EFI_EVENT             mExitBootServicesEvent = NULL;
 
 //
 // TRUE after ExitBootServices. This instance clears its logger info pointer at
-// ExitBootServices (see OnExitBootServicesNotification), making a NULL logger info block
-// ambiguous between early boot and runtime. AdvancedLoggerCommon.c (compiled with
-// -D ADVANCED_LOGGER_RUNTIME for this instance) consults this flag, only when a platform
-// sets PcdAdvancedLoggerHdwPortRuntimeDisable, to suppress hardware port writes at runtime
-// while preserving boot-time output.
+// ExitBootServices, so AdvancedLoggerPrintToHwPort uses this flag to obtain the OS runtime
+// status once the logger info block is no longer available.
 //
-BOOLEAN  gAdvancedLoggerAtRuntime = FALSE;
+STATIC BOOLEAN  mAdvancedLoggerAtRuntime = FALSE;
 
 /**
     CheckAddress
@@ -141,6 +139,38 @@ AdvancedLoggerGetPhase (
 }
 
 /**
+  Returns whether this (DXE runtime) Advanced Logger instance permits writing debug output to
+  the hardware port.
+
+  Hardware port writes are always permitted unless the platform sets
+  PcdAdvancedLoggerHdwPortRuntimeDisable, in which case they are suppressed once at OS runtime
+  (after ExitBootServices). The runtime status is taken from the logger info block's AtRuntime
+  field when available; this instance clears that block at ExitBootServices, so it falls back
+  to mAdvancedLoggerAtRuntime once the block is no longer available.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+
+  @retval TRUE   Hardware port writes are permitted.
+  @retval FALSE  Hardware port writes are currently suppressed (OS runtime, opt-in platform).
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerPrintToHwPort (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo
+  )
+{
+  BOOLEAN  AtOsRuntime;
+
+  if (!FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable)) {
+    return TRUE;
+  }
+
+  AtOsRuntime = (LoggerInfo != NULL) ? LoggerInfo->AtRuntime : mAdvancedLoggerAtRuntime;
+
+  return (BOOLEAN)(!AtOsRuntime);
+}
+
+/**
     Inform all instances of Advanced Logger that ExitBoot Services has occurred.
 
     @param    Event           Not Used.
@@ -158,7 +188,7 @@ OnExitBootServicesNotification (
   //
   // Runtime logging is currently not supported, so clear mLoggerInfo.
   //
-  gAdvancedLoggerAtRuntime = TRUE;
+  mAdvancedLoggerAtRuntime = TRUE;
   mLoggerInfo              = NULL;
   mBS                      = NULL;
 }

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -26,6 +26,16 @@ STATIC EFI_PHYSICAL_ADDRESS  mMaxAddress            = 0;
 STATIC EFI_BOOT_SERVICES     *mBS                   = NULL;
 STATIC EFI_EVENT             mExitBootServicesEvent = NULL;
 
+//
+// TRUE after ExitBootServices. This instance clears its logger info pointer at
+// ExitBootServices (see OnExitBootServicesNotification), making a NULL logger info block
+// ambiguous between early boot and runtime. AdvancedLoggerCommon.c (compiled with
+// -D ADVANCED_LOGGER_RUNTIME for this instance) consults this flag, only when a platform
+// sets PcdAdvancedLoggerHdwPortRuntimeDisable, to suppress hardware port writes at runtime
+// while preserving boot-time output.
+//
+BOOLEAN  gAdvancedLoggerAtRuntime = FALSE;
+
 /**
     CheckAddress
 
@@ -148,8 +158,9 @@ OnExitBootServicesNotification (
   //
   // Runtime logging is currently not supported, so clear mLoggerInfo.
   //
-  mLoggerInfo = NULL;
-  mBS         = NULL;
+  gAdvancedLoggerAtRuntime = TRUE;
+  mLoggerInfo              = NULL;
+  mBS                      = NULL;
 }
 
 /**

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.c
@@ -143,7 +143,7 @@ AdvancedLoggerGetPhase (
   the hardware port.
 
   Hardware port writes are always permitted unless the platform sets
-  PcdAdvancedLoggerHdwPortRuntimeDisable, in which case they are suppressed once at OS runtime
+  PcdAdvancedLoggerHdwPortOsRuntimeDisable, in which case they are suppressed once at OS runtime
   (after ExitBootServices). The runtime status is taken from the logger info block's AtRuntime
   field when available; this instance clears that block at ExitBootServices, so it falls back
   to mAdvancedLoggerAtRuntime once the block is no longer available.
@@ -161,7 +161,7 @@ AdvancedLoggerPrintToHwPort (
 {
   BOOLEAN  AtOsRuntime;
 
-  if (!FeaturePcdGet (PcdAdvancedLoggerHdwPortRuntimeDisable)) {
+  if (!FeaturePcdGet (PcdAdvancedLoggerHdwPortOsRuntimeDisable)) {
     return TRUE;
   }
 

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
@@ -47,3 +47,10 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+
+[BuildOptions]
+  # Tell the shared AdvancedLoggerCommon.c that this is the DXE runtime instance, which
+  # clears its logger info pointer at ExitBootServices. This lets the hardware port runtime
+  # gating distinguish runtime from early boot when the logger info block is NULL.
+  *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_RUNTIME=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
@@ -47,4 +47,4 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Runtime/AdvancedLoggerLib.inf
@@ -48,9 +48,3 @@
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
-
-[BuildOptions]
-  # Tell the shared AdvancedLoggerCommon.c that this is the DXE runtime instance, which
-  # clears its logger info pointer at ExitBootServices. This lets the hardware port runtime
-  # gating distinguish runtime from early boot when the logger info block is NULL.
-  *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_RUNTIME=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.c
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.c
@@ -88,3 +88,30 @@ AdvancedLoggerGetPhase (
 {
   return ADVANCED_LOGGER_PHASE_SEC;
 }
+
+/**
+  Returns whether the given message should be written to the hardware port for this SEC
+  Advanced Logger instance.
+
+  SEC instances use only the static hardware port debug level and do not consult the logger
+  info block's dynamic hardware port level.
+
+  @param  LoggerInfo  The logger info block, or NULL if it is not available.
+  @param  DebugLevel  The debug level of the message being logged.
+
+  @retval TRUE   The message should be written to the hardware port.
+  @retval FALSE  The message should not be written to the hardware port.
+**/
+BOOLEAN
+EFIAPI
+AdvancedLoggerPrintToHwPort (
+  IN ADVANCED_LOGGER_INFO  *LoggerInfo,
+  IN UINTN                 DebugLevel
+  )
+{
+  if ((LoggerInfo != NULL) && (LoggerInfo->HdwPortDisabled)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)((DebugLevel & PcdGet32 (PcdAdvancedLoggerHdwPortDebugPrintErrorLevel)) != 0);
+}

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
@@ -50,7 +50,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
@@ -49,6 +49,7 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
@@ -28,7 +28,6 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
-  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -50,7 +49,3 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable
-
-[BuildOptions]
-  *_*_*_CC_FLAGS  = -D ADVANCED_LOGGER_SEC=1

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/Sec/AdvancedLoggerLib.inf
@@ -28,6 +28,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -50,4 +50,3 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -50,4 +50,4 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -49,3 +49,4 @@
 
 [FeaturePcd]
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable

--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/SmmCore/AdvancedLoggerLib.inf
@@ -24,6 +24,7 @@
   AdvancedLoggerLib.c
   ../AdvancedLoggerCommon.h
   ../AdvancedLoggerCommon.c
+  ../AdvancedLoggerHwPort.c
 
 [Packages]
   MdePkg/MdePkg.dec


### PR DESCRIPTION
## Description

`AdvancedLoggerWrite` unconditionally wrote debug output to the hardware serial
port at both boot time and OS runtime (after ExitBootServices). Some platforms'
serial implementations cannot be safely called at OS runtime.

This change adds an **opt-in** FeatureFlag PCD
`PcdAdvancedLoggerHdwPortRuntimeDisable` (default **FALSE**):

- **Default (FALSE):** behavior is unchanged — hardware port writes remain
  enabled at runtime, so existing platforms are unaffected.
- **TRUE:** a platform whose serial cannot be safely called after
  ExitBootServices restricts hardware port writes to boot time only, while
  early-boot and boot-time serial output is preserved.

Runtime is detected via the logger info block's `AtRuntime` field when
available. The DXE runtime `AdvancedLoggerLib` instance clears its logger info
pointer at ExitBootServices, so it consults a module-scoped
`ADVANCED_LOGGER_RUNTIME` build flag plus a `gAdvancedLoggerAtRuntime` flag to
distinguish post-EBS runtime from early boot when the logger info block is NULL.

- [x] Impacts functionality? Only when the new PCD is set TRUE (default FALSE = no change)
- [ ] Impacts security?
- [ ] Breaking change? No — default preserves existing behavior
- [ ] Includes tests? Not included; hardware-port gating path has no existing host-test coverage. Can add a GoogleTest if desired.
- [ ] Includes documentation? PCD documented in AdvLoggerPkg.dec

## How This Was Tested

Built an ARM AARCH64 platform (DEBUG); all `AdvancedLoggerLib` instances
compile. Verified on ARM AARCH64 hardware with a temporary driver that forces a
serial write on the first post-SetVirtualAddressMap runtime call:

- PCD default (FALSE): the firmware faults on the runtime serial write
  (reproduces the unsafe-at-runtime behavior).
- PCD TRUE: the runtime write is suppressed and the system boots cleanly,
  while boot-time serial output is unaffected.

## Integration Instructions

None required by default. Platforms whose serial implementation cannot be
called safely at OS runtime should set
`gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortRuntimeDisable` to TRUE.