### PR TITLE
Drop mu_pi and mu_rust_helpers crate dependencies (and fix build due to incoming r-efi v7) [Rebase & FF]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ hidparser = { version = "1" }
 HiiKeyboardLayout = { path = "HidPkg/Crates/HiiKeyboardLayout" }
 memoffset = "0.9.0"
 mockall = {version = "0.14.0"}
-mu_rust_helpers = { version = "4" }
 MuTelemetryHelperLib = { path = "MsWheaPkg/Crates/MuTelemetryHelperLib" }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ hidparser = { version = "1" }
 HiiKeyboardLayout = { path = "HidPkg/Crates/HiiKeyboardLayout" }
 memoffset = "0.9.0"
 mockall = {version = "0.14.0"}
-mu_pi = { version = "7" }
 mu_rust_helpers = { version = "4" }
 MuTelemetryHelperLib = { path = "MsWheaPkg/Crates/MuTelemetryHelperLib" }
 num-derive = { version = "0.4", default-features = false }

--- a/HidPkg/UefiHidDxeV2/Cargo.toml
+++ b/HidPkg/UefiHidDxeV2/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 HidIo = {workspace=true}
 hidparser = {workspace=true}
 HiiKeyboardLayout = {workspace=true}
-mu_rust_helpers = {workspace=true}
+patina = {workspace=true}
 r-efi = {workspace=true}
 RustAdvancedLoggerDxe = {workspace=true}
 scroll = {workspace=true}

--- a/HidPkg/UefiHidDxeV2/src/keyboard.rs
+++ b/HidPkg/UefiHidDxeV2/src/keyboard.rs
@@ -36,7 +36,7 @@ use hidparser::{
     ArrayField, ReportDescriptor, ReportField, VariableField,
     report_data_types::{ReportId, Usage},
 };
