### PR TITLE
[REBASE & FF] AdvLoggerPkg: PeiCore Instance: Update Override Tag And Apply SecDebugAgent Fix

### DIFF
--- a/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
+++ b/AdvLoggerPkg/Library/AdvancedLoggerLib/PeiCore/AdvancedLoggerLib.inf
@@ -5,7 +5,7 @@
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-#Override : 00000002 | MdeModulePkg/Core/Pei/PeiMain.h | 5f8415080619b4d12d294f54e3fec16d | 2026-06-25T18-37-10 | 3fcfa38b0117f38468e2106feef56feb9fd47e28
+#Override : 00000002 | MdeModulePkg/Core/Pei/PeiMain.h | b95e7c1747b1fb8735072cdee35b0132 | 2026-06-25T18-37-10 | 3fcfa38b0117f38468e2106feef56feb9fd47e28
 ##
 
 [Defines]

--- a/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
+++ b/AdvLoggerPkg/Library/DebugAgent/Sec/AdvancedLoggerSecDebugAgent.c
@@ -12,13 +12,13 @@
 #include <AdvancedLoggerInternal.h>
 
 /**
-  Including the PeiMain.h from PeiCore in order to access the Platform Blob data member.
+  Include a copy of PeiMain.h from PeiCore in order to access the Platform Blob data member.
 
-  This is breaking the rules, but PeiCore on a system using ROM for PeiPremem has no place
+  This is breaking the rules, but PeiCore on a system using ROM for PeiPreMem has no place
   to store long term data besides the Hob or Ppi list.  Accessing these list for high
   frequency operations is a performance issue.
 **/
-#include <Core/Pei/PeiMain.h>
+#include "../../AdvancedLoggerLib/PeiCore/PeiMain.h"
 
 #include <Library/AdvancedLoggerHdwPortLib.h>
 #include <Library/BaseMemoryLib.h>


### PR DESCRIPTION
## Description

Update the override tag in PeiMain.h as it has been updated in basecore v2025110002.0.8.

Also, SecDebugAgent was missed when using the local header, update it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

This is marked as a breaking change because the build will break if mu_basecore v2025110002.0.8 is not updated to (or later) at the same time by consumers.
