### PR TITLE
Patina 22.1.0 integration (r-efi 7) [Rebase & FF]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ MuTelemetryHelperLib = { path = "MsWheaPkg/Crates/MuTelemetryHelperLib" }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 patina = { version = "22" }
-r-efi = "^6"
+r-efi = "^7"
 RustAdvancedLoggerDxe = { path = "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe" }
 RustBootServicesAllocatorDxe = { path = "MsCorePkg/Crates/RustBootServicesAllocatorDxe" }
 rustversion = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 resolver = "2"
 
-# Add packages that generate binaries here
 members = [
+  "AdvLoggerPkg/Crates/RustAdvancedLoggerDxe",
   "HidPkg/Crates/HidIo",
   "HidPkg/Crates/HiiKeyboardLayout",
   "HidPkg/UefiHidDxe",


### PR DESCRIPTION
## Description

Two commits to integrate the latest patina v22.1.0 (and fix the build).

---

**Cargo.toml: Add AdvLoggerPkg/Crates/RustAdvancedLoggerDxe as a member**

Library crates are currently being listed in the `members` section, so
the line about binary crates is removed.

RustAdvancedLoggerDxe is currently being built as a dependency, but
this commit adds it as a member for consistency with other crates.

---

**Bump r-efi to 7 to match patina's update**

patina 22.1.0 moved its r-efi dependency up to version 7, but the
workspace was still pinned to ^6.

Cargo then pulled in both r-efi 6 and 7 at the same time, and since
types from different major versions don't unify, that broke
`cargo make check` and `cargo make test`.

This moves the workspace to r-efi 7.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- cargo make tasks
- Repo CI

## Integration Instructions

- If library crates are used from this repo, it is recommended to move to r-efi 7.