-use mu_rust_helpers::function;
+use patina::function;
 use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, DEBUG_WARN, debugln};
 
 use crate::{
@@ -969,7 +969,7 @@ mod test {
     use core::{ffi::c_void, mem::MaybeUninit, ptr, slice::from_raw_parts_mut};
 
     use hii_keyboard_layout::HiiKeyboardLayout;
-    use mu_rust_helpers::function;
+    use patina::function;
     use r_efi::{efi, hii, protocols};
     use scroll::Pwrite;
     use std::sync::Mutex;

--- a/HidPkg/UefiHidDxeV2/src/pointer.rs
+++ b/HidPkg/UefiHidDxeV2/src/pointer.rs
@@ -22,7 +22,7 @@ use hidparser::{
     ReportDescriptor, ReportField, VariableField,
     report_data_types::{ReportId, Usage},
 };
-use mu_rust_helpers::function;
+use patina::function;
 use rust_advanced_logger_dxe::{DEBUG_ERROR, DEBUG_VERBOSE, debugln};
 
 use self::absolute_pointer::PointerContext;

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
@@ -8,7 +8,6 @@ name = "mu_telemetry_helper_lib"
 path = "src/lib.rs"
 
 [dependencies]
-mu_pi = { workspace = true }
 mu_rust_helpers = { workspace = true }
 r-efi = { workspace = true }
 patina = { workspace = true }

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/Cargo.toml
@@ -8,7 +8,6 @@ name = "mu_telemetry_helper_lib"
 path = "src/lib.rs"
 
 [dependencies]
-mu_rust_helpers = { workspace = true }
 r-efi = { workspace = true }
 patina = { workspace = true }
 

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
@@ -34,11 +34,9 @@
 //!
 #![cfg_attr(target_os = "uefi", no_std)]
 
-use mu_pi::{
-    protocols::status_code::{EfiStatusCodeType, EfiStatusCodeValue},
-    status_code::{EFI_ERROR_CODE, EFI_ERROR_MAJOR, EFI_ERROR_MINOR},
-};
 use patina::boot_services::{BootServices, StandardBootServices};
+use patina::pi::protocols::status_code::{EfiStatusCodeType, EfiStatusCodeValue};
+use patina::pi::status_code::{EFI_ERROR_CODE, EFI_ERROR_MAJOR, EFI_ERROR_MINOR};
 use patina::uefi_protocol::status_code::StatusCodeRuntimeProtocol;
 use patina::{base::guid::BinaryGuid, guids};
 use r_efi::efi;
@@ -159,12 +157,12 @@ pub fn init_telemetry(efi_boot_services: *mut efi::BootServices) {
 
 #[cfg(test)]
 mod test {
-    use mu_pi::protocols::{
+    use mu_rust_helpers::guid::guid;
+    use patina::boot_services::MockBootServices;
+    use patina::pi::protocols::{
         status_code,
         status_code::{EfiStatusCodeData, EfiStatusCodeType, EfiStatusCodeValue},
     };
-    use mu_rust_helpers::guid::guid;
-    use patina::boot_services::MockBootServices;
     use r_efi::efi;
 
     use crate::{MS_WHEA_ERROR_STATUS_TYPE_FATAL, MsWheaRscInternalErrorData, log_telemetry_internal};

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
@@ -38,16 +38,17 @@ use mu_pi::{
     protocols::status_code::{EfiStatusCodeType, EfiStatusCodeValue},
     status_code::{EFI_ERROR_CODE, EFI_ERROR_MAJOR, EFI_ERROR_MINOR},
 };
-use mu_rust_helpers::{guid, guid::guid};
 use patina::boot_services::{BootServices, StandardBootServices};
 use patina::uefi_protocol::status_code::StatusCodeRuntimeProtocol;
+use patina::{base::guid::BinaryGuid, guids};
 use r_efi::efi;
 
 static BOOT_SERVICES: StandardBootServices = StandardBootServices::new_uninit();
 
 /// Matches gMsWheaRSCDataTypeGuid in MsWheaPkg\MsWheaPkg.dec
 /// Matches MS_WHEA_RSC_DATA_TYPE in MsWheaPkg\Private\Guid\MsWheaReportDataType.h
-const MS_WHEA_RSC_DATA_TYPE_GUID: efi::Guid = guid!("91DEEA05-8C0A-4DCD-B91E-F21CA0C68405");
+const MS_WHEA_RSC_DATA_TYPE_GUID: efi::Guid =
+    BinaryGuid::from_string("91DEEA05-8C0A-4DCD-B91E-F21CA0C68405").into_inner();
 
 const MS_WHEA_ERROR_STATUS_TYPE_INFO: EfiStatusCodeType = EFI_ERROR_MINOR | EFI_ERROR_CODE;
 const MS_WHEA_ERROR_STATUS_TYPE_FATAL: EfiStatusCodeType = EFI_ERROR_MAJOR | EFI_ERROR_CODE;
@@ -131,15 +132,15 @@ fn log_telemetry_internal<B: BootServices>(
         if is_fatal { MS_WHEA_ERROR_STATUS_TYPE_FATAL } else { MS_WHEA_ERROR_STATUS_TYPE_INFO };
 
     let error_data = MsWheaRscInternalErrorData {
-        library_id: *library_id.unwrap_or(&guid::ZERO),
-        ihv_sharing_guid: *ihv_id.unwrap_or(&guid::ZERO),
+        library_id: *library_id.unwrap_or(guids::ZERO.as_efi_guid()),
+        ihv_sharing_guid: *ihv_id.unwrap_or(guids::ZERO.as_efi_guid()),
         additional_info1: extra_data1,
         additional_info2: extra_data2,
     };
 
     let protocol = unsafe { boot_services.locate_protocol::<StatusCodeRuntimeProtocol>(None)? };
 
-    let caller_id = component_id.unwrap_or(&guid::CALLER_ID);
+    let caller_id = component_id.unwrap_or(guids::CALLER_ID.as_efi_guid());
 
     protocol.report_status_code_with_data(
         status_code_type,

--- a/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
+++ b/MsWheaPkg/Crates/MuTelemetryHelperLib/src/lib.rs
@@ -157,7 +157,7 @@ pub fn init_telemetry(efi_boot_services: *mut efi::BootServices) {
 
 #[cfg(test)]
 mod test {
-    use mu_rust_helpers::guid::guid;
+    use patina::base::guid::BinaryGuid;
     use patina::boot_services::MockBootServices;
     use patina::pi::protocols::{
         status_code,
@@ -170,7 +170,7 @@ mod test {
     use patina::uefi_protocol::status_code::StatusCodeRuntimeProtocol;
 
     const DATA_SIZE: usize = size_of::<EfiStatusCodeData>() + size_of::<MsWheaRscInternalErrorData>();
-    const MOCK_CALLER_ID: efi::Guid = guid!("d0d1d2d3-d4d5-d6d7-d8d9-dadbdcdddedf");
+    const MOCK_CALLER_ID: efi::Guid = BinaryGuid::from_string("d0d1d2d3-d4d5-d6d7-d8d9-dadbdcdddedf").into_inner();
     const MOCK_STATUS_CODE_VALUE: EfiStatusCodeValue = 0xa0a1a2a3;
 
     extern "efiapi" fn mock_report_status_code(
@@ -214,8 +214,8 @@ mod test {
                 0xb0b1b2b3b4b5b6b7,
                 0xc0c1c2c3c4c5c6c7,
                 Some(&MOCK_CALLER_ID),
-                Some(&guid!("e0e1e2e3-e4e5-e6e7-e8e9-eaebecedeeef")),
-                Some(&guid!("f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff"))
+                Some(BinaryGuid::from_string("e0e1e2e3-e4e5-e6e7-e8e9-eaebecedeeef").as_efi_guid()),
+                Some(BinaryGuid::from_string("f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff").as_efi_guid())
             )
         );
         assert_eq!(


### PR DESCRIPTION
## Description

A series of commits with two goals:

1. `mu_rust_helpers` moved to r-efi v7 in [eefef09](https://github.com/microsoft/mu_rust_helpers/commit/eefef09d4bb70298ac83b8aab11d26fc0f8ea388). The minor version was updated which caused many crates depending on `mu_rust_helpers` to pick up the change automatically per semantic versioning while there other dependencies stayed on r-efi v6. This could lead to type mismatches (and did in this repo). So, this prevents that.
2. Support the longer-term goal of deprecating `mu_rust_helpers` and `mu_pi` (as described in #906) by removing their usage in this repo.

---

**MuTelemetryHelperLib: Fix r-efi v7 GUID constant conflict**

mu_rust_helpers re-exports mu_uefi_guid, which updated to r-efi v7.

Its `guid::ZERO` and `guid::CALLER_ID` constants are compiled against
r-efi v7, while patina (and the rest of the tree) remain on r-efi v6,
producing mismatched-type errors when those constants are used in v6
contexts.

This makes the move to the patina crate's GUID constants. The patina
version used here is still on r-efi v6, so its `patina::guids::ZERO`
and `patina::guids::CALLER_ID` constants are compiled against r-efi
v6.

This is also a step toward removing the mu_rust_helpers dependency
from this crate.

---

**MuTelemetryHelperLib: Use patina instead of mu_pi**

Replaces the mu_pi status code types and error-code constants with the
equivalent definitions from the patina crate (`patina::pi::status_code`
and `patina::pi::protocols::status_code`).

This removes the mu_pi dependency from the crate and the workspace.

---

**MsWheaPkg: Remove mu_rust_helpers dependency**

Makes the remaining changes needed to replace mu_rust_helpers with
the patina crate. This is part of the effort to remove mu_rust_helpers
as it is being deprecated.

---

**Remove mu_rust_helpers as a workspace dependency**

Makes the remaining changes needed in UefiHidDxeV2 to use
patina::function instead of mu_rust_helpers::function so the
crate dependency can be removed from the workspace.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run cargo make tasks
- CI

## Integration Instructions

- N/A - Replace `mu_rust_helpers` and `mu_pi` functionality with equivalent functionality from the `patina` crate. The `patina` crate was already a dependency.