### PR TITLE
UefiTestingPkg: Fix memory info database dump

### DIFF
--- a/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
+++ b/UefiTestingPkg/AuditTests/PagingAudit/UEFI/PagingAuditCommon.c
@@ -1606,7 +1606,7 @@ DumpPagingInfo (
   StringLength                  = 0;
 
   // Calculate the string size of the Loaded Image Table
-  Status = LoadedImageTableDump (TRUE, &StringLength);
+  Status = LoadedImageTableDump (FALSE, &StringLength);
 
   if (EFI_ERROR (Status) && (Status != EFI_NOT_STARTED)) {
     DEBUG ((DEBUG_ERROR, "%a - Error tabulating required string size for the loaded image info in the memory info database\n", __func__));
@@ -1649,6 +1649,9 @@ DumpPagingInfo (
     ASSERT (mMemoryInfoDatabaseBuffer != NULL);
     goto Cleanup;
   }
+
+  // Prevent a stale, non-zero offset from writing past the beginning of the buffer.
+  mMemoryInfoDatabaseSize = 0;
 
   if (mPteCounts[EntryGuard] > 0) {
     // Calculate the string size of the guard page entries


### PR DESCRIPTION
## Description

Fixes: https://github.com/microsoft/mu_plus/issues/924

Memory info is stored in `mMemoryInfoDatabaseBuffer`. The code first calculates how large of a buffer is needed. A "dry run" is performed to compute that. It calls each dump handler with `AllowAllocation=FALSE`, to get the size of the data that would be written.

However, the call to `LoadedImageTableDump()` during this phase, sets `AllowAllocation=TRUE`. `mMemoryInfoDatabaseOffset` is still `NULL`, then `AppendMemoryInfoDatabase()` sees that and allocates a buffer.

Now, `mMemoryInfoDatabaseSize` is advanced. Other dump handlers after write to the buffer now that it exists.

Eventually, `DumpPagingInfo()` allocates the real (intended) buffer. Because of what happened earlier, the "accidental" buffer is leaked and `mMemoryInfoDatabaseSize` is non-zero which causes `mMemoryInfoDatabaseBuffer[mMemoryInfoDatabaseSize]` to write past the beginning of the buffer:

```c
  // Copy the new string to the end of the buffer and update the size.
  if (!EFI_ERROR (Status)) {
    CopyMem (&mMemoryInfoDatabaseBuffer[mMemoryInfoDatabaseSize], DatabaseString, NewStringSize);
    mMemoryInfoDatabaseSize = NewDatabaseSize;
  }
```

This change sets `AllowAllocation=FALSE` in that call and resets `mMemoryInfoDatabaseSize` to zero before the real allocation as a precaution.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. Before - Reproduce the problem:

   <img width="609" height="318" alt="image" src="https://github.com/user-attachments/assets/7bba25bb-1fe7-4b66-b9cf-386a509b7e3b" />

    ```
    (venv) paging>python PagingReportGenerator.py -i ..\collection_data -o report1.html
    Traceback (most recent call last):
      File "paging\PagingReportGenerator.py", line 312, in <module>
        retcode = main()
      File "paging\PagingReportGenerator.py", line 294, in main
        spt.Parse()
        ~~~~~~~~~^^
      File "paging\PagingReportGenerator.py", line 79, in Parse
        self.MemoryRangeInfo.extend(ParseInfoFile(info))
                                    ~~~~~~~~~~~~~^^^^^^
      File "paging\BinaryParsing.py", line 38, in ParseInfoFile
        MemoryRanges.append(MemoryRange(row[0], *row[1:]))
                            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
      File "paging\MemoryRangeObjects.py", line 126, in __init__
        raise RuntimeError("Unknown type '%s' found!" % self.RecordType)
    RuntimeError: Unknown type 'MemoryMap' found!
    ```

2. After - Verify the problem no longer exists:

   
   <img width="610" height="303" alt="image" src="https://github.com/user-attachments/assets/fc706e5a-c95b-4c8f-8143-d3af7fb763c6" />

    ```
    python Windows\PagingReportGenerator.py -i ../collection_data -o report1.html
    ```

## Integration Instructions

- N/A