### PR TITLE
AdvLoggerPkg: Default PcdAdvancedLoggerHdwPortOsRuntimeDisable to TRUE

### DIFF
--- a/AdvLoggerPkg/AdvLoggerPkg.dec
+++ b/AdvLoggerPkg/AdvLoggerPkg.dec
@@ -100,11 +100,11 @@
   gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerAutoWrapEnable|FALSE|BOOLEAN|0x00010188
 
   ## PcdAdvancedLoggerHdwPortOsRuntimeDisable - Suppress hardware port writes at OS
-  # runtime (after ExitBootServices). By default (FALSE), hardware port writes remain
-  # enabled at runtime. Set to TRUE on a platform whose underlying hardware port
-  # implementation cannot be safely called after ExitBootServices.
+  # runtime (after ExitBootServices). By default, hardware port writes remain disabled for an
+  # implementation that cannot be safely called after ExitBootServices. Set to FALSE for a
+  # platform where the hardware port implementation can safely be called after ExitBootServices.
   #
-  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable|FALSE|BOOLEAN|0x0001018A
+  gAdvLoggerPkgTokenSpaceGuid.PcdAdvancedLoggerHdwPortOsRuntimeDisable|TRUE|BOOLEAN|0x0001018A
 
 
 [PcdsFixedAtBuild]


### PR DESCRIPTION
## Description

https://github.com/microsoft/mu_plus/commit/1d1b4dbb468755c8a3e7558701b60b6e41a88b09 changed the behavior of runtime AdvLogger prints to always print to the serial port. This breaks platforms who give up control of the serial port to an OS after ExitBootServices.

https://github.com/microsoft/mu_plus/commit/cea5d2a4121c36a36eb2a4038f31f8aa3e06232f followed on to fix this behavior by introducing
PcdAdvancedLoggerHdwPortOsRuntimeDisable to allow returning to the original behavior and disabling the hardware port logging during runtime.

However, this commit set the PCD default to FALSE, which left the breaking change behavior in place, which quietly gets picked up by platforms.

This commit flips the PCD default to return to the original behavior and not log to the hardware port at runtime by default. Platforms may set this PCD to FALSE if it is safe to do so on their implementation.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a platform where it is not safe to write to the serial port at runtime. It crashed before this change and boots after it.

## Integration Instructions

Platforms will continue to work as they did before 1d1b4dbb468755c8a3e7558701b60b6e41a88b09. Platforms who wish to have serial logging at runtime can set `PcdAdvancedLoggerHdwPortOsRuntimeDisable|TRUE` in their DSC.
