### PR TITLE
MsGraphicsPkg: use GOP from ConsoleOut

### DIFF
--- a/MsGraphicsPkg/Library/SimpleUIToolKit/SimpleUIToolKit.c
+++ b/MsGraphicsPkg/Library/SimpleUIToolKit/SimpleUIToolKit.c
@@ -42,9 +42,9 @@ InitializeUIToolKit (
 
   // Determine if the GOP is available.
   //
-  Status = gBS->LocateProtocol (
+  Status = gBS->HandleProtocol (
+                  gST->ConsoleOutHandle,
                   &gEfiGraphicsOutputProtocolGuid,
-                  NULL,
                   (VOID **)&mUITGop
                   );
 

--- a/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
+++ b/MsGraphicsPkg/SimpleWindowManagerDxe/WindowManager.c
@@ -1507,9 +1507,9 @@ GopRegisteredCallback (
 
   // Determine if the Graphics Output Protocol is available on the Console Out handle.
   //
-  Status = gBS->LocateProtocol (
+  Status = gBS->HandleProtocol (
+                  gST->ConsoleOutHandle,
                   &gEfiGraphicsOutputProtocolGuid,
-                  NULL,
                   (VOID **)&mGop
                   );
 


### PR DESCRIPTION
## Description
When multiple GOP protocol instances are installed in the system, different components of MsGraphicsPkg can connect to different GOP instances leading to inconsistent graphics rendering or failures. Always use the one that is connected to ConsoleOut.

## How This Was Tested
Boot test with multiple GOP configuration.

## Integration Instructions
N/A